### PR TITLE
Fix vt_params. Send the vt's id instead vt's name.

### DIFF
--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -86,14 +86,15 @@ class NVTICache(object):
         if prefs:
             for nvt_pref in prefs:
                 elem = nvt_pref.split('|||')
-                vt_params[elem[0]] = dict()
-                vt_params[elem[0]]['type'] = elem[1]
-                vt_params[elem[0]]['name'] = elem[0]
-                vt_params[elem[0]]['description'] = 'Description'
+                _param_name = elem[0].strip()
+                vt_params[_param_name] = dict()
+                vt_params[_param_name]['type'] = elem[1]
+                vt_params[_param_name]['name'] = _param_name
+                vt_params[_param_name]['description'] = 'Description'
                 if elem[2]:
-                    vt_params[elem[0]]['default'] = elem[2]
+                    vt_params[_param_name]['default'] = elem[2]
                 else:
-                    vt_params[elem[0]]['default'] = ''
+                    vt_params[_param_name]['default'] = ''
 
         return vt_params
 

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -862,7 +862,6 @@ class OSPDopenvas(OSPDaemon):
 
         for vtid, vt_params in vts.items():
             vts_list.append(vtid)
-            nvt_name = self.vts[vtid].get('name')
             for vt_param_id, vt_param_value in vt_params.items():
                 param_type = self.get_vt_param_type(vtid, vt_param_id)
                 if not param_type:
@@ -876,7 +875,7 @@ class OSPDopenvas(OSPDaemon):
                 if self.check_param_type(vt_param_value, type_aux):
                     logger.debug('Expected {} type for parameter value {}'
                                  .format(type_aux, str(vt_param_value)))
-                param = ["{0}[{1}]:{2}".format(nvt_name, param_type,
+                param = ["{0}:{1}:{2}".format(vtid, param_type,
                                                vt_param_id),
                          str(vt_param_value)]
                 vts_params.append(param)


### PR DESCRIPTION
It removes the white space at the end of a vt parameter name before
storing it into the VTS dictionary. The preference names are stored
in redis as they are in the nasl script, but the spaces at the end
of the name are removed in gvmd side. Therefore to avoid inconsistencies
the whitespace is removed in ospd-openvas too.

Also, it send the vt's preference to the scanner in the format
oid:type:pref_name.