### PR TITLE
Use refs instead vt_refs.

### DIFF
--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -453,7 +453,7 @@ class OSPDopenvas(OSPDaemon):
         Return:
             string: xml element as string.
         """
-        vt_refs_xml = Element('vt_refs')
+        vt_refs_xml = Element('refs')
         for ref_type, ref_values in vt_refs.items():
             for value in ref_values:
                 vt_ref = Element('ref')

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -238,8 +238,8 @@ class TestOspdOpenvas(unittest.TestCase):
 
     def test_get_refs_xml(self, mock_nvti, mock_db):
         w =  DummyWrapper(mock_nvti, mock_db)
-        out = '<vt_refs><ref type="url" id="http://www.mantisbt.org/"/>' \
-              '</vt_refs>'
+        out = '<refs><ref type="url" id="http://www.mantisbt.org/"/>' \
+              '</refs>'
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         refs = vt.get('vt_refs')
         res = w.get_refs_vt_as_xml_str(


### PR DESCRIPTION
Use refs instead vt_refs.
Update tests accordingly.