### PR TITLE
Add custom date formatter to be used by the nvt filter.

### DIFF
--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -222,7 +222,7 @@ class OSPDopenvas(OSPDaemon):
 
     """ Class for ospd-openvas daemon. """
 
-    def __init__(self, certfile, keyfile, cafile, customvtfilter):
+    def __init__(self, certfile, keyfile, cafile):
         """ Initializes the ospd-openvas daemon's internal data. """
 
         super(OSPDopenvas, self).__init__(certfile=certfile, keyfile=keyfile,

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -24,12 +24,14 @@ import time
 import signal
 import uuid
 from lxml.etree import tostring, SubElement, Element
+from datetime import datetime
 import psutil
 
 from ospd.ospd import OSPDaemon, logger
 from ospd.misc import main as daemon_main
 from ospd.misc import target_str_to_list
 from ospd.cvss import CVSS
+from ospd.vtfilter import VtsFilter
 from ospd_openvas import __version__
 
 from ospd_openvas.nvticache import NVTICache
@@ -201,16 +203,31 @@ def _from_bool_to_str(value):
     uses 1 and 0."""
     return 'yes' if value == 1 else 'no'
 
+class OpenVasVtsFilter(VtsFilter):
+    """ Methods to overwrite the ones in the original class.
+    Each method formats the value to be compatible with the filter
+    """
+    def format_vt_modification_time(self, value):
+        """ Convert the datetime value in an 19 character string
+        representing YearMonthDateHourMinuteSecond.
+        e.g. 20190319122532
+        """
+
+        date = value[7:26].replace(" ", "")
+        date = date.replace("-", "")
+        date = date.replace(":","")
+        return date
 
 class OSPDopenvas(OSPDaemon):
 
     """ Class for ospd-openvas daemon. """
 
-    def __init__(self, certfile, keyfile, cafile):
+    def __init__(self, certfile, keyfile, cafile, customvtfilter):
         """ Initializes the ospd-openvas daemon's internal data. """
 
         super(OSPDopenvas, self).__init__(certfile=certfile, keyfile=keyfile,
-                                          cafile=cafile)
+                                          cafile=cafile,
+                                          customvtfilter=OpenVasVtsFilter())
         self.server_version = __version__
         self.scanner_info['name'] = 'openvassd'
         self.scanner_info['version'] = ''  # achieved during self.check()

--- a/tests/dummywrapper.py
+++ b/tests/dummywrapper.py
@@ -95,4 +95,4 @@ class DummyWrapper(OSPDopenvas):
         with patch('ospd_openvas.wrapper.OpenvasDB', return_value=redis):
             with patch('ospd_openvas.wrapper.NVTICache', return_value=nvti):
                 with patch.object(OSPDopenvas, 'load_vts', return_value=None):
-                    super().__init__('cert', 'key', 'ca')
+                    super().__init__('cert', 'key', 'ca', None)

--- a/tests/dummywrapper.py
+++ b/tests/dummywrapper.py
@@ -95,4 +95,4 @@ class DummyWrapper(OSPDopenvas):
         with patch('ospd_openvas.wrapper.OpenvasDB', return_value=redis):
             with patch('ospd_openvas.wrapper.NVTICache', return_value=nvti):
                 with patch.object(OSPDopenvas, 'load_vts', return_value=None):
-                    super().__init__('cert', 'key', 'ca', None)
+                    super().__init__('cert', 'key', 'ca')

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -23,6 +23,7 @@ import unittest
 from unittest.mock import patch
 from ospd_openvas.wrapper import OSPD_PARAMS
 from tests.dummywrapper import DummyWrapper
+from  ospd_openvas.wrapper import OpenVasVtsFilter
 
 OSPD_PARAMS_OUT = {
     'auto_enable_dependencies': {
@@ -454,3 +455,11 @@ class TestOspdOpenvas(unittest.TestCase):
         w =  DummyWrapper(mock_nvti, mock_db)
         ret = w.scan_is_stopped('123-456')
         self.assertEqual(ret, True)
+
+class TestFilters(unittest.TestCase):
+
+    def test_format_vt_modification_time(self):
+        ovformat = OpenVasVtsFilter()
+        td = '$Date: 2018-02-01 02:09:01 +0200 (Thu, 18 Oct 2018) $'
+        formated = ovformat.format_vt_modification_time(td)
+        self.assertEqual(formated, "20180201020901")


### PR DESCRIPTION
Each wrapper has different formats for datetime values. This method
formats the datetime valued to be comapared with a standar format.

The method overwrites the original in the parent class.