### PR TITLE
handle dead hosts

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1048,6 +1048,11 @@ class OSPDopenvas(OSPDaemon):
 
                 rname = vt_aux.get('name')
 
+            if msg[0] == 'DEADHOST':
+                hosts = msg[3].split(',')
+                for host in hosts:
+                    self.update_progress(scan_id, host, "-1/-1")
+
             if msg[0] == 'ERRMSG':
                 self.add_scan_error(
                     scan_id,


### PR DESCRIPTION
When the test_alive_hosts_only feature of openvas is enabled we
do not scan every single host in the target list and therefore
do not have the host progress for all hosts. To still be able
to update the progress bar we need to send all the dead hosts
from openvas to ospd-openvas. This is not an optimal solution as
we get big jumps in the progress bar if the target lists has many
hosts which are dead because they all get sent at once after the
host discovery is completed.