### PR TITLE
Call load_vts() at the init, which loads the nvt's oid into the vts_id.

### DIFF
--- a/ospd_openvas/openvas_db.py
+++ b/ospd_openvas/openvas_db.py
@@ -227,7 +227,7 @@ def get_pattern(pattern):
 
     elem_list = []
     for item in items:
-        elem_list.append(ctx.smembers(item))
+        elem_list.append([item, ctx.smembers(item)])
     return elem_list
 
 def release_db(kbindex=0):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author_email='info@greenbone.net',
 
     license='GPLV2+',
-    install_requires=['ospd>=1.3.0', 'ospd<=1.4.0', 'redis'],
+    install_requires=['ospd>=1.4b1', 'ospd<=1.5.0', 'redis'],
 
     entry_points={
         'console_scripts': ['ospd-openvas=ospd_openvas.wrapper:main'],


### PR DESCRIPTION
Call load_vts() at the init, which loads the nvt's oid into the vts_id dict calling the the function add_vts().
* ospd_openvas/openvas_db.py (get_pattern): Return not only the content, but also the key found
with pattern.
* ospd_openvas/wrapper.py (load_vts): New function
* seput.py: Require install ospd >= 1.4b1 and <= 1.5