### PR TITLE
Send the id parameter too.

### DIFF
--- a/ospd_openvas/wrapper.py
+++ b/ospd_openvas/wrapper.py
@@ -1043,7 +1043,12 @@ class OSPDopenvas(OSPDaemon):
                         str(vt_param_value),
                     )
                 param = [
-                    "{0}:{1}:{2}".format(vtid, param_type, param_name),
+                    "{0}:{1}:{2}:{3}".format(
+                        vtid,
+                        vt_param_id,
+                        param_type,
+                        param_name
+                    ),
                     str(vt_param_value),
                 ]
                 vts_params.append(param)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -454,7 +454,10 @@ class TestOspdOpenvas(unittest.TestCase):
         vt_out = (
             ['1.3.6.1.4.1.25623.1.0.100061'],
             [
-                ['1.3.6.1.4.1.25623.1.0.100061:entry:Data length :', 'new value'],
+                [
+                    '1.3.6.1.4.1.25623.1.0.100061:1:entry:Data length :',
+                    'new value'
+                ],
             ],
         )
         w = DummyWrapper(mock_nvti, mock_db)


### PR DESCRIPTION
The scanner expects to receive vt preferences in OID:PrefID:PrefType:PrefName form.