### PR TITLE
Maintains the results order

### DIFF
--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -402,7 +402,7 @@ class OpenvasDB(object):
         """
         if not ctx:
             ctx = self.get_kb_context()
-        return ctx.rpop("internal/results")
+        return ctx.lpop("internal/results")
 
     def get_status(self, ctx=None):
         """ Get and remove the oldest host scan status from the list.
@@ -412,7 +412,7 @@ class OpenvasDB(object):
         """
         if not ctx:
             ctx = self.get_kb_context()
-        return ctx.rpop("internal/status")
+        return ctx.lpop("internal/status")
 
     def get_host_scan_scan_start_time(self, ctx=None):
         """ Get the timestamp of the scan start from redis.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -211,13 +211,13 @@ class TestDB(TestCase):
         mock_redis.hdel.assert_called_once_with('GVM.__GlobalDBIndex', 3)
 
     def test_get_result(self, mock_redis):
-        mock_redis.rpop.return_value = 'some result'
+        mock_redis.lpop.return_value = 'some result'
         with patch.object(OpenvasDB, 'get_kb_context', return_value=mock_redis):
             ret = self.db.get_result()
         self.assertEqual(ret, 'some result')
 
     def test_get_status(self, mock_redis):
-        mock_redis.rpop.return_value = 'some status'
+        mock_redis.lpop.return_value = 'some status'
         with patch.object(OpenvasDB, 'get_kb_context', return_value=mock_redis):
             ret = self.db.get_status()
         self.assertEqual(ret, 'some status')


### PR DESCRIPTION
Openvas uses rpush to store the result in redis, and now ospd-openvas uses
lpop to get them.
Update tests.