### PR TITLE
Fix stop_scan_cleanup

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1147,7 +1147,7 @@ class OSPDopenvas(OSPDaemon):
                         parent = None
 
             for scan_db in kbdb.get_scan_databases():
-                scan_db.release()
+                self.main_db.release_database(scan_db)
 
     def get_vts_in_groups(self, filters: List[str]) -> List[str]:
         """ Return a list of vts which match with the given filter.


### PR DESCRIPTION
scan_db does not have the methods to release it self. Instead, use main_db to do it.