### PR TITLE
Fix issue #4.

### DIFF
--- a/ospd_openvas/openvas_db.py
+++ b/ospd_openvas/openvas_db.py
@@ -96,7 +96,7 @@ def max_db_index():
     try:
         ctx = kb_connect()
         resp = ctx.config_get("databases")
-    except RedisError:
+    except redis.RedisError:
         return 2
 
     if isinstance(resp, dict) is False:

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -22,10 +22,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-import logging
 import subprocess
 
-from ospd.ospd import OSPDaemon
+from ospd.ospd import OSPDaemon, logger
 from ospd.misc import main as daemon_main
 from ospd_openvas import __version__
 
@@ -202,10 +201,9 @@ class OSPDopenvas(OSPDaemon):
             self.add_scanner_param(name, param)
 
         if openvas_db.db_init() is False:
-            self.add_scan_error(
-                scan_id, host=target,
-                value='OpenVAS Redis Error: Not possible to find db_connection.')
-            return 2
+            logger.error('OpenVAS Redis Error: Not possible '
+                         'to find db_connection.')
+            raise Exception
 
         ctx = openvas_db.db_find('nvticache10')
         openvas_db.set_global_redisctx(ctx)


### PR DESCRIPTION

* ospd_openvas/wrapper.py (__init__): Log an error message and exit if
a redis connection is not possible.
* ospd_openvas/openvas_db.py (max_db_index): Fix exception error.