### PR TITLE
Check for a valid OID when prepare results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve error handling when creating vts xml elements. [#139](https://github.com/greenbone/ospd-openvas/pull/139)
 - Init the superclass with kwargs. [#141](https://github.com/greenbone/ospd-openvas/pull/141)
 - Avoid ospd-openvas to crash if redis is flushed during vt dictionary creation. [#146](https://github.com/greenbone/ospd-openvas/pull/146)
+- Check for a valid OID when prepare results. [#183](https://github.com/greenbone/ospd-openvas/pull/183)
 
 [1.0.1]: https://github.com/greenbone/ospd-openvas/commits/v1.0.0...ospd-openvas-1.0
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -930,8 +930,12 @@ class OSPDopenvas(OSPDaemon):
             rname = ''
             rhostname = msg[1].strip() if msg[1] else ''
             host_is_dead = "Host dead" in msg[4]
+            valid_oid = roid and roid in self.vts
 
-            if roid and not host_is_dead:
+            if not valid_oid:
+                logger.warning('Invalid VT oid %s for a result', roid)
+
+            if valid_oid and not host_is_dead:
                 if self.vts[roid].get('qod_type'):
                     qod_t = self.vts[roid].get('qod_type')
                     rqod = self.nvti.QOD_TYPES[qod_t]


### PR DESCRIPTION
This improve the error handling and avoid unexpected traceback.