### PR TITLE
Ospd-openvas is able to run a scan.

### DIFF
--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+# Description:
+# Provide functions to handle NVT Info Cache
+#
+# Authors:
+# Juan José Nicola <juan.nicola@greenbone.net>
+#
+# Copyright:
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+""" Functions related to the NVT information. """
+
+# Needed to say that when we import ospd, we mean the package and not the
+# module in that directory.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import xml.etree.ElementTree as ET
+import ospd_openvas.openvas_db as openvas_db
+
+
+NVTICACHE_STR = 'nvticache10'
+
+def get_feed_version():
+    """ Get feed version.
+    """
+    return openvas_db.item_get_single(NVTICACHE_STR)
+
+def get_oids():
+    """ Get the list of NVT OIDs.
+    """
+    return openvas_db.get_pattern('filename:*:oid')
+
+def get_nvt_pref(oid):
+    """ Get NVT's preferences.
+        @Return XML tree with preferences
+    """
+    ctx = openvas_db.get_kb_context()
+    resp = ctx.smembers('oid:%s:prefs' % oid)
+    timeout = ctx.lindex('nvt:%s' % oid,
+                         openvas_db.nvt_meta_fields.index("NVT_TIMEOUT_POS"))
+    preferences = ET.Element('preferences')
+    if int(timeout) > 0:
+        xml_timeout = ET.Element('timeout')
+        xml_timeout.text = timeout
+        preferences.append(xml_timeout)
+
+    if len(resp) > 0:
+        for nvt_pref in resp:
+            elem = nvt_pref.split('|||')
+            preference = ET.Element('preference')
+            xml_name = ET.SubElement(preference, 'name')
+            xml_name.text = elem[0]
+            xml_type = ET.SubElement(preference, 'type')
+            xml_type.text = elem[1]
+            if elem[2]:
+                xml_def = ET.SubElement(preference, 'default')
+                xml_def.text = elem[2]
+            preferences.append(preference)
+
+    return preferences
+
+def get_nvt_all(oid, is_custom=0):
+    """ Get a full NVT. Returns an XML tree with the NVT metadata.
+    """
+    ctx = openvas_db.get_kb_context()
+
+    resp = ctx.lrange("nvt:%s" % oid,
+                      openvas_db.nvt_meta_fields.index("NVT_FILENAME_POS"),
+                      openvas_db.nvt_meta_fields.index("NVT_VERSION_POS"))
+    if (isinstance(resp, list) and len(resp) > 0) is False:
+        return None
+
+    nvt = ET.Element('vt')
+    nvt.set('id', oid)
+
+    subelem = ['file_name', 'required_keys', 'mandatory_keys',
+               'excluded_keys', 'required_udp_ports', 'required_ports',
+               'dependencies', 'tag', 'cve', 'bid', 'xref', 'category',
+               'timeout', 'family', 'copyright', 'name', 'version']
+
+    for elem in subelem:
+        ET.SubElement(nvt, elem)
+    for child, res in zip(nvt.getchildren(), resp):
+        child.text = res
+
+    # Add preferences
+    nvt.append(get_nvt_pref(oid))
+
+    if is_custom:
+        itera = nvt.getiterator()
+        custom = ''
+        for elem in itera:
+          if elem.tag != 'vt' and elem.tag != 'file_name':
+              custom +=(ET.tostring(elem).decode('utf-8'))
+        return custom
+
+    return nvt

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -95,18 +95,18 @@ def get_nvt_all(oid, is_custom=0):
 
     for elem in subelem:
         ET.SubElement(nvt, elem)
-    for child, res in zip(nvt.getchildren(), resp):
+    for child, res in zip(list(nvt), resp):
         child.text = res
 
     # Add preferences
     nvt.append(get_nvt_pref(oid))
 
     if is_custom:
-        itera = nvt.getiterator()
+        itera = nvt.iter()
         custom = ''
         for elem in itera:
-          if elem.tag != 'vt' and elem.tag != 'file_name':
-              custom +=(ET.tostring(elem).decode('utf-8'))
+            if elem.tag != 'vt' and elem.tag != 'file_name':
+                custom += (ET.tostring(elem).decode('utf-8'))
         return custom
 
     return nvt

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -59,7 +59,7 @@ def get_nvt_pref(oid):
         xml_timeout.text = timeout
         preferences.append(xml_timeout)
 
-    if len(resp) > 0:
+    if resp:
         for nvt_pref in resp:
             elem = nvt_pref.split('|||')
             preference = ET.Element('preference')
@@ -82,7 +82,7 @@ def get_nvt_all(oid, is_custom=0):
     resp = ctx.lrange("nvt:%s" % oid,
                       openvas_db.nvt_meta_fields.index("NVT_FILENAME_POS"),
                       openvas_db.nvt_meta_fields.index("NVT_VERSION_POS"))
-    if (isinstance(resp, list) and len(resp) > 0) is False:
+    if (isinstance(resp, list) and resp) is False:
         return None
 
     nvt = ET.Element('vt')

--- a/ospd_openvas/openvas_db.py
+++ b/ospd_openvas/openvas_db.py
@@ -209,7 +209,8 @@ def item_set_single(name, value):
     ctx = get_kb_context()
     pipe = ctx.pipeline()
     pipe.delete(name)
