### PR TITLE
Add openvas_db.py

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,6 +7,7 @@ Prerequisites for OSPD-OPENVAS
 Prerequisites:
 * Python 3
 * ospd: Base class for OSP servers.
+* python3-redis
 
 
 Installing OSPD-OPENVAS

--- a/ospd_openvas/openvas_db.py
+++ b/ospd_openvas/openvas_db.py
@@ -1,0 +1,261 @@
+# -*- coding: utf-8 -*-
+# Description:
+# Access management for redis-based OpenVAS Scanner Database
+#
+# Authors:
+# Juan José Nicola <juan.nicola@greenbone.net>
+#
+# Copyright:
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+""" Functios to retrieve and store data from redis-based OpenVAS Scanner database. """
+
+# Needed to say that when we import ospd, we mean the package and not the
+# module in that directory.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import redis
+import subprocess
+import string
+
+""" Path to the Redis socket. """
+DB_ADDRESS = ""
+
+""" Name of the namespace usage bitmap in redis. """
+DBINDEX_NAME = "GVM.__GlobalDBIndex"
+MAX_DBINDEX = 0
+DB_INDEX = 0
+REDISCONTEXT = None
+SOCKET_TIMEOUT = 60
+
+# Possible positions of nvt values in cache list.
+nvt_meta_fields = [
+    "NVT_FILENAME_POS",
+    "NVT_REQUIRED_KEYS_POS",
+    "NVT_MANDATORY_KEYS_POS",
+    "NVT_EXCLUDED_KEYS_POS",
+    "NVT_REQUIRED_UDP_PORTS_POS",
+    "NVT_REQUIRED_PORTS_POS",
+    "NVT_DEPENDENCIES_POS",
+    "NVT_TAGS_POS",
+    "NVT_CVES_POS",
+    "NVT_BIDS_POS",
+    "NVT_XREFS_POS",
+    "NVT_CATEGORY_POS",
+    "NVT_TIMEOUT_POS",
+    "NVT_FAMILY_POS",
+    "NVT_COPYRIGHT_POS",
+    "NVT_NAME_POS",
+    "NVT_VERSION_POS",]
+
+def get_db_connection():
+    """ Retrive the db address from openvassd config.
+    """
+    global DB_ADDRESS
+    try:
+        result = subprocess.check_output(['openvassd', '-s'],
+                                         stderr=subprocess.STDOUT)
+        result = result.decode('ascii')
+    except OSError:
+        # the command is not available
+        return 2
+
+    if result is None:
+        return 2
+
+    path = None
+    for conf in result.split('\n'):
+        if conf.find("db_address") == 0:
+            path = conf.split('=')
+            break
+
+    if path is None:
+        return 2
+
+    DB_ADDRESS = str.strip(path[1])
+
+
+def max_db_index():
+    """Set the number of databases have been configured into kbr struct.
+    """
+    global MAX_DBINDEX
+    try:
+        ctx = kb_connect()
+        resp = ctx.config_get("databases")
+    except RedisError:
+        return 2
+
+    if isinstance(resp, dict) is False:
+        return 2
+    if len(resp) == 1:
+        MAX_DBINDEX = int(resp["databases"])
+    else:
+        print("Redis: unexpected reply length %d" % len(resp))
+        return 2
+
+def set_global_redisctx(ctx):
+    """ Set the global set the global REDISCONTEXT.
+    """
+    global REDISCONTEXT
+    REDISCONTEXT = ctx
+
+def db_init():
+    """ Set DB_ADDRESS and max_db_index. """
+    if get_db_connection() or max_db_index():
+        return False
+    return True
+
+def try_database_index(ctx, i):
+    """ Check if it is already in use. If not set it as in use and return.
+    """
+    try:
+        resp = ctx.hsetnx(DBINDEX_NAME, i, 1)
+    except:
+        return 2
+
+    if isinstance(resp, int) is False:
+        return 2
+
+    if resp == 1:
+        return 1
+
+def kb_connect(dbnum=0):
+    """ Connect to redis to the given database or to the default db 0 .
+    """
+    global DB_INDEX
+    if get_db_connection() is 2:
+        return 2
+    try:
+        ctx = redis.Redis(unix_socket_path=DB_ADDRESS,
+                          db=dbnum,
+                          socket_timeout=SOCKET_TIMEOUT, charset="latin-1",
+                          decode_responses=True)
+    except ConnectionError as e:
+        return {"error": str(e)}
+    DB_INDEX = dbnum
+    return ctx
+
+def db_find(patt):
+    """ Search a pattern inside all kbs. When find it return it.
+    """
+    for i in range(0, MAX_DBINDEX):
+        ctx = kb_connect (i)
+        if ctx.keys(patt):
+            return ctx
+
+def kb_new():
+    """ Return a new kb context to an empty kb.
+    """
+    ctx = db_find(DBINDEX_NAME)
+    for index in range(1, MAX_DBINDEX):
+            if try_database_index(ctx, index) == 1:
+                ctx = kb_connect(index)
+                return ctx
+
+def get_kb_context():
+    """ Get redis context if it is already connected or do a connection.
+    """
+    global REDISCONTEXT
+    if REDISCONTEXT is not None:
+        return REDISCONTEXT
+
+    REDISCONTEXT = db_find(DBINDEX_NAME)
+
+    if REDISCONTEXT is None:
+        print("Problem retrieving Redis Context")
+        return 2
+
+    return REDISCONTEXT
+
+def item_get_set(name):
+    """ Get all values under a KB elements.
+    The right global REDISCONTEXT must be already set.
+    """
+    ctx = get_kb_context()
+    return ctx.smembers(name)
+
+def item_get_single(name):
+    """ Get a single KB element. The right global REDISCONTEXT must be
+    already set.
+    """
+    ctx = get_kb_context()
+    return ctx.srandmember(name)
+
+def item_add_single(name, values):
+    """ Add a single KB element with one or more values.
+    The right global REDISCONTEXT must be already set.
+    """
+    ctx = get_kb_context()
+    ctx.sadd(name, *set(values))
+
+def item_set_single(name, value):
+    """ Set (replace) a new single KB element. The right global
+    REDISCONTEXT must be already set.
+    """
+    ctx = get_kb_context()
+    pipe = ctx.pipeline()
+    pipe.delete(name)
+    pipe.sadd(name, value)
+
+def item_del_single(name):
+    """ Delete a single KB element. The right global REDISCONTEXT must be
+    already set.
+    """
+    ctx = get_kb_context()
+    ctx.delete(name)
+
+def get_pattern(pattern):
+    """ Get all items stored under a given pattern.
+    """
+    ctx = get_kb_context()
+    items = ctx.keys(pattern)
+
+    elem_list = []
+    for item in items:
+        elem_list.append(ctx.smembers(item))
+    return elem_list
+
+def release_db(kbindex=0):
+    """ Connect to redis and select the db by index.
+    Flush db and delete the index from DBINDEX_NAME list.
+    """
+    if kbindex:
+        ctx = kb_connect(kbindex)
+        ctx.flushdb()
+        ctx = kb_connect()
+        ctx.hdel(DBINDEX_NAME, kbindex)
+
+def get_result():
+    """ Get and remove the oldest result from the list. """
+    ctx = get_kb_context()
+    return ctx.rpop("internal/results")
+
+def get_status():
+    """ Get and remove the oldest host scan status from the list. """
+    ctx = get_kb_context()
+    return ctx.rpop("internal/status")
+
+def get_host_scan_scan_start_time():
+    """ Get the timestamp of the scan start from redis. """
+    ctx = get_kb_context()
+    return ctx.rpop("internal/start_time")
+
+def get_host_scan_scan_end_time():
+    """ Get the timestamp of the scan end from redis. """
+    ctx = get_kb_context()
+    return ctx.rpop("internal/end_time")

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -32,6 +32,8 @@ from ospd.ospd import OSPDaemon
 from ospd.misc import main as daemon_main
 from ospd_openvas import __version__
 
