### PR TITLE
Code improvement

### DIFF
--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -452,11 +452,7 @@ class OSPDopenvas(OSPDaemon):
                     continue
                 vt_refs_xml.append(vt_ref)
 
-        refs_list = vt_refs_xml.findall("ref")
-        refs = ''
-        for ref in refs_list:
-            refs += (tostring(ref).decode('utf-8'))
-        return refs
+        return tostring(vt_refs_xml).decode('utf-8')
 
     @staticmethod
     def get_dependencies_vt_as_xml_str(vt_id, dep_list):

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -478,7 +478,9 @@ class OSPDopenvas(OSPDaemon):
     @staticmethod
     def get_modification_time_vt_as_xml_str(vt_id, modification_time):
         """ Return modification time as string."""
-        return modification_time
+        _time = Element('modification_time')
+        _time.text = modification_time
+        return tostring(_time).decode('utf-8')
 
     @staticmethod
     def get_summary_vt_as_xml_str(vt_id, summary):

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -457,7 +457,7 @@ class OSPDopenvas(OSPDaemon):
     @staticmethod
     def get_dependencies_vt_as_xml_str(vt_id, dep_list):
         """ Return  an xml element with dependencies as string."""
-        vt_deps_xml = Element('vt_deps')
+        vt_deps_xml = Element('dependencies')
         for dep in dep_list:
             _vt_dep = Element('dependency')
             try:
@@ -468,11 +468,7 @@ class OSPDopenvas(OSPDaemon):
                 continue
             vt_deps_xml.append(_vt_dep)
 
-        _deps_list = vt_deps_xml.findall("dependency")
-        deps = ''
-        for _dep in _deps_list:
-            deps += (tostring(_dep).decode('utf-8'))
-        return deps
+        return tostring(vt_deps_xml).decode('utf-8')
 
     @staticmethod
     def get_creation_time_vt_as_xml_str(vt_id, creation_time):

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -674,10 +674,15 @@ class OSPDopenvas(OSPDaemon):
             res = self.openvas_db.get_status()
 
     def get_severity_score(self, oid):
-        """ Return the severity score for the given oid. """
+        """ Return the severity score for the given oid.
+        Arguments:
+            oid (str): VT OID from which to get the severity vector
+        Returns:
+            The calculated cvss base value. None if there is no severity
+            vector or severity type is not cvss base version 2.
+        """
         severity_type = (
             self.vts[oid]['severities'].get('severity_type'))
-
         severity_vector = (
             self.vts[oid]['severities'].get('severity_base_vector'))
 
@@ -1016,7 +1021,6 @@ class OSPDopenvas(OSPDaemon):
         nvts = self.get_scan_vts(scan_id)
         if nvts != '':
             nvts_list, nvts_params = self.process_vts(nvts)
-           
             # Add nvts list
             separ = ';'
             plugin_list = 'plugin_set|||%s' % separ.join(nvts_list)

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -641,25 +641,37 @@ class OSPDopenvas(OSPDaemon):
         return True
 
     def update_progress(self, scan_id, target, msg):
-        """ Calculate porcentage and update the scan status
-        for the progress bar. """
+        """ Calculate percentage and update the scan status of a target
+        for the progress bar.
+        Arguments:
+            scan_id (uuid): Scan ID to identify the current scan process.
+            target (str): Target to be updated with the calculated
+                          scan progress.
+            msg (str): String with launched and total plugins.
+        """
         host_progress_dict = dict()
-        prog = str.split(msg, '/')
-        if float(prog[1]) == 0:
+        try:
+            launched, total = msg.split('/')
+        except ValueError:
             return
-        host_prog = (float(prog[0]) / float(prog[1])) * 100
+        if float(total) == 0:
+            return
+        host_prog = (float(launched) / float(total)) * 100
         host_progress_dict[target] = host_prog
         total_host = len(target_str_to_list(target))
-        self.set_scan_target_progress(scan_id, target,
-                                      sum(host_progress_dict.values()) / total_host)
+        target_progress = sum(host_progress_dict.values()) / total_host
+        self.set_scan_target_progress(scan_id, target, target_progress)
 
     def get_openvas_status(self, scan_id, target):
-        """ Get all status entries from redis kb. """
+        """ Get all status entries from redis kb.
+        Arguments:
+            scan_id (uuid): Scan ID to identify the current scan.
+            target (str): Target progress to be updated.
+        """
         res = self.openvas_db.get_status()
         while res:
             self.update_progress(scan_id, target, res)
             res = self.openvas_db.get_status()
-
 
     def get_severity_score(self, oid):
         """ Return the severity score for the given oid. """

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -425,11 +425,7 @@ class OSPDopenvas(OSPDaemon):
                 xml_def.text = prefs[1]['default']
             vt_params_xml.append(vt_param)
 
