### PR TITLE
Test alive hosts only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check if the amount of vts in redis is coherent. 
   [#195](https://github.com/greenbone/ospd-openvas/pull/195)
   [#197](https://github.com/greenbone/ospd-openvas/pull/197)
+- Add support for test_alive_hosts_only feature of openvas. [#204](https://github.com/greenbone/ospd-openvas/pull/204)
 
 ### Changed
 - Less strict checks for the nvti cache version

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1569,10 +1569,8 @@ class OSPDopenvas(OSPDaemon):
             # Set alive test option. Overwrite the scan config settings.
             target_options = self.get_scan_target_options(scan_id)
             if target_options:
-                # check if test_alive_hosts_only() feature is active
-                # TODO: put this in build_alive_test_opt_as_prefs() and change function
-                # to nonstatic for self.openvas_db.add_item()?
-                # Or put it in completely new function? or something else?
+                # Check if test_alive_hosts_only feature of openvas is active.
+                # If active, put ALIVE_TEST enum in preferences.
                 settings = Openvas.get_settings()
                 if settings:
                     test_alive_hosts_only = settings.get(
@@ -1590,12 +1588,12 @@ class OSPDopenvas(OSPDaemon):
                                     'Invalid alive test value %s',
                                     target_options.get('alive_test'),
                                 )
-                            # put ALIVE_TEST enum in db, this is then taken by openvas to determine the method to use
+                            # Put ALIVE_TEST enum in db, this is then taken by openvas
+                            # to determine the method to use for the alive test.
                             if alive_test >= 1 and alive_test <= 31:
                                 item = 'ALIVE_TEST|||%s' % str(alive_test)
-                                self.openvas_db.add_single_item(
-                                    'internal/%s/scanprefs' % openvas_scan_id,
-                                    [item],
+                                kbdb.add_scan_preferences(
+                                    openvas_scan_id, [item]
                                 )
 
                 alive_test_opt = self.build_alive_test_opt_as_prefs(

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1588,8 +1588,9 @@ class OSPDopenvas(OSPDaemon):
                                     'Invalid alive test value %s',
                                     target_options.get('alive_test'),
                                 )
-                            # Put ALIVE_TEST enum in db, this is then taken by openvas
-                            # to determine the method to use for the alive test.
+                            # Put ALIVE_TEST enum in db, this is then taken
+                            # by openvas to determine the method to use
+                            # for the alive test.
                             if alive_test >= 1 and alive_test <= 31:
                                 item = 'ALIVE_TEST|||%s' % str(alive_test)
                                 kbdb.add_scan_preferences(


### PR DESCRIPTION
Add support for test_alive_hosts_only feature of openvas.
Put target preference for alive detection method in redis to be fetched by openvas.

Related PR:
- [openvas PR](https://github.com/greenbone/openvas/pull/456)
- [gvm-libs PR](https://github.com/greenbone/gvm-libs/pull/320)