### PR TITLE
Add ID element to the NVT.

### DIFF
--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -86,13 +86,14 @@ class NVTICache(object):
         if prefs:
             for nvt_pref in prefs:
                 elem = nvt_pref.split('|||')
-                _param_name = elem[0].strip()
+                _param_name = elem[1].strip()
                 vt_params[_param_name] = dict()
-                vt_params[_param_name]['type'] = elem[1]
+                vt_params[_param_name]['id'] = elem[0]
+                vt_params[_param_name]['type'] = elem[2]
                 vt_params[_param_name]['name'] = _param_name
                 vt_params[_param_name]['description'] = 'Description'
                 if elem[2]:
-                    vt_params[_param_name]['default'] = elem[2]
+                    vt_params[_param_name]['default'] = elem[3]
                 else:
                     vt_params[_param_name]['default'] = ''
 

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -434,7 +434,7 @@ class OSPDopenvas(OSPDaemon):
         for pref_name, prefs in vt_params.items():
             vt_param = Element('vt_param')
             vt_param.set('type', prefs['type'])
-            vt_param.set('id', pref_name)
+            vt_param.set('id', prefs['id'])
             xml_name = SubElement(vt_param, 'name')
             xml_name.text = prefs['name']
             if prefs['default']:

--- a/tests/dummywrapper.py
+++ b/tests/dummywrapper.py
@@ -28,12 +28,14 @@ class DummyWrapper(OSPDopenvas):
                 'affected': 'some affection',
                 'vt_dependencies': [],
                 'vt_params': {
-                    'Data length : ': {
+                    'Data length :': {
+                        'id': '1',
                         'default': '',
                         'description': 'Description',
-                        'name': 'Data length : ',
+                        'name': 'Data length :',
                         'type': 'entry'},
                     'Do not randomize the  order  in  which ports are scanned': {
+                        'id': '2',
                         'default': 'no',
                         'description': 'Description',
                         'name': 'Do not randomize the  order  in  which ports are scanned',
@@ -48,13 +50,15 @@ class DummyWrapper(OSPDopenvas):
         oids = [['mantis_detect.nasl', '1.3.6.1.4.1.25623.1.0.100061']]
         nvti.get_oids.return_value = oids
         nvti.get_nvt_params.return_value = {
-            'Data length : ': {
+            'Data length :': {
+                'id': '1',
                 'default': '',
                 'description': 'Description',
-                'name': 'Data length : ',
+                'name': 'Data length :',
                 'type': 'entry'
             },
             'Do not randomize the  order  in  which ports are scanned': {
+                'id': '2',
                 'default': 'no',
                 'description': 'Description',
                 'name': 'Do not randomize the  order  in  which ports are scanned',

--- a/tests/testNVTICache.py
+++ b/tests/testNVTICache.py
@@ -55,12 +55,13 @@ class TestNVTICache(TestCase):
         self.assertEqual(ret, {})
 
     def test_get_nvt_params(self, mock_redis):
-        prefs = ['dns-fuzz.timelimit|||entry|||default']
-        prefs1 = ['dns-fuzz.timelimit|||entry|||']
+        prefs = ['1|||dns-fuzz.timelimit|||entry|||default']
+        prefs1 = ['1|||dns-fuzz.timelimit|||entry|||']
 
         timeout = '300'
         out_dict = {
             'dns-fuzz.timelimit': {
+                'id': '1',
                 'type': 'entry',
                 'default': 'default',
                 'name': 'dns-fuzz.timelimit',
@@ -75,6 +76,7 @@ class TestNVTICache(TestCase):
 
         out_dict1 = {
             'dns-fuzz.timelimit': {
+                'id': '1',
                 'type': 'entry',
                 'default': '',
                 'name': 'dns-fuzz.timelimit',

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -224,11 +224,10 @@ class TestOspdOpenvas(unittest.TestCase):
 
     def test_get_params_xml(self, mock_nvti, mock_db):
         w =  DummyWrapper(mock_nvti, mock_db)
-        out = '<vt_params><vt_param type="checkbox" id="Do not randomize the  ' \
-              'order  in  which ports are scanned"><name>Do not ran' \
-              'domize the  order  in  which ports are scanned</name' \
+        out = '<vt_params><vt_param type="checkbox" id="2"><name>Do ' \
+              'not randomize the  order  in  which ports are scanned</name' \
               '><default>no</default></vt_param><vt_param type="ent' \
-              'ry" id="Data length : "><name>Data length : </name><' \
+              'ry" id="1"><name>Data length :</name><' \
               '/vt_param></vt_params>'
 
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
@@ -409,7 +408,7 @@ class TestOspdOpenvas(unittest.TestCase):
     def test_process_vts(self, mock_nvti, mock_db):
         vts = {
             '1.3.6.1.4.1.25623.1.0.100061': {
-                'Data length : ': 'new value',
+                'Data length :': 'new value',
                 'Do not randomize the  order  in  which ports are ' \
                 'scanned': 'new value'},
             'vt_groups': ['family=debian', 'family=general']


### PR DESCRIPTION
Get the id element from redis and stored it in the dictionary.
Send the ID in the response of the <get_vts> command as vt_param argument.
e.g.
`<get_vts_response status="200" status_text="OK">
  <vts>
    <vt id="1.3.6.1.4.1.25623.1.0.12288">
      <name>Global variable settings</name>
      <vt_params>
        <vt_param id="6" type="checkbox">
          <name>Enable generic web application scanning</name>
          <default>no</default>
        </vt_param>
...`