### PR TITLE
[1.0] Improve redis clean out when stopping a scan.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.1] (unreleased)
+
+### Fixed
+- Improve redis clean out when stopping a scan. [#128](https://github.com/greenbone/ospd-openvas/pull/128)
+
+[1.0.1]: https://github.com/greenbone/ospd-openvas/commits/v1.0.0...ospd-openvas-1.0
+
 ## [1.0.0] (2019-10-11)
 
 This is the first release of the ospd-openvas module for the Greenbone
 Vulnerability Management (GVM) framework.
 
-[1.0.0]: https://github.com/greenbone/ospd-openvas/commits/ospd-openvas-1.0
+[1.0.0]: https://github.com/greenbone/ospd-openvas/commits/v1.0.0
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1015,6 +1015,14 @@ class OSPDopenvas(OSPDaemon):
                             parent = None
 
                 self.openvas_db.release_db(current_kbi)
+                for host_kb in range(0, self.openvas_db.max_dbindex):
+                    self.openvas_db.select_kb(
+                        ctx,
+                        str(host_kb),
+                        set_global=True)
+                    if self.openvas_db.get_single_item(
+                            'internal/%s' % scan_id):
+                        self.openvas_db.release_db(host_kb)
 
     def get_vts_in_groups(self, filters):
         """ Return a list of vts which match with the given filter.


### PR DESCRIPTION
After stopping a scan, a redis clean out is performed. All the host kb related to the stopped scan will be deleted.