### PR TITLE
Add set_nvticache_str().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add solution method to solution of vt object. [#131](https://github.com/greenbone/ospd-openvas/pull/131)
+- Add set_nvticache_str(). [#150](https://github.com/greenbone/ospd-openvas/pull/150)
 
 ## [1.0.1] (unreleased)
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -278,6 +278,7 @@ class OSPDopenvas(OSPDaemon):
         self.openvas_db = OpenvasDB()
 
         self.nvti = NVTICache(self.openvas_db)
+        self.nvti.set_nvticache_str()
 
         self.pending_feed = None
 

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -23,7 +23,7 @@ import logging
 import subprocess
 import sys
 
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 
 from ospd_openvas.db import NVT_META_FIELDS
 from ospd_openvas.errors import OspdOpenvasError
@@ -75,13 +75,14 @@ class NVTICache(object):
                 "gvm-libs version. %s" % e
             )
 
-        installed_lib = StrictVersion(str(result.decode('utf-8'))).version
+        installed_lib = parse_version(str(result.decode('utf-8')))
 
         for supported_item in SUPPORTED_NVTICACHE_VERSIONS:
-            supported_lib = StrictVersion(supported_item).version
+            supported_lib = parse_version(supported_item)
             if (
                 installed_lib >= supported_lib
-                and installed_lib[0] == supported_lib[0]
+                and installed_lib.base_version.split('.')[0]
+                == supported_lib.base_version.split('.')[0]
             ):
                 NVTICache.NVTICACHE_STR = (
                     "nvticache" + result.decode('utf-8').rstrip()

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 LIST_FIRST_POS = 0
 LIST_LAST_POS = -1
 
-SUPPORTED_NVTICACHE_VERSION = ['20.4']
+SUPPORTED_NVTICACHE_VERSIONS = ('20.4',)
 
 
 class NVTICache(object):
@@ -77,7 +77,7 @@ class NVTICache(object):
 
         installed_lib = StrictVersion(str(result.decode('utf-8'))).version
 
-        for supported_item in SUPPORTED_NVTICACHE_VERSION:
+        for supported_item in SUPPORTED_NVTICACHE_VERSIONS:
             supported_lib = StrictVersion(supported_item).version
             if (
                 installed_lib >= supported_lib

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -20,13 +20,21 @@
 """ Provide functions to handle NVT Info Cache. """
 
 import logging
+import subprocess
+import sys
+
+from distutils.version import StrictVersion
 
 from ospd_openvas.db import NVT_META_FIELDS
+from ospd_openvas.errors import OspdOpenvasError
+
 
 logger = logging.getLogger(__name__)
 
 LIST_FIRST_POS = 0
 LIST_LAST_POS = -1
+
+SUPPORTED_NVTICACHE_VERSION = ['20.4']
 
 
 class NVTICache(object):
@@ -48,10 +56,42 @@ class NVTICache(object):
         'default': '70',
     }
 
-    NVTICACHE_STR = 'nvticache20.4'
+    NVTICACHE_STR = None
 
     def __init__(self, openvas_db):
         self._openvas_db = openvas_db
+
+    def set_nvticache_str(self):
+        """Set nvticache name"""
+        try:
+            result = subprocess.check_output(
+                ['pkg-config', '--modversion', 'libgvm_util'],
+                stderr=subprocess.STDOUT,
+            )
+        except (subprocess.CalledProcessError, PermissionError) as e:
+            raise OspdOpenvasError(
+                "Error setting nvticache. "
+                "Not possible to get the installed "
+                "gvm-libs version. %s" % e
+            )
+
+        installed_lib = StrictVersion(str(result.decode('utf-8'))).version
+
+        for supported_item in SUPPORTED_NVTICACHE_VERSION:
+            supported_lib = StrictVersion(supported_item).version
+            if (
+                installed_lib >= supported_lib
+                and installed_lib[0] == supported_lib[0]
+            ):
+                NVTICache.NVTICACHE_STR = (
+                    "nvticache" + result.decode('utf-8').rstrip()
+                )
+                return
+
+        logger.error(
+            "Error setting nvticache. " "Incompatible nvticache version."
+        )
+        sys.exit(1)
 
     def get_feed_version(self):
         """ Get feed version.

--- a/tests/test_nvti_cache.py
+++ b/tests/test_nvti_cache.py
@@ -23,6 +23,7 @@
 
 from unittest import TestCase
 from unittest.mock import patch
+
 from ospd_openvas.db import OpenvasDB
 from ospd_openvas.nvticache import NVTICache
 
@@ -271,3 +272,15 @@ class TestNVTICache(TestCase):
         resp = self.nvti.get_nvt_tag(mock_redis(), '1.2.3.4')
 
         self.assertEqual(out_dict, resp)
+
+    @patch('ospd_openvas.nvticache.subprocess')
+    def test_set_nvticache_str(self, mock_subps, mock_redis):
+        self.assertIsNone(self.nvti.NVTICACHE_STR)
+
+        mock_subps.check_output.return_value = '20.10\n'.encode()
+        self.nvti.set_nvticache_str()
+        self.assertEqual(self.nvti.NVTICACHE_STR, 'nvticache20.10')
+
+        mock_subps.check_output.return_value = '11.0.1\n'.encode()
+        with self.assertRaises(SystemExit):
+            self.nvti.set_nvticache_str()


### PR DESCRIPTION
The nvticache name in redis (dependent on the gvm-libs) will be checked
for compatibility against a list of supported nvticache versions.
