### PR TITLE
Add details parameter to get_vt_iterator()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#197](https://github.com/greenbone/ospd-openvas/pull/197)
 - Add support for test_alive_hosts_only feature of openvas. [#204](https://github.com/greenbone/ospd-openvas/pull/204)
 - Use lock file during feed update to avoid corrupted cache. [#207](https://github.com/greenbone/ospd-openvas/pull/207)
+- Add details parameter to get_vt_iterator(). [#215](https://github.com/greenbone/ospd-openvas/pull/215)
 
 ### Changed
 - Less strict checks for the nvti cache version

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -145,7 +145,7 @@
         "ospd": {
             "editable": true,
             "git": "https://github.com/greenbone/ospd.git",
-            "ref": "9304492be3ea78cba367fdd80ca13eb9d69473c5"
+            "ref": "6846bcc4b165801409978752d7bbf560b55003a4"
         },
         "packaging": {
             "hashes": [
@@ -304,10 +304,10 @@
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
+                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
             ],
-            "version": "==7.0"
+            "version": "==7.1.1"
         },
         "isort": {
             "hashes": [

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -467,7 +467,7 @@ class OSPDopenvas(OSPDaemon):
         """This method is called periodically to run tasks."""
         self.check_feed()
 
-    def get_single_vt(self, vt_id, oids):
+    def get_single_vt(self, vt_id, oids=None):
         _vt_params = self.nvti.get_nvt_params(vt_id)
         _vt_refs = self.nvti.get_nvt_refs(vt_id)
         _custom = self.nvti.get_nvt_metadata(vt_id)
@@ -476,12 +476,15 @@ class OSPDopenvas(OSPDaemon):
         _vt_creation_time = _custom.pop('creation_date')
         _vt_modification_time = _custom.pop('last_modification')
 
-        _vt_dependencies = list()
-        if 'dependencies' in _custom:
-            _deps = _custom.pop('dependencies')
-            _deps_list = _deps.split(', ')
-            for dep in _deps_list:
-                _vt_dependencies.append(oids.get('filename:' + dep))
+        if oids:
+            _vt_dependencies = list()
+            if 'dependencies' in _custom:
+                _deps = _custom.pop('dependencies')
+                _deps_list = _deps.split(', ')
+                for dep in _deps_list:
+                    _vt_dependencies.append(oids.get('filename:' + dep))
+        else:
+            _vt_dependencies = None
 
         _summary = None
         _impact = None
@@ -571,15 +574,15 @@ class OSPDopenvas(OSPDaemon):
         return vt
 
     def get_vt_iterator(
-        self, vt_selection: List[str] = None
+        self, vt_selection: List[str] = None, vt_details: bool = True
     ) -> Iterator[Tuple[str, Dict]]:
         """ Yield the vts from the Redis NVTicache. """
-        oids = dict(self.nvti.get_oids())
-        if vt_selection:
-            vt_id_list = vt_selection
-        else:
-            vt_id_list = oids.values()
-        for vt_id in vt_id_list:
+
+        oids = None
+        if vt_details:
+            oids = dict(self.nvti.get_oids())
+
+        for vt_id in vt_selection:
             vt = self.get_single_vt(vt_id, oids)
             yield (vt_id, vt)
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -574,12 +574,12 @@ class OSPDopenvas(OSPDaemon):
         return vt
 
     def get_vt_iterator(
-        self, vt_selection: List[str] = None, vt_details: bool = True
+        self, vt_selection: List[str] = None, details: bool = True
     ) -> Iterator[Tuple[str, Dict]]:
         """ Yield the vts from the Redis NVTicache. """
 
         oids = None
-        if vt_details:
+        if details:
             oids = dict(self.nvti.get_oids())
 
         for vt_id in vt_selection:


### PR DESCRIPTION
If details is True, it adds the vt dependencies as subelement
with the oid. For this an expensive query to redis is necessary.
The query takes about 3 seconds, which is especially expensive when
only one vt must be sent.
Otherwise, the dependencies are added as subelement of custom, the query
will not be perfomed, and quicker response is given for a single vt.

Depends on PR greenbone/ospd#222