### PR TITLE
Fix check for outdated feed.

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -362,7 +362,7 @@ class OSPDopenvas(OSPDaemon):
         """
         current_feed = self.nvti.get_feed_version()
         # Check if the feed is already accessible in the disk.
-        if self.feed_is_outdated(current_feed) is None:
+        if current_feed and self.feed_is_outdated(current_feed) is None:
             self.pending_feed = True
             return
 


### PR DESCRIPTION
It checks if there is a feed in redis before checking if it is outdated. This avoid ospd-openvas to crash if for some reason the nvticache was flushed.