### PR TITLE
Unit file systemd

### DIFF
--- a/config/ospd-openvas.default
+++ b/config/ospd-openvas.default
@@ -1,0 +1,3 @@
+# The installation prefix to find the ospd-openvas binary.
+PATH=<install-prefix>/bin:<install-prefix>/sbin:$PATH
+PYTHONPATH=<install-prefix>/lib/python3.5/site-packages:$PYTHONPATH

--- a/config/ospd-openvas.default
+++ b/config/ospd-openvas.default
@@ -1,3 +1,3 @@
 # The installation prefix to find the ospd-openvas binary.
-PATH=<install-prefix>/bin:<install-prefix>/sbin:$PATH
+PATH=<install-prefix>/bin:<install-prefix>/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$PATH
 PYTHONPATH=<install-prefix>/lib/python3.5/site-packages:$PYTHONPATH

--- a/config/ospd-openvas.service
+++ b/config/ospd-openvas.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=OSPD OpenVAS
+After=network.target networking.service dnsmasq.service redis-server@openvas.service systemd-tmpfiles.service
+ConditionKernelCommandLine=!recovery
+
+[Service]
+Type=forking
+EnvironmentFile=/etc/default/ospd-openvas.default
+Environment="PATH=$PATH"
+Environment="PYTHONPATH=$PYTHONPATH"
+User=<username>
+Group=<groupname>
+ExecStart=<install-prefix>/bin/ospd-openvas
+SuccessExitStatus=SIGKILL
+# This works asynchronously, but does not take the daemon down during the reload so it's ok.
+Restart=always
+RestartSec=60
+
+[Install]
+WantedBy=multi-user.target
+Alias=ospd-openvas.service

--- a/config/ospd.conf
+++ b/config/ospd.conf
@@ -1,0 +1,6 @@
+[OSPD - openvas]
+log_level = DEBUG
+socket_mode = 0o770
+unix_socket = /run/ospd/openvas.sock
+unix_socket = /run/ospd/openvas.pid
+log_file = <install-prefix>/var/log/gvm/openvas.log


### PR DESCRIPTION
**Add ospd.conf example file.**
Copy this file to ~/.config/ospd.conf (default path),
or copy the file to other location and start ospd-openvas
with the -s option
```
ospd-openvas -s <some-path-to-file>
```

**Add default and unit file templates for ospd-openvas.**
Default file contains the environment variables that ospd-openvas needs. It must be copied to /etc/default/.
The unit file must be copied to /lib/systemd/system/
Depending on where and how ospd-openvas was installed, the <install_prefix>
must be set in the files.
Also the user and group used to run the service.
After modifying the files, the systemctl command can be used to enable and start/stop the service.