### PR TITLE
Fix stop scan cleanup

### DIFF
--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -913,10 +913,19 @@ class OSPDopenvas(OSPDaemon):
                     logger.debug(
                         'Process with pid %s already stopped', ovas_pid
                     )
-                self.openvas_db.release_db(current_kbi)
                 if parent:
-                    parent.send_signal(signal.SIGUSR2)
+                    cmd = ['sudo', 'openvas', '--scan-stop', scan_id]
+
+                    try:
+                        result = subprocess.Popen(cmd, shell=False)
+                    except OSError:
+                        # the command is not available
+                        logger.debug('Not possible to Stopping process: %s',
+                                     parent)
+                        return False
+
                     logger.debug('Stopping process: %s', parent)
+                self.openvas_db.release_db(current_kbi)
 
     def get_vts_in_groups(self, filters):
         """ Return a list of vts which match with the given filter.

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -24,7 +24,6 @@
 import logging
 import subprocess
 import time
-import signal
 import uuid
 
 from os import path

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -1275,7 +1275,6 @@ class OSPDopenvas(OSPDaemon):
             result = subprocess.Popen(cmd, shell=False)
         except OSError:
             # the command is not available
-            print("Estoy en el except")
             return False
 
         ovas_pid = result.pid

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -916,7 +916,7 @@ class OSPDopenvas(OSPDaemon):
                     cmd = ['sudo', 'openvas', '--scan-stop', scan_id]
 
                     try:
-                        result = subprocess.Popen(cmd, shell=False)
+                        subprocess.Popen(cmd, shell=False)
                     except OSError:
                         # the command is not available
                         logger.debug('Not possible to Stopping process: %s',

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -917,10 +917,10 @@ class OSPDopenvas(OSPDaemon):
 
                     try:
                         subprocess.Popen(cmd, shell=False)
-                    except OSError:
+                    except OSError as e:
                         # the command is not available
-                        logger.debug('Not possible to Stopping process: %s',
-                                     parent)
+                        logger.debug('Not possible to Stopping process: %s.'
+                                     'Reason %s', parent, e)
                         return False
 
                     logger.debug('Stopping process: %s', parent)


### PR DESCRIPTION
As openvas is started with sudo, ospd-openvas (launched with non-root user permissions)
is not allowed to send SIGUSR2 kill signal to openvas and stop the running scan.
It used now instead, the new openvas command line option --stop-scan with sudo.
The new called openvas process will stop the running scan.