### PR TITLE
Release the VT's list in the scan table.

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -145,7 +145,7 @@
         "ospd": {
             "editable": true,
             "git": "https://github.com/greenbone/ospd.git",
-            "ref": "67e211162b77de944daff4ef81c0a850b0929c74"
+            "ref": "d4dfd110944be7e280f241c11cfaaef155edbcc3"
         },
         "packaging": {
             "hashes": [

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1626,6 +1626,7 @@ class OSPDopenvas(OSPDaemon):
                 scan_id, name='', host=target, value='No VTS to run.'
             )
             do_not_launch = True
+        self.scan_collection.release_vts_list(scan_id)
 
         # Set reverse lookup options
         if target_options:

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1555,6 +1555,8 @@ class OSPDopenvas(OSPDaemon):
             'internal/%s/scanprefs' % openvas_scan_id, prefs_val
         )
 
+        prefs_val = None
+
         # Store main_kbindex as global preference
         ov_maindbid = 'ov_maindbid|||%d' % self.main_kbindex
         self.openvas_db.add_single_item(
@@ -1619,6 +1621,13 @@ class OSPDopenvas(OSPDaemon):
                 self.openvas_db.add_single_item(
                     'internal/%s/scanprefs' % openvas_scan_id, [item]
                 )
+
+            nvts_params = None
+            nvts_list = None
+            item = None
+            plugin_list = None
+            nvts = None
+
             # Release temp vts dict memory.
             self.temp_vts_dict = None
         else:
@@ -1626,6 +1635,7 @@ class OSPDopenvas(OSPDaemon):
                 scan_id, name='', host=target, value='No VTS to run.'
             )
             do_not_launch = True
+
         self.scan_collection.release_vts_list(scan_id)
 
         # Set reverse lookup options


### PR DESCRIPTION
After the vts were processed and sent to the scanner, they are not
used anymore and can be deleted.
This reduce the memory footprint in about 20Mbytes for a F&F scan in the scan_table.

Also, about 20Mbytes are released from the scan process·

Depends on PR greenbone/ospd#212