### PR TITLE
Resume tasks

### DIFF
--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -424,4 +424,4 @@ class OpenvasDB(object):
         """
         if not ctx:
             ctx = self.get_kb_context()
-        return self.get_list_item("internal/ip")
+        return self.get_single_item("internal/ip")

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -1108,14 +1108,6 @@ class OSPDopenvas(OSPDaemon):
                           value='An OpenVAS Scanner was started for %s.'
                           % target)
 
-        self.add_scan_log(scan_id, host=target, name='KB location Found',
-                          value='KB location path was found: %s.'
-                          % self.openvas_db.db_address)
-
-        self.add_scan_log(scan_id, host=target, name='Feed Update',
-                          value='Feed version: %s.'
-                          % self.nvti.get_feed_version())
-
         cmd = ['openvassd', '--scan-start', openvas_scan_id]
         try:
             result = subprocess.Popen(cmd, shell=False)

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -1047,6 +1047,18 @@ class OSPDopenvas(OSPDaemon):
         self.openvas_db.add_single_item(
             'internal/%s/globalscanid' % scan_id, [openvas_scan_id])
 
+        # Get unfinished hosts, in case it is a resumed scan. And added
+        # into exclude_hosts scan preference. Set progress for the finished ones
+        # to 100%.
+        finished_hosts = self.get_scan_finished_hosts(scan_id)
+        exclude_hosts = options.get('exclude_hosts')
+        if finished_hosts:
+            if exclude_hosts:
+                finished_hosts_str = ','.join(finished_hosts)
+                options['exclude_hosts'] = exlude_hosts + ',' + finished_hosts_str
+            else:
+                options['exclude_hosts'] = ','.join(finished_hosts)
+
         # Set scan preferences
         for key, value in options.items():
             item_type = ''

--- a/tests/testDB.py
+++ b/tests/testDB.py
@@ -243,3 +243,10 @@ class TestDB(TestCase):
                           'get_kb_context', return_value=mock_redis):
             ret = self.db.get_host_scan_scan_end_time()
         self.assertEqual(ret, 'some end time')
+
+    def test_get_host_ip(self, mock_redis):
+        mock_redis.lindex.return_value = '192.168.0.1'
+        with patch.object(OpenvasDB,
+                          'get_kb_context', return_value=mock_redis):
+            ret = self.db.get_host_ip()
+        self.assertEqual(ret, '192.168.0.1')


### PR DESCRIPTION
Get unfinished hosts, in case it is a resumed scan.
Add them into exclude_hosts scan preference.
Set progress for the finished ones to 100%.

Example: Run, stop, and resume an authenticated scan. Only the unfinished host will be scanned when resuming. 

- Start the scan
`gvm-cli socket --socketpath /tmp/openvas.sock --xml "<start_scan scan_id='980eee4d-7360-42e3-bdc8-6e3bf4c39441' parallel='10'><scanner_params/><vt_selection><vt_single id='1.3.6.1.4.1.25623.1.0.802082'></vt_single><vt_single id='1.3.6.1.4.1.25623.1.0.900920'></vt_single><vt_single id='1.3.6.1.4.1.25623.1.0.90022'></vt_single><vt_group filter='family=General'/></vt_selection><targets><target><hosts>192.168.0.1, 192.168.0.2</hosts><ports>22</ports><credentials><credential type='up' service='ssh' port='22'><username>USERNAME</username><password>PASSWORD</password></credential></credentials></target></targets></start_scan>"`

- Stop the scan
`gvm-cli socket --socketpath /tmp/openvas.sock --xml "<stop_scan scan_id='980eee4d-7360-42e3-bdc8-6e3bf4c39441'/>"`

- Start the scan again with the same scan ID.
`gvm-cli socket --socketpath /tmp/openvas.sock --xml "<start_scan scan_id='980eee4d-7360-42e3-bdc8-6e3bf4c39441' parallel='10'><scanner_params/><vt_selection><vt_single id='1.3.6.1.4.1.25623.1.0.802082'></vt_single><vt_single id='1.3.6.1.4.1.25623.1.0.900920'></vt_single><vt_single id='1.3.6.1.4.1.25623.1.0.90022'></vt_single><vt_group filter='family=General'/></vt_selection><targets><target><hosts>192.168.0.1,192.168.0.2</hosts><ports>22</ports><credentials><credential type='up' service='ssh' port='22'><username>USERNAME</username><password>PASSWORD</password></credential></credentials></target></targets></start_scan>"`

