### PR TITLE
Add pylint statements to tests

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -17,6 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
+# pylint: disable=invalid-name,line-too-long
+
 """ Unit Test for ospd-openvas """
 
 import unittest
@@ -200,8 +202,8 @@ class TestOspdOpenvas(unittest.TestCase):
     def test_sudo_available(self, mock_subproc, mock_nvti, mock_db):
         mock_subproc.check_call.return_value = 0
         w = DummyDaemon(mock_nvti, mock_db)
-        w._sudo_available = None
-        w.sudo_available
+        w._sudo_available = None  # pylint: disable=protected-access
+        w.sudo_available  # pylint: disable=pointless-statement
         self.assertTrue(w.sudo_available)
 
     def test_load_vts(self, mock_nvti, mock_db):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -17,6 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
+# pylint: disable=unused-argument
+
 """ Unit Test for ospd-openvas """
 
 from unittest import TestCase
@@ -36,7 +38,9 @@ class TestDB(TestCase):
 
     def test_parse_openvas_db_addres(self, mock_redis):
         with self.assertRaises(OspdOpenvasError):
-            self.db._parse_openvas_db_address(b'somedata')
+            self.db._parse_openvas_db_address(  # pylint: disable=protected-access
+                b'somedata'
+            )
 
     def test_max_db_index_fail(self, mock_redis):
         mock_redis.config_get.return_value = {}

--- a/tests/test_nvti_cache.py
+++ b/tests/test_nvti_cache.py
@@ -17,6 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
+# pylint: disable=unused-argument
+
 """ Unit Test for ospd-openvas """
 
 from unittest import TestCase
@@ -48,7 +50,9 @@ class TestNVTICache(TestCase):
 
     def test_parse_metadata_tags(self, mock_redis):
         tags = 'tag1'
-        ret = self.nvti._parse_metadata_tags(tags, '1.2.3')
+        ret = self.nvti._parse_metadata_tags(  # pylint: disable=protected-access
+            tags, '1.2.3'
+        )
         self.assertEqual(ret, {})
 
     def test_get_nvt_params(self, mock_redis):


### PR DESCRIPTION
Get tests error and warning free by deactivating unecessary pylint
checks for the tests.