### PR TITLE
Update CHANGES before tagging.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,11 +8,8 @@ $ git clone https://github.com/greenbone/ospd-openvas.git
 $ cd ospd-openvas && git log
 
 
-ospd-openvas 1.0+beta1 (2018-XX-XX)
+ospd-openvas 1.0alpha1 (2019-05-21)
 
-This is the first beta release of the Open Scanner Protocol (OSP) server
+This is the first alpha version of the Open Scanner Protocol (OSP) server
 for the OpenVAS Scanner to allow the retrieval of the OpenVAS Scanner
 scan results into the Greenbone Vulnerability Manager (GVM).
-
-Many thanks to everyone who has contributed to this release:
-Juan Nicola and Jan-Oliver Wagner.


### PR DESCRIPTION
Quoting to @bjoernricks from PR #70:

> In general updating to a lower version (1.0b1 to 1.0a1) is not the best idea but IMHO it was a mistake to use a beta version in master and we don't have any real release yet. Therefore it should be ok.