### PR TITLE
Fix check feed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for alive test settings. [#182](https://github.com/greenbone/ospd-openvas/pull/182)
 - Add missing scan preferences expand_vhosts and test_empty_vhost. [#184](https://github.com/greenbone/ospd-openvas/pull/184)
 - Set reverse lookup options. [#185](https://github.com/greenbone/ospd-openvas/pull/185)
-- Check if the amount of vts in redis is coherent. [#195](https://github.com/greenbone/ospd-openvas/pull/195)
+- Check if the amount of vts in redis is coherent. 
+  [#195](https://github.com/greenbone/ospd-openvas/pull/195)
+  [#197](https://github.com/greenbone/ospd-openvas/pull/197)
 
 ### Changed
 - Less strict checks for the nvti cache version

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -409,7 +409,6 @@ class OSPDopenvas(OSPDaemon):
         # Check if the nvticache in redis is outdated
         feed_is_healthy = self.feed_is_healthy()
         if not current_feed or is_outdated or not feed_is_healthy:
-            ctx = self.nvti.get_redis_context()
             if not feed_is_healthy:
                 # Force complete redis reload
                 self.openvas_db.release_db(kbindex=1)
@@ -419,6 +418,7 @@ class OSPDopenvas(OSPDaemon):
                 )
 
             Openvas.load_vts_into_redis()
+            ctx = self.nvti.get_redis_context()
             self.openvas_db.set_redisctx(ctx)
             self.pending_feed = True
 


### PR DESCRIPTION
It set the redis context after reloading the complete VTs collection in redis.