### PR TITLE
[1.0] Check the vt's preference value for type 'file'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Exit with exit code 1 if it was not possible to connect to redis. [#133](https://github.com/greenbone/ospd-openvas/pull/133)
 - Return None if the scan finished successfully. [#137](https://github.com/greenbone/ospd-openvas/pull/137)
 
+### Added
+- Check the vt's preference value for type 'file'. [#130](https://github.com/greenbone/ospd-openvas/pull/130).
+
 ### Fixed
 - Improve redis clean out when stopping a scan. [#128](https://github.com/greenbone/ospd-openvas/pull/128)
 


### PR DESCRIPTION
If the preference type is file, it check if the value is
encoded into base64 format, as expected for openvas.