+import ospd_openvas.openvas_db as openvas_db
+
 OSPD_DESC = """
 This scanner runs 'OpenVAS Scanner' to scan the target hosts.
 
@@ -43,8 +45,8 @@ various types of systems and services.
 For more details about OpenVAS see the OpenVAS homepage:
 http://www.openvas.org/
 
-The current version of ospd-openvas is a simple frame, which sends 
-the server parameters to the Greenbone Vulnerability Manager (GVM) and checks the 
+The current version of ospd-openvas is a simple frame, which sends
+the server parameters to the Greenbone Vulnerability Manager (GVM) and checks the
 existence of OpenVAS Scanner binary. But it can not run scans yet.
 """
 
@@ -201,9 +203,14 @@ class OSPDopenvas(OSPDaemon):
         for name, param in OSPD_PARAMS.items():
             self.add_scanner_param(name, param)
 
+        if openvas_db.db_init() is False:
+            self.add_scan_error(scan_id, host=target,
+                 value='OpenVAS Redis Error: Not possible to find db_connection.')
+            return 2
+
 
     def parse_param(self):
-        ''' Set OSPD_PARAMS with the params taken from the openvas_scanner. '''
+        """ Set OSPD_PARAMS with the params taken from the openvas_scanner. """
         global OSPD_PARAMS
         result = subprocess.check_output(['openvassd', '-s'],
                                          stderr=subprocess.STDOUT)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author_email='info@greenbone.net',
 
     license='GPLV2+',
-    install_requires=['ospd>=1.3.0', 'ospd<=1.4.0'],
+    install_requires=['ospd>=1.3.0', 'ospd<=1.4.0', 'redis'],
 
     entry_points={
         'console_scripts': ['ospd-openvas=ospd_openvas.wrapper:main'],


### PR DESCRIPTION
Add access management for redis-based OpenVAS Scanner Database.

* INSTALL: add prerequisit python3-redis
* ospd_openvas/wrapper.py: Import openvas_db and initialize related redis variables.
* setup.py: add redis as intall requirement.