### PR TITLE
get_oids() return the list sorted by oid.

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -452,7 +452,7 @@ class OSPDopenvas(OSPDaemon):
                 _deps = _custom.pop('dependencies')
                 _deps_list = _deps.split(', ')
                 for dep in _deps_list:
-                    _vt_dependencies.append(oids.get('filename:' + dep))
+                    _vt_dependencies.append(oids.get(dep))
         else:
             _vt_dependencies = None
 

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -130,7 +130,7 @@ class NVTICache(BaseDB):
             A i. Each single list contains the filename
             as first element and the oid as second one.
         """
-        return OpenvasDB.get_elem_pattern_by_index(self.ctx, 'filename:*')
+        return OpenvasDB.get_filenames_and_oids(self.ctx)
 
     def get_nvt_params(self, oid: str) -> Optional[Dict[str, str]]:
         """ Get NVT's preferences.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -227,23 +227,38 @@ class TestOpenvasDB(TestCase):
         with self.assertRaises(RequiredArgument):
             OpenvasDB.get_pattern(ctx, None)
 
-    def test_get_elem_pattern_by_index_error(self, mock_redis):
+    def test_get_filenames_and_oids_error(self, mock_redis):
         ctx = mock_redis.return_value
 
         with self.assertRaises(RequiredArgument):
-            OpenvasDB.get_elem_pattern_by_index(None, 'a')
+            OpenvasDB.get_filenames_and_oids(None)
+
+    def test_get_filenames_and_oids(self, mock_redis):
+        ctx = mock_redis.return_value
+        ctx.keys.return_value = ['nvt:1', 'nvt:2']
+        ctx.lindex.side_effect = ['aa', 'ab']
+
+        ret = OpenvasDB.get_filenames_and_oids(ctx)
+
+        self.assertEqual(list(ret), [('aa', '1'), ('ab', '2')])
+
+    def test_get_keys_by_pattern_error(self, mock_redis):
+        ctx = mock_redis.return_value
 
         with self.assertRaises(RequiredArgument):
-            OpenvasDB.get_elem_pattern_by_index(ctx, None)
+            OpenvasDB.get_keys_by_pattern(None, 'a')
 
-    def test_get_elem_pattern_by_index(self, mock_redis):
+        with self.assertRaises(RequiredArgument):
+            OpenvasDB.get_keys_by_pattern(ctx, None)
+
+    def test_get_keys_by_pattern(self, mock_redis):
         ctx = mock_redis.return_value
-        ctx.keys.return_value = ['aa', 'ab']
-        ctx.lindex.side_effect = [1, 2]
+        ctx.keys.return_value = ['nvt:2', 'nvt:1']
 
-        ret = OpenvasDB.get_elem_pattern_by_index(ctx, 'a')
+        ret = OpenvasDB.get_keys_by_pattern(ctx, 'nvt:*')
 
-        self.assertEqual(list(ret), [('aa', 1), ('ab', 2)])
+        # Return sorted list
+        self.assertEqual(ret, ['nvt:1', 'nvt:2'])
 
     def test_get_key_count(self, mock_redis):
         ctx = mock_redis.return_value

--- a/tests/test_nvti_cache.py
+++ b/tests/test_nvti_cache.py
@@ -76,7 +76,7 @@ class TestNVTICache(TestCase):
         MockOpenvasDB.find_database_by_pattern.assert_called_with('20.4', 123)
 
     def test_get_oids(self, MockOpenvasDB):
-        MockOpenvasDB.get_elem_pattern_by_index.return_value = ['oids']
+        MockOpenvasDB.get_filenames_and_oids.return_value = ['oids']
 
         resp = self.nvti.get_oids()
 


### PR DESCRIPTION
This allows to add the vts in the dictionary already sorted by oid.