### PR TITLE
Check for dead hosts before log the warning.

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1040,7 +1040,7 @@ class OSPDopenvas(OSPDaemon):
             host_is_dead = "Host dead" in msg[4]
             valid_oid = roid and roid in self.vts
 
-            if not valid_oid:
+            if not valid_oid and not host_is_dead:
                 logger.warning('Invalid VT oid %s for a result', roid)
 
             if valid_oid and not host_is_dead:


### PR DESCRIPTION
Since dead hosts messages come from scanner (not from plugin) and do not have a roid.