### PR TITLE
Fix stop_scan

### DIFF
--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -52,7 +52,8 @@ class NVTICache(object):
     def get_feed_version(self):
         """ Get feed version.
         """
-        return self._openvas_db.get_single_item(self.NVTICACHE_STR)
+        ctx = self._openvas_db.db_find(self.NVTICACHE_STR)
+        return self._openvas_db.get_single_item(self.NVTICACHE_STR, ctx=ctx)
 
     def get_oids(self):
         """ Get the list of NVT OIDs.

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -651,8 +651,7 @@ class OSPDopenvas(OSPDaemon):
         status = self.openvas_db.get_single_item('internal/%s' % scan_id)
         return status == 'stop_all'
 
-    @staticmethod
-    def stop_scan(global_scan_id):
+    def stop_scan(self, global_scan_id):
         """ Set a key in redis to indicate the wrapper is stopped.
         It is done through redis because it is a new multiprocess
         instance and it is not possible to reach the variables


### PR DESCRIPTION
Remove staticmethod python decorator which made method static. Now the method needs access to the self.openvas_db() object.
Also, ensure that the query to get the feed version is performed in the right db.