### PR TITLE
[1.0] Escape script name before adding the result in an xml entity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Avoid ospd-openvas to crash if redis is flushed during vt dictionary creation. [#146](https://github.com/greenbone/ospd-openvas/pull/146)
 - Check for a valid OID when prepare results. [#183](https://github.com/greenbone/ospd-openvas/pull/183)
 - Fix snmp credentials. [#187](https://github.com/greenbone/ospd-openvas/pull/187)
+- Escape script name before adding the result in an xml entity. [#189](https://github.com/greenbone/ospd-openvas/pull/189)
 
 ### Removed
 - Remove use_mac_addr, vhost_ip and vhost scan preferences. [#185](https://github.com/greenbone/ospd-openvas/pull/185)

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -32,8 +32,8 @@ from base64 import b64decode
 
 from pathlib import Path
 from os import geteuid
-from lxml.etree import tostring, SubElement, Element
 from xml.sax.saxutils import escape
+from lxml.etree import tostring, SubElement, Element
 
 import psutil
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -33,6 +33,7 @@ from base64 import b64decode
 from pathlib import Path
 from os import geteuid
 from lxml.etree import tostring, SubElement, Element
+from xml.sax.saxutils import escape
 
 import psutil
 
@@ -940,6 +941,9 @@ class OSPDopenvas(OSPDaemon):
                     rqod = self.vts[roid].get('qod')
 
                 rname = self.vts[roid].get('name')
+
+            if rname:
+                rname = escape(rname)
 
             if msg[0] == 'ERRMSG':
                 self.add_scan_error(

--- a/tests/dummydaemon.py
+++ b/tests/dummydaemon.py
@@ -38,7 +38,7 @@ class DummyDaemon(OSPDopenvas):
                     'timeout': '0',
                 },
                 'modification_time': ('1533906565'),
-                'name': 'Mantis Detection',
+                'name': 'Mantis Detection & foo',
                 'qod_type': 'remote_banner',
                 'insight': 'some insight',
                 'severities': {
@@ -106,7 +106,7 @@ class DummyDaemon(OSPDopenvas):
             'family': 'Product detection',
             'filename': 'mantis_detect.nasl',
             'last_modification': ('1533906565'),
-            'name': 'Mantis Detection',
+            'name': 'Mantis Detection & foo',
             'qod_type': 'remote_banner',
             'required_ports': 'Services/www, 80',
             'solution': 'some solution',

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -703,6 +703,30 @@ class TestOspdOpenvas(TestCase):
             value='Host dead',
         )
 
+    @patch('ospd_openvas.daemon.OSPDaemon.add_scan_log')
+    def test_get_openvas_result_escaped(self, mock_ospd, mock_nvti, mock_db):
+        results = [
+            "LOG||| |||general/Host_Details|||1.3.6.1.4.1.25623.1.0.100061|||Alive",
+            None,
+        ]
+        mock_db.get_result.side_effect = results
+        w = DummyDaemon(mock_nvti, mock_db)
+        w.load_vts()
+        mock_ospd.return_value = None
+        mock_nvti.QOD_TYPES.__getitem__.return_value = ''
+        w.get_openvas_result('123-456', 'localhost')
+
+        mock_ospd.assert_called_with(
+            '123-456',
+            host='localhost',
+            hostname='',
+            name='Mantis Detection &amp; foo',
+            port='general/Host_Details',
+            qod='',
+            test_id='1.3.6.1.4.1.25623.1.0.100061',
+            value='Alive',
+        )
+
     @patch('ospd_openvas.daemon.OSPDaemon.set_scan_host_progress')
     def test_update_progress(self, mock_ospd, mock_nvti, mock_db):
         msg = '0/-1'


### PR DESCRIPTION
Backport PR #188 
Close Issue greenbone/gvmd#945