-        params_list = vt_params_xml.findall("vt_param")
-        params = ''
-        for param in params_list:
-            params += (tostring(param).decode('utf-8'))
-        return params
+        return tostring(vt_params_xml).decode('utf-8')
 
     @staticmethod
     def get_refs_vt_as_xml_str(vt_id, vt_refs):

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -473,7 +473,9 @@ class OSPDopenvas(OSPDaemon):
     @staticmethod
     def get_creation_time_vt_as_xml_str(vt_id, creation_time):
         """ Return creation time as string."""
-        return creation_time
+        _time = Element('creation_time')
+        _time.text = creation_time
+        return tostring(_time).decode('utf-8')
 
     @staticmethod
     def get_modification_time_vt_as_xml_str(vt_id, modification_time):

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -431,15 +431,15 @@ class OSPDopenvas(OSPDaemon):
             string: xml element as string.
         """
         vt_params_xml = Element('vt_params')
-        for prefs in vt_params.items():
+        for pref_name, prefs in vt_params.items():
             vt_param = Element('vt_param')
-            vt_param.set('type', prefs[1]['type'])
-            vt_param.set('id', prefs[0])
+            vt_param.set('type', prefs['type'])
+            vt_param.set('id', pref_name)
             xml_name = SubElement(vt_param, 'name')
-            xml_name.text = prefs[1]['name']
-            if prefs[1]['default']:
+            xml_name.text = prefs['name']
+            if prefs['default']:
                 xml_def = SubElement(vt_param, 'default')
-                xml_def.text = prefs[1]['default']
+                xml_def.text = prefs['default']
             vt_params_xml.append(vt_param)
 
         return tostring(vt_params_xml).decode('utf-8')

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -399,7 +399,8 @@ class OSPDopenvas(OSPDaemon):
     def get_severities_vt_as_xml_str(vt_id, severities):
         """ Return an xml element with severities as string."""
 
-        _severity = Element('severity')
+        _severities = Element('severities')
+        _severity = SubElement(_severities, 'severity')
         if 'severity_base_vector' in severities:
             _severity.text = severities.pop('severity_base_vector')
         if 'severity_origin' in severities:
@@ -407,7 +408,7 @@ class OSPDopenvas(OSPDaemon):
         if 'severity_type' in severities:
             _severity.set('type', severities.pop('severity_type'))
 
-        return tostring(_severity).decode('utf-8')
+        return tostring(_severities).decode('utf-8')
 
     @staticmethod
     def get_params_vt_as_xml_str(vt_id, vt_params):

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -386,7 +386,13 @@ class OSPDopenvas(OSPDaemon):
 
     @staticmethod
     def get_custom_vt_as_xml_str(vt_id, custom):
-        """ Return an xml element with custom metadata formatted as string."""
+        """ Return an xml element with custom metadata formatted as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            custom (dict): Dictionary with the custom metadata.
+        Return:
+            string: xml element as string.
+        """
 
         _custom = Element('custom')
         for key, val in custom.items():
@@ -397,8 +403,13 @@ class OSPDopenvas(OSPDaemon):
 
     @staticmethod
     def get_severities_vt_as_xml_str(vt_id, severities):
-        """ Return an xml element with severities as string."""
-
+        """ Return an xml element with severities as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            severities (dict): Dictionary with the severities.
+        Return:
+            string: xml element as string.
+        """
         _severities = Element('severities')
         _severity = SubElement(_severities, 'severity')
         if 'severity_base_vector' in severities:
@@ -412,7 +423,13 @@ class OSPDopenvas(OSPDaemon):
 
     @staticmethod
     def get_params_vt_as_xml_str(vt_id, vt_params):
-        """ Return an xml element with params formatted as string."""
+        """ Return an xml element with params formatted as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            vt_params (dict): Dictionary with the VT paramaters.
+        Return:
+            string: xml element as string.
+        """
         vt_params_xml = Element('vt_params')
         for prefs in vt_params.items():
             vt_param = Element('vt_param')
@@ -429,7 +446,13 @@ class OSPDopenvas(OSPDaemon):
 
     @staticmethod
     def get_refs_vt_as_xml_str(vt_id, vt_refs):
-        """ Return an xml element with references formatted as string."""
+        """ Return an xml element with references formatted as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            vt_refs (dict): Dictionary with the VT references.
+        Return:
+            string: xml element as string.
+        """
         vt_refs_xml = Element('vt_refs')
         for ref_type, ref_values in vt_refs.items():
             for value in ref_values:
@@ -456,7 +479,13 @@ class OSPDopenvas(OSPDaemon):
 
     @staticmethod
     def get_dependencies_vt_as_xml_str(vt_id, dep_list):
-        """ Return  an xml element with dependencies as string."""
+        """ Return  an xml element with dependencies as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            dep_list (List): List with the VT dependencies.
+        Return:
+            string: xml element as string.
+        """
         vt_deps_xml = Element('dependencies')
         for dep in dep_list:
             _vt_dep = Element('dependency')
@@ -472,49 +501,93 @@ class OSPDopenvas(OSPDaemon):
 
     @staticmethod
     def get_creation_time_vt_as_xml_str(vt_id, creation_time):
-        """ Return creation time as string."""
+        """ Return creation time as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            creation_time (str): String with the VT creation time.
+        Return:
+            string: xml element as string.
+        """
         _time = Element('creation_time')
         _time.text = creation_time
         return tostring(_time).decode('utf-8')
 
     @staticmethod
     def get_modification_time_vt_as_xml_str(vt_id, modification_time):
-        """ Return modification time as string."""
+        """ Return modification time as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            modification_time (str): String with the VT modification time.
+        Return:
+            string: xml element as string.
+        """
         _time = Element('modification_time')
         _time.text = modification_time
         return tostring(_time).decode('utf-8')
 
     @staticmethod
     def get_summary_vt_as_xml_str(vt_id, summary):
-        """ Return summary as string."""
+        """ Return summary as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            summary (str): String with a VT summary.
+        Return:
+            string: xml element as string.
+        """
         _summary = Element('summary')
         _summary.text = summary
         return tostring(_summary).decode('utf-8')
 
     @staticmethod
     def get_impact_vt_as_xml_str(vt_id, impact):
-        """ Return impact as string."""
+        """ Return impact as string.
+
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            impact (str): String which explain the vulneravility impact.
+        Return:
+            string: xml element as string.
+        """
         _impact = Element('impact')
         _impact.text = impact
         return tostring(_impact).decode('utf-8')
 
     @staticmethod
     def get_affected_vt_as_xml_str(vt_id, affected):
-        """ Return affected as string."""
+        """ Return affected as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            affected (str): String which explain what is affected.
+        Return:
+            string: xml element as string.
+        """
         _affected = Element('affected')
         _affected.text = affected
         return tostring(_affected).decode('utf-8')
 
     @staticmethod
     def get_insight_vt_as_xml_str(vt_id, insight):
-        """ Return insight as string."""
+        """ Return insight as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            insight (str): String giving an insight of the vulnerability.
+        Return:
+            string: xml element as string.
+        """
         _insight = Element('insight')
         _insight.text = insight
         return tostring(_insight).decode('utf-8')
 
     @staticmethod
     def get_solution_vt_as_xml_str(vt_id, solution, solution_type=None):
-        """ Return solution as string."""
+        """ Return solution as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            solution (str): String giving a possible solution.
+            solution_type (str): A solution type
+        Return:
+            string: xml element as string.
+        """
         _solution = Element('solution')
         _solution.text = solution
         if solution_type:
@@ -522,8 +595,18 @@ class OSPDopenvas(OSPDaemon):
         return tostring(_solution).decode('utf-8')
 
     @staticmethod
-    def get_detection_vt_as_xml_str(vt_id, vuldetect=None, qod_type=None, qod=None):
-        """ Return detection as string."""
+    def get_detection_vt_as_xml_str(vt_id, vuldetect=None,
+                                    qod_type=None, qod=None):
+        """ Return detection as string.
+        Arguments:
+            vt_id (str): VT OID. Only used for logging in error case.
+            vuldetect (str, opt): String which explain how the vulnerability
+                was detected.
+            qod_type (str, opt): qod type.
+            qod (str, opt): qod value.
+        Return:
+            string: xml element as string.
+        """
         _detection = Element('detection')
         if vuldetect:
             _detection.text = vuldetect

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -388,17 +388,12 @@ class OSPDopenvas(OSPDaemon):
     def get_custom_vt_as_xml_str(vt_id, custom):
         """ Return an xml element with custom metadata formatted as string."""
 
-        nvt = Element('vt')
+        _custom = Element('custom')
         for key, val in custom.items():
-            xml_key = SubElement(nvt, key)
+            xml_key = SubElement(_custom, key)
             xml_key.text = val
 
-        itera = nvt.iter()
-        metadata = ''
-        for elem in itera:
-            if elem.tag != 'vt':
-                metadata += (tostring(elem).decode('utf-8'))
-        return metadata
+        return tostring(_custom).decode('utf-8')
 
     @staticmethod
     def get_severities_vt_as_xml_str(vt_id, severities):

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -197,13 +197,13 @@ class TestOspdOpenvas(unittest.TestCase):
         self.assertEqual(w.vts, w.VT)
 
     def test_get_custom_xml(self, mock_nvti, mock_db):
-        out = '<required_ports>Services/www, 80</re' \
+        out = '<custom><required_ports>Services/www, 80</re' \
               'quired_ports><category>3</category><' \
               'excluded_keys>Settings/disable_cgi_s' \
               'canning</excluded_keys><family>Produ' \
               'ct detection</family><filename>manti' \
               's_detect.nasl</filename><timeout>0</' \
-              'timeout>'
+              'timeout></custom>'
         w =  DummyWrapper(mock_nvti, mock_db)
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         res = w.get_custom_vt_as_xml_str(

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -239,7 +239,8 @@ class TestOspdOpenvas(unittest.TestCase):
 
     def test_get_refs_xml(self, mock_nvti, mock_db):
         w =  DummyWrapper(mock_nvti, mock_db)
-        out = '<ref type="url" id="http://www.mantisbt.org/"/>'
+        out = '<vt_refs><ref type="url" id="http://www.mantisbt.org/"/>' \
+              '</vt_refs>'
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         refs = vt.get('vt_refs')
         res = w.get_refs_vt_as_xml_str(

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -250,7 +250,8 @@ class TestOspdOpenvas(unittest.TestCase):
 
     def test_get_dependencies_xml(self, mock_nvti, mock_db):
         w =  DummyWrapper(mock_nvti, mock_db)
-        out = '<dependency vt_id="1.2.3.4"/><dependency vt_id="4.3.2.1"/>'
+        out = '<dependencies><dependency vt_id="1.2.3.4"/><dependency vt' \
+              '_id="4.3.2.1"/></dependencies>'
         dep = ['1.2.3.4', '4.3.2.1']
         res = w.get_dependencies_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', dep)

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -224,12 +224,12 @@ class TestOspdOpenvas(unittest.TestCase):
 
     def test_get_params_xml(self, mock_nvti, mock_db):
         w =  DummyWrapper(mock_nvti, mock_db)
-        out = '<vt_param type="checkbox" id="Do not randomize the  ' \
+        out = '<vt_params><vt_param type="checkbox" id="Do not randomize the  ' \
               'order  in  which ports are scanned"><name>Do not ran' \
               'domize the  order  in  which ports are scanned</name' \
               '><default>no</default></vt_param><vt_param type="ent' \
               'ry" id="Data length : "><name>Data length : </name><' \
-              '/vt_param>'
+              '/vt_param></vt_params>'
 
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         params = vt.get('vt_params')

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -270,7 +270,8 @@ class TestOspdOpenvas(unittest.TestCase):
 
     def test_get_mtime_xml(self, mock_nvti, mock_db):
         w =  DummyWrapper(mock_nvti, mock_db)
-        out = '$Date: 2018-08-10 15:09:25 +0200 (Fri, 10 Aug 2018) $'
+        out = '<modification_time>$Date: 2018-08-10 15:09:25 +0200 ' \
+              '(Fri, 10 Aug 2018) $</modification_time>'
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         mtime = vt.get('modification_time')
         res = w.get_modification_time_vt_as_xml_str(

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -213,8 +213,8 @@ class TestOspdOpenvas(unittest.TestCase):
 
     def test_get_severities_xml(self, mock_nvti, mock_db):
         w =  DummyWrapper(mock_nvti, mock_db)
-        out = '<severity type="cvss_base_v2">' \
-              'AV:N/AC:L/Au:N/C:N/I:N/A:N</severity>'
+        out = '<severities><severity type="cvss_base_v2">' \
+              'AV:N/AC:L/Au:N/C:N/I:N/A:N</severity></severities>'
         vt =w.VT['1.3.6.1.4.1.25623.1.0.100061']
         severities = vt.get('severities')
         res = w.get_severities_vt_as_xml_str(

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -260,7 +260,8 @@ class TestOspdOpenvas(unittest.TestCase):
 
     def test_get_ctime_xml(self, mock_nvti, mock_db):
         w =  DummyWrapper(mock_nvti, mock_db)
-        out = '2009-03-19 11:22:36 +0100 (Thu, 19 Mar 2009)'
+        out = '<creation_time>2009-03-19 11:22:36 +0100 ' \
+              '(Thu, 19 Mar 2009)</creation_time>'
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         ctime = vt.get('creation_time')
         res = w.get_creation_time_vt_as_xml_str(


### PR DESCRIPTION
Depends on PR greenbone/ospd#91

The complete xml for each VT member is made by get_*_vt_as_xml_str() in the wrapper side, using xml function from the library. This avoid the use of string formatting in the ospd base code side too. 
Modify the corresponding unit test.