### PR TITLE
[1.0] Exit with exit code 1 if it was not possible to connect to redis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.0.1] (unreleased)
 
+### Changed
+- Exit with exit code 1 if it was not possible to connect to redis. [#133](https://github.com/greenbone/ospd-openvas/pull/133)
+
 ### Fixed
 - Improve redis clean out when stopping a scan. [#128](https://github.com/greenbone/ospd-openvas/pull/128)
 

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -191,9 +191,10 @@ class OpenvasDB(object):
             break
 
         if not tries:
-            raise OspdOpenvasError(
+            logger.error(
                 'Redis Error: Not possible to connect to the kb.'
             )
+            sys.exit(1)
 
         self.db_index = dbnum
         return ctx

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -88,7 +88,7 @@ class TestDB(TestCase):
         mock_redis.side_effect = RCE
         with patch.object(OpenvasDB, 'get_db_connection', return_value=None):
             with patch.object(time, 'sleep', return_value=None):
-                with self.assertRaises(OspdOpenvasError):
+                with self.assertRaises(SystemExit):
                     self.db.kb_connect()
 
     def test_kb_new_fail(self, mock_redis):


### PR DESCRIPTION
After trying 5 times to connect to redis, it exits with error code 1
instead of raise an error not being catched.