### PR TITLE
Change parsing of modification time

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -26,12 +26,12 @@ import subprocess
 import time
 import uuid
 
+from datetime import datetime
+
 from pathlib import Path
 from lxml.etree import tostring, SubElement, Element
 
 import psutil
-
-from datetime import datetime
 
 from ospd.errors import OspdError
 from ospd.ospd import OSPDaemon

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -235,15 +235,12 @@ class OpenVasVtsFilter(VtsFilter):
     """
 
     def format_vt_modification_time(self, value):
-        """ Convert the datetime value in an 19 character string
-        representing YearMonthDateHourMinuteSecond.
+        """ Convert the string seconds since epoch into a 19 character
+        string representing YearMonthDayHourMinuteSecond.
         e.g. 20190319122532
         """
 
-        date = value[7:26].replace(" ", "")
-        date = date.replace("-", "")
-        date = date.replace(":", "")
-        return date
+        return time.strftime("%Y%m%d%H%M%S", time.gmtime(int(value)));
 
 
 class OSPDopenvas(OSPDaemon):

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -240,7 +240,7 @@ class OpenVasVtsFilter(VtsFilter):
         e.g. 20190319122532
         """
 
-        return time.strftime("%Y%m%d%H%M%S", time.gmtime(int(value)));
+        return time.strftime("%Y%m%d%H%M%S", time.gmtime(int(value)))
 
 
 class OSPDopenvas(OSPDaemon):

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2019 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -31,6 +31,8 @@ from lxml.etree import tostring, SubElement, Element
 
 import psutil
 
+from datetime import datetime
+
 from ospd.errors import OspdError
 from ospd.ospd import OSPDaemon
 from ospd.main import main as daemon_main
@@ -46,19 +48,19 @@ from ospd_openvas.db import OpenvasDB
 logger = logging.getLogger(__name__)
 
 OSPD_DESC = """
-This scanner runs 'OpenVAS Scanner' to scan the target hosts.
+This scanner runs OpenVAS to scan the target hosts.
 
 OpenVAS (Open Vulnerability Assessment Scanner) is a powerful scanner
 for vulnerabilities in IT infrastrucutres. The capabilities include
 unauthenticated scanning as well as authenticated scanning for
 various types of systems and services.
 
-For more details about OpenVAS see the OpenVAS homepage:
+For more details about OpenVAS see:
 http://www.openvas.org/
 
 The current version of ospd-openvas is a simple frame, which sends
 the server parameters to the Greenbone Vulnerability Manager daemon (GVMd) and
-checks the existence of OpenVAS scanner binary. But it can not run scans yet.
+checks the existence of OpenVAS binary. But it can not run scans yet.
 """
 
 OSPD_PARAMS = {
@@ -236,11 +238,11 @@ class OpenVasVtsFilter(VtsFilter):
 
     def format_vt_modification_time(self, value):
         """ Convert the string seconds since epoch into a 19 character
-        string representing YearMonthDayHourMinuteSecond.
-        e.g. 20190319122532
+        string representing YearMonthDayHourMinuteSecond,
+        e.g. 20190319122532. This always refers to UTC.
         """
 
-        return time.strftime("%Y%m%d%H%M%S", time.gmtime(int(value)))
+        return datetime.utcfromtimestamp(int(value)).strftime("%Y%m%d%H%M%S")
 
 
 class OSPDopenvas(OSPDaemon):

--- a/tests/dummydaemon.py
+++ b/tests/dummydaemon.py
@@ -27,7 +27,7 @@ class DummyDaemon(OSPDopenvas):
 
         self.VT = {
             '1.3.6.1.4.1.25623.1.0.100061': {
-                'creation_time': '2009-03-19 11:22:36 +0100 (Thu, 19 Mar 2009)',
+                'creation_time': '1237458156',
                 'custom': {
                     'category': '3',
                     'excluded_keys': 'Settings/disable_cgi_scanning',
@@ -37,7 +37,7 @@ class DummyDaemon(OSPDopenvas):
                     'timeout': '0',
                 },
                 'modification_time': (
-                    '$Date: 2018-08-10 15:09:25 +0200 (Fri, ' '10 Aug 2018) $'
+                    '1533906565'
                 ),
                 'name': 'Mantis Detection',
                 'qod_type': 'remote_banner',
@@ -101,13 +101,13 @@ class DummyDaemon(OSPDopenvas):
         }
         nvti.get_nvt_metadata.return_value = {
             'category': '3',
-            'creation_date': '2009-03-19 11:22:36 +0100 (Thu, 19 Mar 2009)',
+            'creation_date': '1237458156',
             'cvss_base_vector': 'AV:N/AC:L/Au:N/C:N/I:N/A:N',
             'excluded_keys': 'Settings/disable_cgi_scanning',
             'family': 'Product detection',
             'filename': 'mantis_detect.nasl',
             'last_modification': (
-                '$Date: 2018-08-10 15:09:25 +0200 (Fri, 10 Aug 2018) $'
+                '1533906565'
             ),
             'name': 'Mantis Detection',
             'qod_type': 'remote_banner',

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -284,8 +284,7 @@ class TestOspdOpenvas(unittest.TestCase):
     def test_get_ctime_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = (
-            '<creation_time>2009-03-19 11:22:36 +0100 '
-            '(Thu, 19 Mar 2009)</creation_time>'
+            '<creation_time>1237458156</creation_time>'
         )
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         ctime = vt.get('creation_time')
@@ -298,8 +297,7 @@ class TestOspdOpenvas(unittest.TestCase):
     def test_get_mtime_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = (
-            '<modification_time>$Date: 2018-08-10 15:09:25 +0200 '
-            '(Fri, 10 Aug 2018) $</modification_time>'
+            '<modification_time>1533906565</modification_time>'
         )
         vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         mtime = vt.get('modification_time')
@@ -591,6 +589,6 @@ class TestOspdOpenvas(unittest.TestCase):
 class TestFilters(unittest.TestCase):
     def test_format_vt_modification_time(self):
         ovformat = OpenVasVtsFilter()
-        td = '$Date: 2018-02-01 02:09:01 +0200 (Thu, 18 Oct 2018) $'
+        td = '1517443741'
         formatted = ovformat.format_vt_modification_time(td)
-        self.assertEqual(formatted, "20180201020901")
+        self.assertEqual(formatted, "20180201000901")


### PR DESCRIPTION
With https://github.com/greenbone/gvm-libs/pull/265 the timestamps
in redis created by openvas will be always seconds since epoch as
strings.

This patch changes the parsing of the string to assuming the string
is seconds since epoch.