-    pipe.sadd(name, value)
+    pipe.sadd(name, *set(value))
+    pipe.execute()
 
 def item_del_single(name):
     """ Delete a single KB element. The right global REDISCONTEXT must be

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -49,9 +49,11 @@ For more details about OpenVAS see the OpenVAS homepage:
 http://www.openvas.org/
 
 The current version of ospd-openvas is a simple frame, which sends
-the server parameters to the Greenbone Vulnerability Manager (GVM) and checks the
-existence of OpenVAS Scanner binary. But it can not run scans yet.
+the server parameters to the Greenbone Vulnerability Manager (GVM) and checks
+the existence of OpenVAS Scanner binary. But it can not run scans yet.
 """
+
+MAIN_KBINDEX = None
 
 OSPD_PARAMS = {
     'auto_enable_dependencies': {
@@ -73,7 +75,8 @@ OSPD_PARAMS = {
         'name': 'checks_read_timeout',
         'default': 5,
         'mandatory': 1,
-        'description': 'Number  of seconds that the security checks will wait for when doing a recv()',
+        'description': ('Number  of seconds that the security checks will ' +
+                        'wait for when doing a recv()'),
     },
     'drop_privileges': {
         'type': 'boolean',
@@ -94,28 +97,32 @@ OSPD_PARAMS = {
         'name': 'non_simult_ports',
         'default': '139, 445, 3389, Services/irc',
         'mandatory': 1,
-        'description': 'Prevent to make two connections on the same given ports at the same time.',
+        'description': ('Prevent to make two connections on the same given ' +
+                        'ports at the same time.'),
     },
     'open_sock_max_attempts': {
         'type': 'integer',
         'name': 'open_sock_max_attempts',
         'default': 5,
         'mandatory': 0,
-        'description': 'Number of unsuccessful retries to open the socket before to set the port as closed.',
+        'description': ('Number of unsuccessful retries to open the socket ' +
+                        'before to set the port as closed.'),
     },
     'timeout_retry': {
         'type': 'integer',
         'name': 'timeout_retry',
         'default': 5,
         'mandatory': 0,
-        'description': 'Number of retries when a socket connection attempt timesout.',
+        'description': ('Number of retries when a socket connection attempt ' +
+                        'timesout.'),
     },
     'optimize_test': {
         'type': 'integer',
         'name': 'optimize_test',
         'default': 5,
         'mandatory': 0,
-        'description': 'By default, openvassd does not trust the remote host banners.',
+        'description': ('By default, openvassd does not trust the remote ' +
+                        'host banners.'),
     },
     'plugins_timeout': {
         'type': 'integer',
@@ -136,7 +143,8 @@ OSPD_PARAMS = {
         'name': 'safe_checks',
         'default': 1,
         'mandatory': 1,
-        'description': 'Disable the plugins with potential to crash the remote services',
+        'description': ('Disable the plugins with potential to crash ' +
+                        'the remote services'),
     },
     'scanner_plugins_timeout': {
         'type': 'integer',
@@ -150,7 +158,8 @@ OSPD_PARAMS = {
         'name': 'time_between_request',
         'default': 0,
         'mandatory': 0,
-        'description': 'Allow to set a wait time between two actions (open, send, close).',
+        'description': ('Allow to set a wait time between two actions ' +
+                        '(open, send, close).'),
     },
     'unscanned_closed': {
         'type': 'boolean',
@@ -171,7 +180,8 @@ OSPD_PARAMS = {
         'name': 'use_mac_addr',
         'default': 0,
         'mandatory': 0,
-        'description': 'To test the local network. Hosts will be referred to by their MAC address.',
+        'description': 'To test the local network. ' +
+                       'Hosts will be referred to by their MAC address.',
     },
     'vhosts': {
         'type': 'string',

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -260,15 +260,9 @@ class OSPDopenvas(OSPDaemon):
             if ret == -2:
                 logger.info("{0}: Invalid OID.".format(vt_id))
 
-    def get_custom_vt_as_xml_str(self, custom):
-        """ Create a string representation of the XML object from the
-        custom data object.
-
-        The custom XML object which is returned will be embedded
-        into a <custom></custom> element.
-
-        @return: XML object as string for custom data.
-        """
+    @staticmethod
+    def get_custom_vt_as_xml_str(custom):
+        """ Return custom since it is already formated as string. """
         return custom
 
     def check(self):

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -280,18 +280,18 @@ class OSPDopenvas(OSPDaemon):
                                              stderr=subprocess.STDOUT)
             result = result.decode('ascii')
         except OSError:
-            # the command is not available
+            # The command is not available
             return False
 
         if result is None:
             return False
 
-        version = result.find('OpenVAS')
-        if version < 0:
+        version = result.split('\n')
+        if version[0].find('OpenVAS') < 0:
             return False
 
         self.parse_param()
-        self.scanner_info['version'] = result.replace('\n', '. ')
+        self.scanner_info['version'] = version[0]
         return True
 
     def exec_scan(self, scan_id, target):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author_email='info@greenbone.net',
 
     license='GPLV2+',
-    install_requires=['ospd>=1.4b1', 'ospd<=1.5.0', 'redis'],
+    install_requires=['ospd>=1.4b1', 'ospd<=1.5.0', 'redis', 'psutil'],
 
     entry_points={
         'console_scripts': ['ospd-openvas=ospd_openvas.wrapper:main'],


### PR DESCRIPTION
Prepare the kb to run a scan.
Retrieve results from Redis.
When the scan finished, clean the redis kb.
If the scan is stopped with <stop_scan scan_id=...>, stop the scan cleanly and delete the redis kb. 
Add custom NVTs metadata to the <get_vts/> response.