### PR TITLE
Improve nvt feed check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add typing to daemon.py, nvticache.py and db.py. [#161](https://github.com/greenbone/ospd-openvas/pull/161)[#162](https://github.com/greenbone/ospd-openvas/pull/162)[#163](https://github.com/greenbone/ospd-openvas/pull/163)
 - Add support for alive test settings. [#182](https://github.com/greenbone/ospd-openvas/pull/182)
 - Add missing scan preferences expand_vhosts and test_empty_vhost. [#184](https://github.com/greenbone/ospd-openvas/pull/184)
-- Set reverse lookup options. [#185](https://github.com/greenbone/ospd-openvas/pull/185)
-
+- Set reverse lookup options. [#185](https://gitub.com/greenbone/ospd-openvas/pull/185)
+- Check if the amount of vts in redis is coherent. [#195](https://github.com/greenbone/ospd-openvas/pull/195)
 ### Changed
 - Less strict checks for the nvti cache version
   [#150](https://github.com/greenbone/ospd-openvas/pull/150)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add typing to daemon.py, nvticache.py and db.py. [#161](https://github.com/greenbone/ospd-openvas/pull/161)[#162](https://github.com/greenbone/ospd-openvas/pull/162)[#163](https://github.com/greenbone/ospd-openvas/pull/163)
 - Add support for alive test settings. [#182](https://github.com/greenbone/ospd-openvas/pull/182)
 - Add missing scan preferences expand_vhosts and test_empty_vhost. [#184](https://github.com/greenbone/ospd-openvas/pull/184)
-- Set reverse lookup options. [#185](https://gitub.com/greenbone/ospd-openvas/pull/185)
+- Set reverse lookup options. [#185](https://github.com/greenbone/ospd-openvas/pull/185)
 - Check if the amount of vts in redis is coherent. [#195](https://github.com/greenbone/ospd-openvas/pull/195)
+
 ### Changed
 - Less strict checks for the nvti cache version
   [#150](https://github.com/greenbone/ospd-openvas/pull/150)

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -252,6 +252,23 @@ class OpenvasDB(object):
             ctx = self.get_kb_context()
         return ctx.lrange(name, start, end)
 
+    def get_key_count(
+        self, pattern: Optional[str] = None, ctx: Optional[RedisCtx] = None,
+    ) -> Optional[int]:
+        """ Get the number of keys matching with the pattern.
+        Arguments:
+            pattern: pattern used as filter.
+            ctx: Redis context to use.
+        Return an element.
+        """
+        if not pattern:
+            pattern = "*"
+
+        if not ctx:
+            ctx = self.get_kb_context()
+
+        return len(ctx.keys(pattern))
+
     def remove_list_item(
         self, key: str, value: str, ctx: Optional[RedisCtx] = None
     ):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -683,6 +683,30 @@ class TestOspdOpenvas(TestCase):
         ret = w.scan_is_stopped('123-456')
         self.assertEqual(ret, True)
 
+    def test_feed_is_healthy_true(
+        self, mock_nvti: MagicMock, mock_db: MagicMock,
+    ):
+        w = DummyDaemon(mock_nvti, mock_db)
+
+        mock_nvti.get_redix_context.return_value = None
+        mock_db.get_key_count.side_effect = [2, 2]
+        w.vts = ["a", "b"]
+
+        ret = w.feed_is_healthy()
+        self.assertTrue(ret)
+
+    def test_feed_is_healthy_false(
+        self, mock_nvti: MagicMock, mock_db: MagicMock,
+    ):
+        w = DummyDaemon(mock_nvti, mock_db)
+
+        mock_nvti.get_redix_context.return_value = None
+        mock_db.get_key_count.side_effect = [1, 2]
+        w.vts = ["a", "b"]
+
+        ret = w.feed_is_healthy()
+        self.assertFalse(ret)
+
     @patch('ospd_openvas.daemon.Path.exists')
     @patch('ospd_openvas.daemon.OSPDopenvas.set_params_from_openvas_settings')
     def test_feed_is_outdated_none(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -255,3 +255,9 @@ class TestDB(TestCase):
         with patch.object(OpenvasDB, 'get_kb_context', return_value=mock_redis):
             ret = self.db.get_host_ip()
         self.assertEqual(ret, '192.168.0.1')
+
+    def test_get_key_count(self, mock_redis):
+        mock_redis.keys.return_value = ['aa', 'ab']
+        with patch.object(OpenvasDB, 'get_kb_context', return_value=mock_redis):
+            ret = self.db.get_key_count("")
+        self.assertEqual(ret, 2)


### PR DESCRIPTION
Compare the amount of filename keys and nvt keys in redis with the amount of oid loaded in memory.