### PR TITLE
Check if target finished.

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1422,7 +1422,7 @@ class OSPDopenvas(OSPDaemon):
                         self.openvas_db.release_db(i)
 
             # Scan end. No kb in use for this scan id
-            if no_id_found:
+            if no_id_found and self.target_is_finished(scan_id):
                 break
             no_id_found = True
 


### PR DESCRIPTION
For targets with reverse lookup activated, the scanners takes long
to start scanning the first host. Therefore, no new host kb was created
and this situation has been interpreted as finished scan.