### PR TITLE
Add vt references to the vts dictionary.

### DIFF
--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -109,9 +109,28 @@ def get_nvt_metadata(oid):
 
     custom = dict()
     for child, res in zip(subelem, resp):
-        custom[child] = res
+        if child not in ['cve', 'bid', 'xref', ]:
+            custom[child] = res
 
     return custom
+
+def get_nvt_refs(oid):
+    """ Get a full NVT. Returns an XML tree with the NVT references.
+    """
+    ctx = openvas_db.get_kb_context()
+    resp = ctx.lrange("nvt:%s" % oid,
+                      openvas_db.nvt_meta_fields.index("NVT_CVES_POS"),
+                      openvas_db.nvt_meta_fields.index("NVT_XREFS_POS"))
+    if (isinstance(resp, list) and resp) is False:
+        return None
+
+    subelem = ['cve', 'bid', 'xref',]
+
+    refs = dict()
+    for child, res in zip(subelem, resp):
+        refs[child] = res.split(", ")
+
+    return refs
 
 def get_nvt_name(ctx, oid):
     """ Get the NVT name of the given OID."""

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -92,39 +92,26 @@ def get_nvt_params(oid):
 
     return vt_params
 
-def get_nvt_metadata(oid, str_format=False):
+def get_nvt_metadata(oid):
     """ Get a full NVT. Returns an XML tree with the NVT metadata.
     """
     ctx = openvas_db.get_kb_context()
-
     resp = ctx.lrange("nvt:%s" % oid,
                       openvas_db.nvt_meta_fields.index("NVT_FILENAME_POS"),
                       openvas_db.nvt_meta_fields.index("NVT_VERSION_POS"))
     if (isinstance(resp, list) and resp) is False:
         return None
 
-    nvt = ET.Element('vt')
-    nvt.set('id', oid)
-
     subelem = ['file_name', 'required_keys', 'mandatory_keys',
                'excluded_keys', 'required_udp_ports', 'required_ports',
                'dependencies', 'tag', 'cve', 'bid', 'xref', 'category',
-               'timeout', 'family', 'copyright', 'name', 'version']
+               'timeout', 'family', 'copyright', 'name', 'version',]
 
-    for elem in subelem:
-        ET.SubElement(nvt, elem)
-    for child, res in zip(list(nvt), resp):
-        child.text = res
+    custom = dict()
+    for child, res in zip(subelem, resp):
+        custom[child] = res
 
-    if str_format:
-        itera = nvt.iter()
-        metadata = ''
-        for elem in itera:
-            if elem.tag != 'vt' and elem.tag != 'file_name':
-                metadata += (ET.tostring(elem).decode('utf-8'))
-        return metadata
-
-    return nvt
+    return custom
 
 def get_nvt_name(ctx, oid):
     """ Get the NVT name of the given OID."""

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -312,6 +312,23 @@ class OSPDopenvas(OSPDaemon):
             params += (ET.tostring(param).decode('utf-8'))
         return params
 
+    @staticmethod
+    def get_refs_vt_as_xml_str(vt_refs):
+        """ Return custom since it is already formated as string. """
+        vt_refs_xml = ET.Element('vt_prefs')
+        for ref_type, ref_values in vt_refs.items():
+            for value in ref_values:
+                vt_ref = ET.Element('ref')
+                vt_ref.set('type', ref_type)
+                vt_ref.set('id', value)
+                vt_refs_xml.append(vt_ref)
+
+        refs_list = vt_refs_xml.findall("ref")
+        refs = ''
+        for ref in refs_list:
+            refs += (ET.tostring(ref).decode('utf-8'))
+        return refs
+
     def check(self):
         """ Checks that openvassd command line tool is found and
         is executable. """

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -268,6 +268,7 @@ class OSPDopenvas(OSPDaemon):
             ret = self.add_vt(vt_id,
                               name=filename[1],
                               vt_params=nvti.get_nvt_params(vt_id),
+                              vt_refs=nvti.get_nvt_refs(vt_id),
                               custom=nvti.get_nvt_metadata(vt_id))
             if ret == -1:
                 logger.info("Dupplicated VT with OID: {0}".format(vt_id))


### PR DESCRIPTION
Add get_nvt_refs(), which returns a dictionary with vt references.
Since the references are an element it self, don't add it in
metadata (custom element).

Add get_refs_vt_as_xml_str().
Return an XML element as string with the vt references.
It is the content of <vt_refs> of each vt in the response to <get_vts>.