### PR TITLE
Check sudo permissions before call openvas.

### DIFF
--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -269,7 +269,7 @@ class OSPDopenvas(OSPDaemon):
         self.scanner_info['description'] = OSPD_DESC
         for name, param in OSPD_PARAMS.items():
             self.add_scanner_param(name, param)
-        self.sudo_available = self.sudo_check()
+        self.sudo_available = False
 
         self.scan_only_params = dict()
         self.main_kbindex = None
@@ -718,7 +718,6 @@ class OSPDopenvas(OSPDaemon):
 
     def sudo_check(self):
         """ Checks that sudo is available and set the global var. """
-        _sudo_available = False
         try:
             result = subprocess.check_call(
                 ['sudo', '-n', 'openvas', '-s'], stdout=subprocess.PIPE
@@ -726,12 +725,10 @@ class OSPDopenvas(OSPDaemon):
         except subprocess.CalledProcessError as e:
             logger.debug('It was not possible to call openvas with sudo. '
                          'The scanner will run as non-root user. Reason %s', e)
-            return _sudo_available
+            self.sudo_available = False
 
         if result == 0:
-            _sudo_available = True
-
-        return _sudo_available
+            self.sudo_available = True
 
     def check(self):
         """ Checks that openvas command line tool is found and

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -928,10 +928,9 @@ class OSPDopenvas(OSPDaemon):
                         'Process with pid %s already stopped', ovas_pid
                     )
                 if parent:
+                    cmd = ['openvas', '--scan-stop', scan_id]
                     if self.sudo_available:
-                        cmd = ['sudo', 'openvas', '--scan-stop', scan_id]
-                    else:
-                        cmd = ['openvas', '--scan-stop', scan_id]
+                        cmd = ['sudo'] + cmd
 
                     try:
                         subprocess.Popen(cmd, shell=False)
@@ -1282,15 +1281,13 @@ class OSPDopenvas(OSPDaemon):
             value='An OpenVAS Scanner was started for %s.' % target,
         )
 
-        if self.sudo_available:
-            cmd = ['sudo', 'openvas', '--scan-start', openvas_scan_id]
-        else:
-            cmd = ['openvas', '--scan-start', openvas_scan_id]
-
+        cmd = ['openvas', '--scan-start', openvas_scan_id]
         if self._niceness is not None:
-            cmd_nice = ['nice', '-n', self._niceness]
-            cmd_nice.extend(cmd)
-            cmd = cmd_nice
+            cmd = ['nice', '-n', self._niceness] + cmd
+
+        if self.sudo_available:
+            cmd = ['sudo'] + cmd
+
         logger.debug("Running scan with niceness %s", self._niceness)
         try:
             result = subprocess.Popen(cmd, shell=False)

--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -269,7 +269,7 @@ class OSPDopenvas(OSPDaemon):
         self.scanner_info['description'] = OSPD_DESC
         for name, param in OSPD_PARAMS.items():
             self.add_scanner_param(name, param)
-        self.sudo_available = False
+        self._sudo_available = None
 
         self.scan_only_params = dict()
         self.main_kbindex = None
@@ -716,19 +716,23 @@ class OSPDopenvas(OSPDaemon):
 
         return tostring(_detection).decode('utf-8')
 
-    def sudo_check(self):
-        """ Checks that sudo is available and set the global var. """
+    @property
+    def sudo_available(self):
+        """ Checks that sudo is available """
+        if self._sudo_available is not None:
+            return self._sudo_available
         try:
-            result = subprocess.check_call(
+            subprocess.check_call(
                 ['sudo', '-n', 'openvas', '-s'], stdout=subprocess.PIPE
             )
+            self._sudo_available = True
         except subprocess.CalledProcessError as e:
             logger.debug('It was not possible to call openvas with sudo. '
                          'The scanner will run as non-root user. Reason %s', e)
-            self.sudo_available = False
+            self._sudo_available = False
 
-        if result == 0:
-            self.sudo_available = True
+        return self._sudo_available
+
 
     def check(self):
         """ Checks that openvas command line tool is found and
@@ -930,7 +934,7 @@ class OSPDopenvas(OSPDaemon):
                 if parent:
                     cmd = ['openvas', '--scan-stop', scan_id]
                     if self.sudo_available:
-                        cmd = ['sudo'] + cmd
+                        cmd = ['sudo', '-n'] + cmd
 
                     try:
                         subprocess.Popen(cmd, shell=False)
@@ -1282,11 +1286,11 @@ class OSPDopenvas(OSPDaemon):
         )
 
         cmd = ['openvas', '--scan-start', openvas_scan_id]
