### PR TITLE
Correct license text to align with SPDX license identifier (GPL-2.0-or-later)

### DIFF
--- a/ospd_openvas/errors.py
+++ b/ospd_openvas/errors.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,7 +14,8 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 """
 Module for OSPD OpenVAS errors
 """


### PR DESCRIPTION
The current license text is GPL-3.0-or-later, which is not consistent with the SPDX license identifier and project license (GPL-2.0-or-later).

Signed-off-by: SZ Lin (林上智) <szlin@debian.org>