### PR TITLE
Handle except

### DIFF
--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -22,6 +22,7 @@
 import redis
 import subprocess
 import time
+import sys
 
 from ospd_openvas.errors import OSPDOpenvasError
 from ospd_openvas.errors import RequiredArgument
@@ -89,9 +90,13 @@ class OpenvasDB(object):
     def get_db_connection(self):
         """ Retrieve the db address from openvassd config.
         """
-        result = subprocess.check_output(
-            ['openvassd', '-s'], stderr=subprocess.STDOUT)
-
+        try:
+            result = subprocess.check_output(
+                ['openvassd', '-s'], stderr=subprocess.STDOUT)
+        except PermissionError:
+            sys.exit("ERROR: %s: Not possible to run openvassd. "
+                     "Check permissions and/or path to the binary." \
+                     % self.get_db_connection.__name__)
         if result:
             path = self._parse_openvassd_db_address(result)
 

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -289,8 +289,7 @@ class OSPDopenvas(OSPDaemon):
             logger.debug('Loading NVTs in Redis DB')
             subprocess.check_call(['openvassd', '-C'])
         except subprocess.CalledProcessError as err:
-            logger.error('OpenVAS Scanner failed to load NVTs.')
-            raise err
+            logger.error('OpenVAS Scanner failed to load NVTs. %s' % err)
 
     def feed_is_outdated(self, current_feed):
         """ Compare the current feed with the one in the disk.

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -857,10 +857,15 @@ class OSPDopenvas(OSPDaemon):
                 self.openvas_db.set_single_item('internal/%s' % scan_id,
                                            ['stop_all', ])
                 ovas_pid = self.openvas_db.get_single_item('internal/ovas_pid')
-                parent = psutil.Process(int(ovas_pid))
+                parent = None
+                try:
+                    parent = psutil.Process(int(ovas_pid))
+                except psutil._exceptions.NoSuchProcess:
+                    logger.debug('Process with pid {0} already stopped'.format(ovas_pid))
                 self.openvas_db.release_db(current_kbi)
-                parent.send_signal(signal.SIGUSR2)
-                logger.debug('Stopping process: {0}'.format(parent))
+                if parent:
+                    parent.send_signal(signal.SIGUSR2)
+                    logger.debug('Stopping process: {0}'.format(parent))
 
     def get_vts_in_groups(self, filters):
         """ Return a list of vts which match with the given filter.
@@ -1131,6 +1136,7 @@ class OSPDopenvas(OSPDaemon):
             result = subprocess.Popen(cmd, shell=False)
         except OSError:
             # the command is not available
+            print ("Estoy en el except")
             return False
 
         ovas_pid = result.pid
@@ -1139,12 +1145,18 @@ class OSPDopenvas(OSPDaemon):
 
         # Wait until the scanner starts and loads all the preferences.
         while self.openvas_db.get_single_item('internal/'+ openvas_scan_id) == 'new':
+            res = result.poll()
+            if res and res < 0:
+                self.stop_scan_cleanup(scan_id)
+                msg = 'It was not possible run the task %s, since openvassd ended ' \
+                      'unexpectedly with errors during launching.' % scan_id
+                logger.error(msg)
+                return 1
             time.sleep(1)
 
         no_id_found = False
         while True:
             time.sleep(3)
-
             # Check if the client stopped the whole scan
             if self.scan_is_stopped(openvas_scan_id):
                 return 1


### PR DESCRIPTION
If during launching a task, openvassd finishes unexpectedly with errors, it logs an error messages and stops the scan cleanly, removing the kb from redis.
Improve exceptions launching openvassd during the nvticache initialization.