+        if self.sudo_available:
+            cmd = ['sudo', '-n'] + cmd
+
         if self._niceness is not None:
             cmd = ['nice', '-n', self._niceness] + cmd
-
-        if self.sudo_available:
-            cmd = ['sudo'] + cmd
 
         logger.debug("Running scan with niceness %s", self._niceness)
         try:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -197,18 +197,12 @@ class TestOspdOpenvas(unittest.TestCase):
         self.assertEqual(w.scan_only_params.get('plugins_folder'), '/foo/bar')
 
     @patch('ospd_openvas.wrapper.subprocess')
-    def test_sudo_check(self, mock_subproc, mock_nvti, mock_db):
-        mock_subproc.check_call.return_value = 1
-        w = DummyWrapper(mock_nvti, mock_db)
-        mock_subproc.reset_mock()
-        w.sudo_check()
-        self.assertFalse(w.sudo_available)
-
+    def test_sudo_available(self, mock_subproc, mock_nvti, mock_db):
         mock_subproc.check_call.return_value = 0
-        w.sudo_check()
+        w = DummyWrapper(mock_nvti, mock_db)
+        w._sudo_available = None
+        w.sudo_available
         self.assertTrue(w.sudo_available)
-        self.assertEqual(mock_subproc.check_call.call_count, 2)
-
 
     def test_load_vts(self, mock_nvti, mock_db):
         w = DummyWrapper(mock_nvti, mock_db)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -180,6 +180,7 @@ class TestOspdOpenvas(unittest.TestCase):
     def test_redis_nvticache_init(self, mock_subproc, mock_nvti, mock_db):
         mock_subproc.check_call.return_value = True
         w = DummyWrapper(mock_nvti, mock_db)
+        mock_subproc.reset_mock()
         w.redis_nvticache_init()
         self.assertEqual(mock_subproc.check_call.call_count, 1)
 
@@ -194,6 +195,20 @@ class TestOspdOpenvas(unittest.TestCase):
         self.assertEqual(mock_subproc.check_output.call_count, 1)
         self.assertEqual(OSPD_PARAMS, OSPD_PARAMS_OUT)
         self.assertEqual(w.scan_only_params.get('plugins_folder'), '/foo/bar')
+
+    @patch('ospd_openvas.wrapper.subprocess')
+    def test_sudo_check(self, mock_subproc, mock_nvti, mock_db):
+        mock_subproc.check_call.return_value = 1
+        w = DummyWrapper(mock_nvti, mock_db)
+        mock_subproc.reset_mock()
+        w.sudo_check()
+        self.assertFalse(w.sudo_available)
+
+        mock_subproc.check_call.return_value = 0
+        w.sudo_check()
+        self.assertTrue(w.sudo_available)
+        self.assertEqual(mock_subproc.check_call.call_count, 2)
+
 
     def test_load_vts(self, mock_nvti, mock_db):
         w = DummyWrapper(mock_nvti, mock_db)


### PR DESCRIPTION
Check if the user running ospd-openvas has permissions to call openvas
with sudo and without password.
Depending on it, it will run openvas with sudo or without it.

How to give the user permission to call openvas with sudo and without password:
`$ sudo visudo
`
Add at the end of the file
`<user> ALL = NOPASSWD: /<install/path/sbin/openvas
`
