### PR TITLE
Remove copyright

### DIFF
--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -98,14 +98,14 @@ def get_nvt_metadata(oid):
     ctx = openvas_db.get_kb_context()
     resp = ctx.lrange("nvt:%s" % oid,
                       openvas_db.nvt_meta_fields.index("NVT_FILENAME_POS"),
-                      openvas_db.nvt_meta_fields.index("NVT_VERSION_POS"))
+                      openvas_db.nvt_meta_fields.index("NVT_NAME_POS"))
     if (isinstance(resp, list) and resp) is False:
         return None
 
     subelem = ['file_name', 'required_keys', 'mandatory_keys',
                'excluded_keys', 'required_udp_ports', 'required_ports',
                'dependencies', 'tag', 'cve', 'bid', 'xref', 'category',
-               'timeout', 'family', 'copyright', 'name', 'version',]
+               'timeout', 'family', 'name', ]
 
     custom = dict()
     for child, res in zip(subelem, resp):

--- a/ospd_openvas/openvas_db.py
+++ b/ospd_openvas/openvas_db.py
@@ -58,9 +58,7 @@ nvt_meta_fields = [
     "NVT_CATEGORY_POS",
     "NVT_TIMEOUT_POS",
     "NVT_FAMILY_POS",
-    "NVT_COPYRIGHT_POS",
-    "NVT_NAME_POS",
-    "NVT_VERSION_POS",]
+    "NVT_NAME_POS",]
 
 def get_db_connection():
     """ Retrive the db address from openvassd config.


### PR DESCRIPTION
It also removes 'version', which was already removed from openvas-scanner
and gvm-libs.
(Work in Progress / Waiting for Feature Specification validation.)
Depends on greenbone/gvm-libs#139 and greenbone/openvas-scanner#199