### PR TITLE
Don't escape name for results

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -34,7 +34,6 @@ from base64 import b64decode
 
 from pathlib import Path
 from os import geteuid
-from xml.sax.saxutils import escape
 from lxml.etree import tostring, SubElement, Element
 
 import psutil
@@ -1072,9 +1071,6 @@ class OSPDopenvas(OSPDaemon):
 
                 if vt_aux:
                     rname = vt_aux.get('name')
-
-            if rname:
-                rname = escape(rname)
 
             if msg[0] == 'ERRMSG':
                 self.add_scan_error(

--- a/tests/dummydaemon.py
+++ b/tests/dummydaemon.py
@@ -37,7 +37,7 @@ class DummyDaemon(OSPDopenvas):
                 'timeout': '0',
             },
             'modification_time': ('1533906565'),
-            'name': 'Mantis Detection & foo',
+            'name': 'Mantis Detection',
             'qod_type': 'remote_banner',
             'insight': 'some insight',
             'severities': {
@@ -110,7 +110,7 @@ class DummyDaemon(OSPDopenvas):
             'family': 'Product detection',
             'filename': 'mantis_detect.nasl',
             'last_modification': ('1533906565'),
-            'name': 'Mantis Detection & foo',
+            'name': 'Mantis Detection',
             'qod_type': 'remote_banner',
             'required_ports': 'Services/www, 80',
             'solution': 'some solution',

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -839,35 +839,6 @@ class TestOspdOpenvas(TestCase):
             value='Host dead',
         )
 
-    @patch('ospd_openvas.daemon.ScanDB')
-    @patch('ospd_openvas.daemon.OSPDaemon.add_scan_log')
-    def test_get_openvas_result_escaped(self, mock_ospd, MockDBClass):
-        w = DummyDaemon()
-        mock_db = MockDBClass.return_value
-
-        results = [
-            "LOG||| |||general/Host_Details|||1.3.6.1.4.1.25623.1.0.100061|||Alive",
-            None,
-        ]
-        mock_db.get_result.side_effect = results
-        mock_ospd.return_value = None
-
-        w.nvti.QOD_TYPES.__getitem__.return_value = ''
-
-        w.load_vts()
-        w.report_openvas_results(mock_db, '123-456', 'localhost')
-
-        mock_ospd.assert_called_with(
-            '123-456',
-            host='localhost',
-            hostname='',
-            name='Mantis Detection &amp; foo',
-            port='general/Host_Details',
-            qod='',
-            test_id='1.3.6.1.4.1.25623.1.0.100061',
-            value='Alive',
-        )
-
     @patch('ospd_openvas.daemon.OSPDaemon.set_scan_host_progress')
     def test_update_progress(self, mock_set_scan_host_progress):
         w = DummyDaemon()


### PR DESCRIPTION
Revert PR #188
Because the escaping will be done in the ospd side.