### PR TITLE
Use a generator to yield the VTs directly from redis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#167](https://github.com/greenbone/ospd-openvas/pull/167)
 - Exit with exit code 1 if it was not possible to connect to redis. [#133](https://github.com/greenbone/ospd-openvas/pull/133)
 - Return None if the scan finished successfully. [#137](https://github.com/greenbone/ospd-openvas/pull/137)
+- Use a generator to yield the VTs directly from redis and reduce data in cache.[#203](https://github.com/greenbone/ospd-openvas/pull/203)
 
 ### Fixed
 - Improve redis clean out when stopping a scan. [#128](https://github.com/greenbone/ospd-openvas/pull/128)

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -39,41 +39,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
-                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
-                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
-                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
-                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
-                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
-                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
-                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
-                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
-                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
-                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
-                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
-                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
-                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
-                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
-                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
-                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
-                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
-                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
-                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
-                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
-                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
-                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
-                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
-                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
-                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
-                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
-                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
-                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
-                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
-                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
-                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
-                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
+                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
+                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
+                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
+                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
+                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
+                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
+                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
+                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
+                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
+                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
+                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
+                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
+                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
+                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
+                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
+                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
+                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
+                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
+                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
+                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
+                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
+                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
+                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
+                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
+                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
+                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
+                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
+                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
             ],
-            "version": "==1.13.2"
+            "version": "==1.14.0"
         },
         "cryptography": {
             "hashes": [
@@ -110,34 +105,35 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:00ac0d64949fef6b3693813fe636a2d56d97a5a49b5bbb86e4cc4cc50ebc9ea2",
-                "sha256:0571e607558665ed42e450d7bf0e2941d542c18e117b1ebbf0ba72f287ad841c",
-                "sha256:0e3f04a7615fdac0be5e18b2406529521d6dbdb0167d2a690ee328bef7807487",
-                "sha256:13cf89be53348d1c17b453867da68704802966c433b2bb4fa1f970daadd2ef70",
-                "sha256:217262fcf6a4c2e1c7cb1efa08bd9ebc432502abc6c255c4abab611e8be0d14d",
-                "sha256:223e544828f1955daaf4cefbb4853bc416b2ec3fd56d4f4204a8b17007c21250",
-                "sha256:277cb61fede2f95b9c61912fefb3d43fbd5f18bf18a14fae4911b67984486f5d",
-                "sha256:3213f753e8ae86c396e0e066866e64c6b04618e85c723b32ecb0909885211f74",
-                "sha256:4690984a4dee1033da0af6df0b7a6bde83f74e1c0c870623797cec77964de34d",
-                "sha256:4fcc472ef87f45c429d3b923b925704aa581f875d65bac80f8ab0c3296a63f78",
-                "sha256:61409bd745a265a742f2693e4600e4dbd45cc1daebe1d5fad6fcb22912d44145",
-                "sha256:678f1963f755c5d9f5f6968dded7b245dd1ece8cf53c1aa9d80e6734a8c7f41d",
-                "sha256:6c6d03549d4e2734133badb9ab1c05d9f0ef4bcd31d83e5d2b4747c85cfa21da",
-                "sha256:6e74d5f4d6ecd6942375c52ffcd35f4318a61a02328f6f1bd79fcb4ffedf969e",
-                "sha256:7b4fc7b1ecc987ca7aaf3f4f0e71bbfbd81aaabf87002558f5bc95da3a865bcd",
-                "sha256:7ed386a40e172ddf44c061ad74881d8622f791d9af0b6f5be20023029129bc85",
-                "sha256:8f54f0924d12c47a382c600c880770b5ebfc96c9fd94cf6f6bdc21caf6163ea7",
-                "sha256:ad9b81351fdc236bda538efa6879315448411a81186c836d4b80d6ca8217cdb9",
-                "sha256:bbd00e21ea17f7bcc58dccd13869d68441b32899e89cf6cfa90d624a9198ce85",
-                "sha256:c3c289762cc09735e2a8f8a49571d0e8b4f57ea831ea11558247b5bdea0ac4db",
-                "sha256:cf4650942de5e5685ad308e22bcafbccfe37c54aa7c0e30cd620c2ee5c93d336",
-                "sha256:cfcbc33c9c59c93776aa41ab02e55c288a042211708b72fdb518221cc803abc8",
-                "sha256:e301055deadfedbd80cf94f2f65ff23126b232b0d1fea28f332ce58137bcdb18",
-                "sha256:ebbfe24df7f7b5c6c7620702496b6419f6a9aa2fd7f005eb731cc80d7b4692b9",
-                "sha256:eff69ddbf3ad86375c344339371168640951c302450c5d3e9936e98d6459db06",
-                "sha256:f6ed60a62c5f1c44e789d2cf14009423cb1646b44a43e40a9cf6a21f077678a1"
+                "sha256:06d4e0bbb1d62e38ae6118406d7cdb4693a3fa34ee3762238bcb96c9e36a93cd",
+                "sha256:0701f7965903a1c3f6f09328c1278ac0eee8f56f244e66af79cb224b7ef3801c",
+                "sha256:1f2c4ec372bf1c4a2c7e4bb20845e8bcf8050365189d86806bad1e3ae473d081",
+                "sha256:4235bc124fdcf611d02047d7034164897ade13046bda967768836629bc62784f",
+                "sha256:5828c7f3e615f3975d48f40d4fe66e8a7b25f16b5e5705ffe1d22e43fb1f6261",
+                "sha256:585c0869f75577ac7a8ff38d08f7aac9033da2c41c11352ebf86a04652758b7a",
+                "sha256:5d467ce9c5d35b3bcc7172c06320dddb275fea6ac2037f72f0a4d7472035cea9",
+                "sha256:63dbc21efd7e822c11d5ddbedbbb08cd11a41e0032e382a0fd59b0b08e405a3a",
+                "sha256:7bc1b221e7867f2e7ff1933165c0cec7153dce93d0cdba6554b42a8beb687bdb",
+                "sha256:8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60",
+                "sha256:8a0ebda56ebca1a83eb2d1ac266649b80af8dd4b4a3502b2c1e09ac2f88fe128",
+                "sha256:90ed0e36455a81b25b7034038e40880189169c308a3df360861ad74da7b68c1a",
+                "sha256:95e67224815ef86924fbc2b71a9dbd1f7262384bca4bc4793645794ac4200717",
+                "sha256:afdb34b715daf814d1abea0317b6d672476b498472f1e5aacbadc34ebbc26e89",
+                "sha256:b4b2c63cc7963aedd08a5f5a454c9f67251b1ac9e22fd9d72836206c42dc2a72",
+                "sha256:d068f55bda3c2c3fcaec24bd083d9e2eede32c583faf084d6e4b9daaea77dde8",
+                "sha256:d5b3c4b7edd2e770375a01139be11307f04341ec709cf724e0f26ebb1eef12c3",
+                "sha256:deadf4df349d1dcd7b2853a2c8796593cc346600726eff680ed8ed11812382a7",
+                "sha256:df533af6f88080419c5a604d0d63b2c33b1c0c4409aba7d0cb6de305147ea8c8",
+                "sha256:e4aa948eb15018a657702fee0b9db47e908491c64d36b4a90f59a64741516e77",
+                "sha256:e5d842c73e4ef6ed8c1bd77806bf84a7cb535f9c0cf9b2c74d02ebda310070e1",
+                "sha256:ebec08091a22c2be870890913bdadd86fcd8e9f0f22bcb398abd3af914690c15",
+                "sha256:edc15fcfd77395e24543be48871c251f38132bb834d9fdfdad756adb6ea37679",
+                "sha256:f2b74784ed7e0bc2d02bd53e48ad6ba523c9b36c194260b7a5045071abbb1012",
+                "sha256:fa071559f14bd1e92077b1b5f6c22cf09756c6de7139370249eb372854ce51e6",
+                "sha256:fd52e796fee7171c4361d441796b64df1acfceb51f29e545e812f16d023c4bbc",
+                "sha256:fe976a0f1ef09b3638778024ab9fb8cde3118f203364212c198f71341c0715ca"
             ],
-            "version": "==4.4.2"
+            "version": "==4.5.0"
         },
         "ospd": {
             "hashes": [
@@ -149,35 +145,35 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
-                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+                "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73",
+                "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
             ],
             "index": "pypi",
-            "version": "==19.2"
+            "version": "==20.1"
         },
         "paramiko": {
             "hashes": [
-                "sha256:99f0179bdc176281d21961a003ffdb2ec369daac1a1007241f53374e376576cf",
-                "sha256:f4b2edfa0d226b70bd4ca31ea7e389325990283da23465d572ed1f70a7583041"
+                "sha256:920492895db8013f6cc0179293147f830b8c7b21fdfc839b6bad760c27459d9f",
+                "sha256:9c980875fa4d2cb751604664e9a2d0f69096643f5be4db1b99599fe114a97b2f"
             ],
-            "version": "==2.6.0"
+            "version": "==2.7.1"
         },
         "psutil": {
             "hashes": [
-                "sha256:094f899ac3ef72422b7e00411b4ed174e3c5a2e04c267db6643937ddba67a05b",
-                "sha256:10b7f75cc8bd676cfc6fa40cd7d5c25b3f45a0e06d43becd7c2d2871cbb5e806",
-                "sha256:1b1575240ca9a90b437e5a40db662acd87bbf181f6aa02f0204978737b913c6b",
-                "sha256:21231ef1c1a89728e29b98a885b8e0a8e00d09018f6da5cdc1f43f988471a995",
-                "sha256:28f771129bfee9fc6b63d83a15d857663bbdcae3828e1cb926e91320a9b5b5cd",
-                "sha256:70387772f84fa5c3bb6a106915a2445e20ac8f9821c5914d7cbde148f4d7ff73",
-                "sha256:b560f5cd86cf8df7bcd258a851ca1ad98f0d5b8b98748e877a0aec4e9032b465",
-                "sha256:b74b43fecce384a57094a83d2778cdfc2e2d9a6afaadd1ebecb2e75e0d34e10d",
-                "sha256:e85f727ffb21539849e6012f47b12f6dd4c44965e56591d8dec6e8bc9ab96f4a",
-                "sha256:fd2e09bb593ad9bdd7429e779699d2d47c1268cbde4dda95fcd1bd17544a0217",
-                "sha256:ffad8eb2ac614518bbe3c0b8eb9dffdb3a8d2e3a7d5da51c5b974fb723a5c5aa"
+                "sha256:1413f4158eb50e110777c4f15d7c759521703bd6beb58926f1d562da40180058",
+                "sha256:298af2f14b635c3c7118fd9183843f4e73e681bb6f01e12284d4d70d48a60953",
+                "sha256:60b86f327c198561f101a92be1995f9ae0399736b6eced8f24af41ec64fb88d4",
+                "sha256:685ec16ca14d079455892f25bd124df26ff9137664af445563c1bd36629b5e0e",
+                "sha256:73f35ab66c6c7a9ce82ba44b1e9b1050be2a80cd4dcc3352cc108656b115c74f",
+                "sha256:75e22717d4dbc7ca529ec5063000b2b294fc9a367f9c9ede1f65846c7955fd38",
+                "sha256:a02f4ac50d4a23253b68233b07e7cdb567bd025b982d5cf0ee78296990c22d9e",
+                "sha256:d008ddc00c6906ec80040d26dc2d3e3962109e40ad07fd8a12d0284ce5e0e4f8",
+                "sha256:d84029b190c8a66a946e28b4d3934d2ca1528ec94764b180f7d6ea57b0e75e26",
+                "sha256:e2d0c5b07c6fe5a87fa27b7855017edb0d52ee73b71e6ee368fae268605cc3f5",
+                "sha256:f344ca230dd8e8d5eee16827596f1c22ec0876127c28e800d7ae20ed44c4b310"
             ],
             "index": "pypi",
-            "version": "==5.6.7"
+            "version": "==5.7.0"
         },
         "pycparser": {
             "hashes": [
@@ -213,25 +209,25 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
-                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
             ],
-            "version": "==2.4.5"
+            "version": "==2.4.6"
         },
         "redis": {
             "hashes": [
-                "sha256:3613daad9ce5951e426f460deddd5caf469e08a3af633e9578fc77d362becf62",
-                "sha256:8d0fc278d3f5e1249967cba2eb4a5632d19e45ce5c09442b8422d15ee2c22cc2"
+                "sha256:0dcfb335921b88a850d461dc255ff4708294943322bd55de6cfd68972490ca1f",
+                "sha256:b205cffd05ebfd0a468db74f0eedbff8df1a7bfc47521516ade4692991bb0833"
             ],
             "index": "pypi",
-            "version": "==3.3.11"
+            "version": "==3.4.1"
         },
         "six": {
             "hashes": [
-                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
-                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.13.0"
+            "version": "==1.14.0"
         }
     },
     "develop": {
@@ -335,9 +331,10 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:e285ccc8b0785beadd4c18e5708b12bb8fcf529a1e61215b3feff1d1e559ea5c"
+                "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424",
+                "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"
             ],
-            "version": "==0.6.0"
+            "version": "==0.7.0"
         },
         "pylint": {
             "hashes": [
@@ -349,28 +346,36 @@
         },
         "regex": {
             "hashes": [
-                "sha256:15454b37c5a278f46f7aa2d9339bda450c300617ca2fca6558d05d870245edc7",
-                "sha256:1ad40708c255943a227e778b022c6497c129ad614bb7a2a2f916e12e8a359ee7",
-                "sha256:5e00f65cc507d13ab4dfa92c1232d004fa202c1d43a32a13940ab8a5afe2fb96",
-                "sha256:604dc563a02a74d70ae1f55208ddc9bfb6d9f470f6d1a5054c4bd5ae58744ab1",
-                "sha256:720e34a539a76a1fedcebe4397290604cc2bdf6f81eca44adb9fb2ea071c0c69",
-                "sha256:7caf47e4a9ac6ef08cabd3442cc4ca3386db141fb3c8b2a7e202d0470028e910",
-                "sha256:7faf534c1841c09d8fefa60ccde7b9903c9b528853ecf41628689793290ca143",
-                "sha256:b4e0406d822aa4993ac45072a584d57aa4931cf8288b5455bbf30c1d59dbad59",
-                "sha256:c31eaf28c6fe75ea329add0022efeed249e37861c19681960f99bbc7db981fb2",
-                "sha256:c7393597191fc2043c744db021643549061e12abe0b3ff5c429d806de7b93b66",
-                "sha256:d2b302f8cdd82c8f48e9de749d1d17f85ce9a0f082880b9a4859f66b07037dc6",
-                "sha256:e3d8dd0ec0ea280cf89026b0898971f5750a7bd92cb62c51af5a52abd020054a",
-                "sha256:ec032cbfed59bd5a4b8eab943c310acfaaa81394e14f44454ad5c9eba4f24a74"
+                "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431",
+                "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242",
+                "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1",
+                "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d",
+                "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045",
+                "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b",
+                "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400",
+                "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa",
+                "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0",
+                "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69",
+                "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74",
+                "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb",
+                "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26",
+                "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5",
+                "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2",
+                "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce",
+                "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab",
+                "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e",
+                "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70",
+                "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc",
+                "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"
             ],
-            "version": "==2019.11.1"
+            "version": "==2020.2.20"
         },
         "six": {
             "hashes": [
-                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
-                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.13.0"
+            "version": "==1.14.0"
         },
         "toml": {
             "hashes": [
@@ -381,29 +386,30 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161",
-                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
-                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
-                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
-                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
-                "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47",
-                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
-                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
-                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
-                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
-                "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2",
-                "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e",
-                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
-                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
-                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
-                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
-                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
-                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
-                "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66",
-                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
             "markers": "implementation_name == 'cpython' and python_version < '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.4.1"
         },
         "wrapt": {
             "hashes": [

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -401,95 +401,138 @@ class OSPDopenvas(OSPDaemon):
         """This method is called periodically to run tasks."""
         self.check_feed()
 
+    def get_single_vt(self, vt_id, oids):
+        _vt_params = self.nvti.get_nvt_params(vt_id)
+        _vt_refs = self.nvti.get_nvt_refs(vt_id)
+        _custom = self.nvti.get_nvt_metadata(vt_id)
+
+        if _vt_params is None or _custom is None:
+            logger.warning('Error loading VTs in memory. Trying again...')
+            return
+
+        _name = _custom.pop('name')
+        _vt_creation_time = _custom.pop('creation_date')
+        _vt_modification_time = _custom.pop('last_modification')
+
+        _vt_dependencies = list()
+        if 'dependencies' in _custom:
+            _deps = _custom.pop('dependencies')
+            _deps_list = _deps.split(', ')
+            for dep in _deps_list:
+                _vt_dependencies.append(oids.get('filename:' + dep))
+
+        _summary = None
+        _impact = None
+        _affected = None
+        _insight = None
+        _solution = None
+        _solution_t = None
+        _vuldetect = None
+        _qod_t = None
+        _qod_v = None
+
+        if 'summary' in _custom:
+            _summary = _custom.pop('summary')
+        if 'impact' in _custom:
+            _impact = _custom.pop('impact')
+        if 'affected' in _custom:
+            _affected = _custom.pop('affected')
+        if 'insight' in _custom:
+            _insight = _custom.pop('insight')
+        if 'solution' in _custom:
+            _solution = _custom.pop('solution')
+            if 'solution_type' in _custom:
+                _solution_t = _custom.pop('solution_type')
+
+        if 'vuldetect' in _custom:
+            _vuldetect = _custom.pop('vuldetect')
+        if 'qod_type' in _custom:
+            _qod_t = _custom.pop('qod_type')
+        elif 'qod' in _custom:
+            _qod_v = _custom.pop('qod')
+
+        _severity = dict()
+        if 'severity_base_vector' in _custom:
+            _severity_vector = _custom.pop('severity_base_vector')
+        else:
+            _severity_vector = _custom.pop('cvss_base_vector')
+        _severity['severity_base_vector'] = _severity_vector
+        if 'severity_type' in _custom:
+            _severity_type = _custom.pop('severity_type')
+        else:
+            _severity_type = 'cvss_base_v2'
+        _severity['severity_type'] = _severity_type
+        if 'severity_origin' in _custom:
+            _severity['severity_origin'] = _custom.pop('severity_origin')
+
+        if _name is None:
+            name = ''
+
+        vt = {'id': vt_id, 'name': _name}
+        if _custom is not None:
+            vt["custom"] = _custom
+        if _vt_params is not None:
+            vt["vt_params"] = _vt_params
+        if _vt_refs is not None:
+            vt["vt_refs"] = _vt_refs
+        if _vt_dependencies is not None:
+            vt["vt_dependencies"] = _vt_dependencies
+        if _vt_creation_time is not None:
+            vt["creation_time"] = _vt_creation_time
+        if _vt_modification_time is not None:
+            vt["modification_time"] = _vt_modification_time
+        if _summary is not None:
+            vt["summary"] = _summary
+        if _impact is not None:
+            vt["impact"] = _impact
+        if _affected is not None:
+            vt["affected"] = _affected
+        if _insight is not None:
+            vt["insight"] = _insight
+
+        if _solution is not None:
+            vt["solution"] = _solution
+            if _solution_t is not None:
+                vt["solution_type"] = _solution_t
+
+        if _vuldetect is not None:
+            vt["detection"] = _vuldetect
+
+        if _qod_t is not None:
+            vt["qod_type"] = _qod_t
+        elif _qod_v is not None:
+            vt["qod"] = _qod_v
+
+        if _severity is not None:
+            vt["severities"] = _severity
+
+        return vt
+
+    def get_vt_iterator(self):
+        """ Yield the vts from the Redis NVTicache. """
+        oids = dict(self.nvti.get_oids())
+        for filename, vt_id in oids.items():
+            vt = self.get_single_vt(vt_id, oids)
+            yield (vt_id, vt)
+
     def load_vts(self):
         """ Load the NVT's metadata into the vts
         global  dictionary. """
         logger.debug('Loading vts in memory.')
         oids = dict(self.nvti.get_oids())
-        for _filename, vt_id in oids.items():
-            _vt_params = self.nvti.get_nvt_params(vt_id)
-            _vt_refs = self.nvti.get_nvt_refs(vt_id)
-            _custom = self.nvti.get_nvt_metadata(vt_id)
-
-            if _vt_params is None or _custom is None:
-                logger.warning('Error loading VTs in memory. Trying again...')
-                return
-
-            _name = _custom.pop('name')
-            _vt_creation_time = _custom.pop('creation_date')
-            _vt_modification_time = _custom.pop('last_modification')
-
-            _summary = None
-            _impact = None
-            _affected = None
-            _insight = None
-            _solution = None
-            _solution_t = None
-            _vuldetect = None
-            _qod_t = None
-            _qod_v = None
-
-            if 'summary' in _custom:
-                _summary = _custom.pop('summary')
-            if 'impact' in _custom:
-                _impact = _custom.pop('impact')
-            if 'affected' in _custom:
-                _affected = _custom.pop('affected')
-            if 'insight' in _custom:
-                _insight = _custom.pop('insight')
-            if 'solution' in _custom:
-                _solution = _custom.pop('solution')
-                if 'solution_type' in _custom:
-                    _solution_t = _custom.pop('solution_type')
-
-            if 'vuldetect' in _custom:
-                _vuldetect = _custom.pop('vuldetect')
-            if 'qod_type' in _custom:
-                _qod_t = _custom.pop('qod_type')
-            elif 'qod' in _custom:
-                _qod_v = _custom.pop('qod')
-
-            _severity = dict()
-            if 'severity_base_vector' in _custom:
-                _severity_vector = _custom.pop('severity_base_vector')
-            else:
-                _severity_vector = _custom.pop('cvss_base_vector')
-            _severity['severity_base_vector'] = _severity_vector
-            if 'severity_type' in _custom:
-                _severity_type = _custom.pop('severity_type')
-            else:
-                _severity_type = 'cvss_base_v2'
-            _severity['severity_type'] = _severity_type
-            if 'severity_origin' in _custom:
-                _severity['severity_origin'] = _custom.pop('severity_origin')
-
-            _vt_dependencies = list()
-            if 'dependencies' in _custom:
-                _deps = _custom.pop('dependencies')
-                _deps_list = _deps.split(', ')
-                for dep in _deps_list:
-                    _vt_dependencies.append(oids.get('filename:' + dep))
-
+        for filename, vt_id in oids.items():
+            vt = self.get_single_vt(vt_id, oids)
+            custom = {'family': vt['custom'].get('family')}
             try:
                 self.add_vt(
                     vt_id,
-                    name=_name,
-                    vt_params=_vt_params,
-                    vt_refs=_vt_refs,
-                    custom=_custom,
-                    vt_creation_time=_vt_creation_time,
-                    vt_modification_time=_vt_modification_time,
-                    vt_dependencies=_vt_dependencies,
-                    summary=_summary,
-                    impact=_impact,
-                    affected=_affected,
-                    insight=_insight,
-                    solution=_solution,
-                    solution_t=_solution_t,
-                    detection=_vuldetect,
-                    qod_t=_qod_t,
-                    qod_v=_qod_v,
-                    severities=_severity,
+                    name=vt.get('name'),
+                    qod_t=vt.get('qod_type'),
+                    qod_v=vt.get('qod'),
+                    severities=vt.get('severities'),
+                    vt_modification_time=vt.get('modification_time'),
+                    vt_params=vt.get('vt_params'),
+                    custom=custom,
                 )
             except OspdError as e:
                 logger.info("Error while adding vt. %s", e)

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -466,7 +466,7 @@ class OSPDopenvas(OSPDaemon):
             _severity['severity_origin'] = _custom.pop('severity_origin')
 
         if _name is None:
-            name = ''
+            _name = ''
 
         vt = {'id': vt_id, 'name': _name}
         if _custom is not None:
@@ -511,7 +511,7 @@ class OSPDopenvas(OSPDaemon):
     def get_vt_iterator(self):
         """ Yield the vts from the Redis NVTicache. """
         oids = dict(self.nvti.get_oids())
-        for filename, vt_id in oids.items():
+        for _, vt_id in oids.items():
             vt = self.get_single_vt(vt_id, oids)
             yield (vt_id, vt)
 
@@ -520,7 +520,7 @@ class OSPDopenvas(OSPDaemon):
         global  dictionary. """
         logger.debug('Loading vts in memory.')
         oids = dict(self.nvti.get_oids())
-        for filename, vt_id in oids.items():
+        for _, vt_id in oids.items():
             vt = self.get_single_vt(vt_id, oids)
             custom = {'family': vt['custom'].get('family')}
             try:

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -406,10 +406,6 @@ class OSPDopenvas(OSPDaemon):
         _vt_refs = self.nvti.get_nvt_refs(vt_id)
         _custom = self.nvti.get_nvt_metadata(vt_id)
 
-        if _vt_params is None or _custom is None:
-            logger.warning('Error loading VTs in memory. Trying again...')
-            return
-
         _name = _custom.pop('name')
         _vt_creation_time = _custom.pop('creation_date')
         _vt_modification_time = _custom.pop('last_modification')
@@ -468,7 +464,7 @@ class OSPDopenvas(OSPDaemon):
         if _name is None:
             _name = ''
 
-        vt = {'id': vt_id, 'name': _name}
+        vt = {'name': _name}
         if _custom is not None:
             vt["custom"] = _custom
         if _vt_params is not None:
@@ -522,6 +518,17 @@ class OSPDopenvas(OSPDaemon):
         oids = dict(self.nvti.get_oids())
         for _, vt_id in oids.items():
             vt = self.get_single_vt(vt_id, oids)
+
+            if (
+                not vt
+                or vt.get('vt_params') is None
+                or vt.get('custom') is None
+            ):
+                logger.warning(
+                    'Error loading VTs in memory. Trying again later...'
+                )
+                return
+
             custom = {'family': vt['custom'].get('family')}
             try:
                 self.add_vt(

--- a/tests/dummydaemon.py
+++ b/tests/dummydaemon.py
@@ -28,29 +28,14 @@ class DummyDaemon(OSPDopenvas):
 
         self.VT = {
             '1.3.6.1.4.1.25623.1.0.100061': {
-                'creation_time': '1237458156',
-                'custom': {
-                    'category': '3',
-                    'excluded_keys': 'Settings/disable_cgi_scanning',
-                    'family': 'Product detection',
-                    'filename': 'mantis_detect.nasl',
-                    'required_ports': 'Services/www, 80',
-                    'timeout': '0',
-                },
+                'custom': {'family': 'Product detection',},
                 'modification_time': ('1533906565'),
                 'name': 'Mantis Detection & foo',
                 'qod_type': 'remote_banner',
-                'insight': 'some insight',
                 'severities': {
                     'severity_base_vector': 'AV:N/AC:L/Au:N/C:N/I:N/A:N',
                     'severity_type': 'cvss_base_v2',
                 },
-                'solution': 'some solution',
-                'solution_type': 'WillNotFix',
-                'impact': 'some impact',
-                'summary': 'some summary',
-                'affected': 'some affection',
-                'vt_dependencies': [],
                 'vt_params': {
                     '1': {
                         'id': '1',
@@ -66,11 +51,6 @@ class DummyDaemon(OSPDopenvas):
                         'name': 'Do not randomize the  order  in  which ports are scanned',
                         'type': 'checkbox',
                     },
-                },
-                'vt_refs': {
-                    'bid': [''],
-                    'cve': [''],
-                    'xref': ['URL:http://www.mantisbt.org/'],
                 },
             }
         }

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -223,7 +223,8 @@ class TestOspdOpenvas(TestCase):
             'timeout></custom>'
         )
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         res = w.get_custom_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', vt.get('custom')
         )
@@ -245,7 +246,8 @@ class TestOspdOpenvas(TestCase):
             '<severities><severity type="cvss_base_v2">'
             'AV:N/AC:L/Au:N/C:N/I:N/A:N</severity></severities>'
         )
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         severities = vt.get('severities')
         res = w.get_severities_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', severities
@@ -255,7 +257,7 @@ class TestOspdOpenvas(TestCase):
 
     def test_get_severities_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+
         sever = {'severity_base_vector': u"\u0006"}
         logging.Logger.warning = Mock()
         w.get_severities_vt_as_xml_str(
@@ -274,14 +276,15 @@ class TestOspdOpenvas(TestCase):
             '/param></params>'
         )
 
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         params = vt.get('vt_params')
         res = w.get_params_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', params)
         self.assertEqual(len(res), len(out))
 
     def test_get_params_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+
         params = {
             '1': {
                 'id': '1',
@@ -299,7 +302,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_refs_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<refs><ref type="url" id="http://www.mantisbt.org/"/>' '</refs>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         refs = vt.get('vt_refs')
         res = w.get_refs_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', refs)
 
@@ -320,7 +324,7 @@ class TestOspdOpenvas(TestCase):
 
     def test_get_dependencies_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+
         dep = [u"\u0006"]
         logging.Logger.error = Mock()
         w.get_dependencies_vt_as_xml_str(
@@ -332,7 +336,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_ctime_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<creation_time>1237458156</creation_time>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         ctime = vt.get('creation_time')
         res = w.get_creation_time_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', ctime
@@ -342,7 +347,7 @@ class TestOspdOpenvas(TestCase):
 
     def test_get_ctime_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+
         ctime = u'\u0006'
         logging.Logger.warning = Mock()
         w.get_creation_time_vt_as_xml_str(
@@ -354,7 +359,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_mtime_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<modification_time>1533906565</modification_time>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         mtime = vt.get('modification_time')
         res = w.get_modification_time_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', mtime
@@ -364,7 +370,8 @@ class TestOspdOpenvas(TestCase):
 
     def test_get_mtime_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         mtime = u'\u0006'
         logging.Logger.warning = Mock()
         w.get_modification_time_vt_as_xml_str(
@@ -376,7 +383,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_summary_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<summary>some summary</summary>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         summary = vt.get('summary')
         res = w.get_summary_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', summary
@@ -386,7 +394,6 @@ class TestOspdOpenvas(TestCase):
 
     def test_get_summary_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         summary = u'\u0006'
         logging.Logger.warning = Mock()
         w.get_summary_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', summary)
@@ -396,7 +403,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_impact_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<impact>some impact</impact>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         impact = vt.get('impact')
         res = w.get_impact_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', impact)
 
@@ -404,7 +412,7 @@ class TestOspdOpenvas(TestCase):
 
     def test_get_impact_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+
         impact = u'\u0006'
         logging.Logger.warning = Mock()
         w.get_impact_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', impact)
@@ -414,7 +422,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_insight_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<insight>some insight</insight>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         insight = vt.get('insight')
         res = w.get_insight_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', insight
@@ -424,7 +433,6 @@ class TestOspdOpenvas(TestCase):
 
     def test_get_insight_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
         insight = u'\u0006'
         logging.Logger.warning = Mock()
         w.get_insight_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', insight)
@@ -434,7 +442,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_solution_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<solution type="WillNotFix">some solution</solution>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         solution = vt.get('solution')
         solution_type = vt.get('solution_type')
 
@@ -446,7 +455,7 @@ class TestOspdOpenvas(TestCase):
 
     def test_get_solution_xml_failed(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+
         solution = u'\u0006'
         logging.Logger.warning = Mock()
         w.get_solution_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', solution)
@@ -456,7 +465,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_detection_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<detection qod_type="remote_banner"/>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         detection_type = vt.get('qod_type')
 
         res = w.get_detection_vt_as_xml_str(
@@ -476,7 +486,8 @@ class TestOspdOpenvas(TestCase):
     def test_get_affected_xml(self, mock_nvti, mock_db):
         w = DummyDaemon(mock_nvti, mock_db)
         out = '<affected>some affection</affected>'
-        vt = w.VT['1.3.6.1.4.1.25623.1.0.100061']
+        for item in w.get_vt_iterator():
+            vt_id, vt = item
         affected = vt.get('affected')
 
         res = w.get_affected_vt_as_xml_str(


### PR DESCRIPTION
The generator uses get_single_vt() to get the each vt from redis. This is method should be use when handling the <get_vts> command.

Improve readability of load_vts(), spliting and using the created get_single_vt()
Also, load_vts() loads now the necessary to run a scan, making the vt cache smaller.

This changes reduce the amount of data stored in cache, which is not being used intensively during scans.

Depends on PR greenbone/ospd#215