### PR TITLE
 Improve vt element regarding dates, empty elements and tags

### DIFF
--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -203,7 +203,7 @@ def get_nvt_severity(ctx, tag=None, oid=None):
         else:
             return '10'
 
-    if tag and 'cvess_base' in tag:
-        return tag['cvess_base']
+    if tag and 'cvss_base' in tag:
+        return tag['cvss_base']
 
     return ''

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -109,7 +109,7 @@ def get_nvt_metadata(oid):
 
     custom = dict()
     for child, res in zip(subelem, resp):
-        if child not in ['cve', 'bid', 'xref', 'tag',]:
+        if child not in ['cve', 'bid', 'xref', 'tag',] and res:
             custom[child] = res
         elif child == 'tag':
             tags = res.split('|')

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -109,8 +109,17 @@ def get_nvt_metadata(oid):
 
     custom = dict()
     for child, res in zip(subelem, resp):
-        if child not in ['cve', 'bid', 'xref', ]:
+        if child not in ['cve', 'bid', 'xref', 'tag',]:
             custom[child] = res
+        elif child == 'tag':
+            tags = res.split('|')
+            for tag in tags:
+                try:
+                    _tag, _value = tag.split('=', 1)
+                except ValueError:
+                    logger.error('Tag %s in %s has no value.' % (_tag, oid))
+                    continue
+                custom[_tag] = _value
 
     return custom
 

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -413,7 +413,7 @@ class OSPDopenvas(OSPDaemon):
             msg = res.split('|||')
             host_aux = openvas_db.item_get_single('internal/ip')
             roid = msg[3]
-            tag = nvti.get_nvt_tag(ctx, roid)
+            tag = self.vts[roid].get('custom')
             rqod = nvti.get_nvt_qod(ctx, tag)
             rseverity = nvti.get_nvt_severity(ctx, tag)
             rname = nvti.get_nvt_name(ctx, roid)

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -352,6 +352,16 @@ class OSPDopenvas(OSPDaemon):
             refs += (tostring(ref).decode('utf-8'))
         return refs
 
+    @staticmethod
+    def get_creation_time_vt_as_xml_str(creation_time):
+        """ Return creation time as string."""
+        return creation_time
+
+    @staticmethod
+    def get_modification_time_vt_as_xml_str(modification_time):
+        """ Return modification time as string."""
+        return modification_time
+
     def check(self):
         """ Checks that openvassd command line tool is found and
         is executable. """

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -264,12 +264,23 @@ class OSPDopenvas(OSPDaemon):
         str_out = True
         for oid in oids:
             vt_id = oid[1]
-            filename = oid[0].split(':')
-            ret = self.add_vt(vt_id,
-                              name=filename[1],
-                              vt_params=nvti.get_nvt_params(vt_id),
-                              vt_refs=nvti.get_nvt_refs(vt_id),
-                              custom=nvti.get_nvt_metadata(vt_id))
+
+            _vt_params = nvti.get_nvt_params(vt_id)
+            _vt_refs = nvti.get_nvt_refs(vt_id)
+            _filename = oid[0].split(':')
+            _custom = nvti.get_nvt_metadata(vt_id)
+            _vt_creation_time = _custom.pop('creation_date')
+            _vt_modification_time = _custom.pop('last_modification')
+
+            ret = self.add_vt(
+                vt_id,
+                name=_filename[1],
+                vt_params=_vt_params,
+                vt_refs=_vt_refs,
+                custom=_custom,
+                vt_creation_time=_vt_creation_time,
+                vt_modification_time=_vt_modification_time
+            )
             if ret == -1:
                 logger.info("Dupplicated VT with OID: {0}".format(vt_id))
             if ret == -2:


### PR DESCRIPTION
Each tag inside custom is an independent element.
Move creation_time and modification_time inside the vts dictionary.
Do not add empty elements into the vts dictionary.
As the vts dictionary changed and tags are independent elements, takes result's qod and severity from the dict. This avoid a redis query for each result.
