### PR TITLE
Udate to new API of OpenVAS Scanner.

### DIFF
--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2018-2019 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -69,10 +69,10 @@ class OpenvasDB(object):
         self.logger = wrapper_logger.getChild('db') if wrapper_logger else logger
 
     @staticmethod
-    def _parse_openvassd_db_address(result):
+    def _parse_openvas_db_address(result):
         """ Return the path to the redis socket.
         Arguments:
-            result (bytes) Output of `openvassd -s`
+            result (bytes) Output of `openvas -s`
         Return redis unix socket path.
         """
         path = None
@@ -88,17 +88,17 @@ class OpenvasDB(object):
         return path[1].strip()
 
     def get_db_connection(self):
-        """ Retrieve the db address from openvassd config.
+        """ Retrieve the db address from openvas config.
         """
         try:
             result = subprocess.check_output(
-                ['openvassd', '-s'], stderr=subprocess.STDOUT)
+                ['openvas', '-s'], stderr=subprocess.STDOUT)
         except PermissionError:
-            sys.exit("ERROR: %s: Not possible to run openvassd. "
+            sys.exit("ERROR: %s: Not possible to run openvas. "
                      "Check permissions and/or path to the binary." \
                      % self.get_db_connection.__name__)
         if result:
-            path = self._parse_openvassd_db_address(result)
+            path = self._parse_openvas_db_address(result)
 
         self.db_address = path
 

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -124,7 +124,7 @@ OSPD_PARAMS = {
         'name': 'optimize_test',
         'default': 5,
         'mandatory': 0,
-        'description': ('By default, openvassd does not trust the remote ' +
+        'description': ('By default, openvas does not trust the remote ' +
                         'host banners.'),
     },
     'plugins_timeout': {
@@ -240,7 +240,7 @@ class OSPDopenvas(OSPDaemon):
 
         self.server_version = __version__
         self._niceness = str(niceness)
-        self.scanner_info['name'] = 'openvassd'
+        self.scanner_info['name'] = 'openvas'
         self.scanner_info['version'] = ''  # achieved during self.check()
         self.scanner_info['description'] = OSPD_DESC
         for name, param in OSPD_PARAMS.items():
@@ -266,7 +266,7 @@ class OSPDopenvas(OSPDaemon):
         global OSPD_PARAMS
         bool_dict = {'no': 0, 'yes': 1}
 
-        result = subprocess.check_output(['openvassd', '-s'],
+        result = subprocess.check_output(['openvas', '-s'],
                                          stderr=subprocess.STDOUT)
         result = result.decode('ascii')
         param_list = dict()
@@ -288,7 +288,7 @@ class OSPDopenvas(OSPDaemon):
         """ Loads NVT's metadata into Redis DB. """
         try:
             logger.debug('Loading NVTs in Redis DB')
-            subprocess.check_call(['openvassd', '-C'])
+            subprocess.check_call(['openvas', '--update-vt-info'])
         except subprocess.CalledProcessError as err:
             logger.error('OpenVAS Scanner failed to load NVTs. %s' % err)
 
@@ -680,10 +680,10 @@ class OSPDopenvas(OSPDaemon):
         return tostring(_detection).decode('utf-8')
 
     def check(self):
-        """ Checks that openvassd command line tool is found and
+        """ Checks that openvas command line tool is found and
         is executable. """
         try:
-            result = subprocess.check_output(['openvassd', '-V'],
+            result = subprocess.check_output(['openvas', '-V'],
                                              stderr=subprocess.STDOUT)
             result = result.decode('ascii')
         except OSError:
@@ -1140,7 +1140,7 @@ class OSPDopenvas(OSPDaemon):
                           value='An OpenVAS Scanner was started for %s.'
                           % target)
 
-        cmd = ['openvassd', '--scan-start', openvas_scan_id]
+        cmd = ['openvas', '--scan-start', openvas_scan_id]
         if self._niceness is not None:
             cmd_nice = ['nice', '-n', self._niceness]
             cmd_nice.extend(cmd)
@@ -1162,7 +1162,7 @@ class OSPDopenvas(OSPDaemon):
             res = result.poll()
             if res and res < 0:
                 self.stop_scan_cleanup(scan_id)
-                msg = 'It was not possible run the task %s, since openvassd ended ' \
+                msg = 'It was not possible run the task %s, since openvas ended ' \
                       'unexpectedly with errors during launching.' % scan_id
                 logger.error(msg)
                 return 1

--- a/tests/testDB.py
+++ b/tests/testDB.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2018-2019 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -31,9 +31,9 @@ class TestDB(TestCase):
     def setUp(self):
         self.db = OpenvasDB()
 
-    def test_parse_openvassd_db_addres(self, mock_redis):
+    def test_parse_openvas_db_addres(self, mock_redis):
         with self.assertRaises(OSPDOpenvasError):
-            self.db._parse_openvassd_db_address(b'somedata')
+            self.db._parse_openvas_db_address(b'somedata')
 
     def test_max_db_index_fail(self, mock_redis):
         mock_redis.config_get.return_value = {}

--- a/tests/testWrapper.py
+++ b/tests/testWrapper.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2018-2019 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -92,7 +92,7 @@ OSPD_PARAMS_OUT = {
         'name': 'optimize_test',
         'default': 5,
         'mandatory': 0,
-        'description': 'By default, openvassd does not trust the remote ' \
+        'description': 'By default, openvas does not trust the remote ' \
                        'host banners.',
     },
     'plugins_timeout': {


### PR DESCRIPTION
This adapts ospd-openvas to the new OpenVAS
Scanner API: The command line tool is now called
"openvas" instead of "openvassd" and the parameter
to update the VT cache changed as well.

This corresponds to
https://github.com/greenbone/openvas-scanner/pull/337