### PR TITLE
Change NVTICACHE_STR.

### DIFF
--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -33,7 +33,7 @@ import xml.etree.ElementTree as ET
 import ospd_openvas.openvas_db as openvas_db
 
 
-NVTICACHE_STR = 'nvticache10'
+NVTICACHE_STR = 'nvticache1.0.0'
 
 def get_feed_version():
     """ Get feed version.


### PR DESCRIPTION
This string is used to find the db in redis that stored the nvti cache.
Depends on greenbone/gvm-libs#124 and 
greenbone/openvas-scanner#176