### PR TITLE
Write results and update host stauts in batch

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -72,29 +72,27 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
-                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
-                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
-                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
-                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
-                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
-                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
-                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
-                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
-                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
-                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
-                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
-                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
-                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
-                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
-                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
-                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
-                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
-                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
-                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
-                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
+                "sha256:0cacd3ef5c604b8e5f59bf2582c076c98a37fe206b31430d0cd08138aff0986e",
+                "sha256:192ca04a36852a994ef21df13cca4d822adbbdc9d5009c0f96f1d2929e375d4f",
+                "sha256:19ae795137682a9778892fb4390c07811828b173741bce91e30f899424b3934d",
+                "sha256:1b9b535d6b55936a79dbe4990b64bb16048f48747c76c29713fea8c50eca2acf",
+                "sha256:2a2ad24d43398d89f92209289f15265107928f22a8d10385f70def7a698d6a02",
+                "sha256:3be7a5722d5bfe69894d3f7bbed15547b17619f3a88a318aab2e37f457524164",
+                "sha256:49870684da168b90110bbaf86140d4681032c5e6a2461adc7afdd93be5634216",
+                "sha256:587f98ce27ac4547177a0c6fe0986b8736058daffe9160dcf5f1bd411b7fbaa1",
+                "sha256:5aca6f00b2f42546b9bdf11a69f248d1881212ce5b9e2618b04935b87f6f82a1",
+                "sha256:6b744039b55988519cc183149cceb573189b3e46e16ccf6f8c46798bb767c9dc",
+                "sha256:6b91cab3841b4c7cb70e4db1697c69f036c8bc0a253edc0baa6783154f1301e4",
+                "sha256:7598974f6879a338c785c513e7c5a4329fbc58b9f6b9a6305035fca5b1076552",
+                "sha256:7a279f33a081d436e90e91d1a7c338553c04e464de1c9302311a5e7e4b746088",
+                "sha256:95e1296e0157361fe2f5f0ed307fd31f94b0ca13372e3673fa95095a627636a1",
+                "sha256:9fc9da390e98cb6975eadf251b6e5fa088820141061bf041cd5c72deba1dc526",
+                "sha256:cc20316e3f5a6b582fc3b029d8dc03aabeb645acfcb7fc1d9848841a33265748",
+                "sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc",
+                "sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547",
+                "sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "defusedxml": {
             "hashes": [
@@ -105,10 +103,10 @@
         },
         "deprecated": {
             "hashes": [
-                "sha256:408038ab5fdeca67554e8f6742d1521cd3cd0ee0ff9d47f29318a4f4da31c308",
-                "sha256:8b6a5aa50e482d8244a62e5582b96c372e87e3a28e8b49c316e46b95c76a611d"
+                "sha256:9caec5374c4b63e12d2ef8c9e01df1c55859db707b384d63f800aac7cbc93509",
+                "sha256:cd98397157a1046784c9ff155730b745f46bb4dfd0175522c5bf348ab10037a5"
             ],
-            "version": "==1.2.7"
+            "version": "==1.2.8"
         },
         "lxml": {
             "hashes": [
@@ -145,7 +143,7 @@
         "ospd": {
             "editable": true,
             "git": "https://github.com/greenbone/ospd.git",
-            "ref": "a72f9d28cefcd2f14e68015757371bef18f18338"
+            "ref": "f571c7a70f1b7992e51e94b1b5b1ab95aed8ffe6"
         },
         "packaging": {
             "hashes": [
@@ -214,10 +212,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
-                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "version": "==2.4.6"
+            "version": "==2.4.7"
         },
         "redis": {
             "hashes": [
@@ -366,29 +364,29 @@
         },
         "regex": {
             "hashes": [
-                "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431",
-                "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242",
-                "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1",
-                "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d",
-                "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045",
-                "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b",
-                "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400",
-                "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa",
-                "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0",
-                "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69",
-                "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74",
-                "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb",
-                "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26",
-                "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5",
-                "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2",
-                "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce",
-                "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab",
-                "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e",
-                "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70",
-                "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc",
-                "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"
+                "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b",
+                "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8",
+                "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3",
+                "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e",
+                "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683",
+                "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1",
+                "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142",
+                "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3",
+                "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468",
+                "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e",
+                "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3",
+                "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a",
+                "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f",
+                "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6",
+                "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156",
+                "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b",
+                "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db",
+                "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd",
+                "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a",
+                "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948",
+                "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"
             ],
-            "version": "==2020.2.20"
+            "version": "==2020.4.4"
         },
         "rope": {
             "hashes": [

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1027,7 +1027,8 @@ class OSPDopenvas(OSPDaemon):
         """ Get all result entries from redis kb. """
         res = db.get_result()
         result_batch = list()
-        host_progress_batch = {}
+        host_progress_batch = dict()
+        finished_host_batch = list()
         while res:
             msg = res.split('|||')
             roid = msg[3].strip()
@@ -1109,6 +1110,7 @@ class OSPDopenvas(OSPDaemon):
                 for _host in hosts:
                     if _host:
                         host_progress_batch[_host] = 100
+                        finished_host_batch.append(_host)
                         result_batch = self.add_scan_log(
                             host=_host,
                             hostname=rhostname,
@@ -1147,6 +1149,11 @@ class OSPDopenvas(OSPDaemon):
         if host_progress_batch:
             self.set_scan_host_progress(
                 scan_id, host_progress_batch=host_progress_batch
+            )
+
+        if finished_host_batch:
+            self.set_scan_host_finished(
+                scan_id, finished_host_batch=finished_host_batch
             )
 
     def report_openvas_timestamp_scan_host(
@@ -1388,7 +1395,7 @@ class OSPDopenvas(OSPDaemon):
                     )
 
                     if scan_db.host_is_finished(openvas_scan_id):
-                        self.set_scan_host_finished(scan_id, current_host)
+                        self.set_scan_host_finished(scan_id, host=current_host)
                         self.report_openvas_scan_status(
                             scan_db, scan_id, current_host
                         )

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1024,6 +1024,7 @@ class OSPDopenvas(OSPDaemon):
     ):
         """ Get all result entries from redis kb. """
         res = db.get_result()
+        result_batch = list()
         while res:
             msg = res.split('|||')
             roid = msg[3].strip()
@@ -1049,19 +1050,19 @@ class OSPDopenvas(OSPDaemon):
                 rname = vt_aux.get('name')
 
             if msg[0] == 'ERRMSG':
-                self.add_scan_error(
-                    scan_id,
+                result_batch = self.add_scan_error(
                     host=current_host,
                     hostname=rhostname,
                     name=rname,
                     value=msg[4],
                     port=msg[2],
                     test_id=roid,
+                    batch=True,
+                    result_batch=result_batch,
                 )
 
             if msg[0] == 'LOG':
-                self.add_scan_log(
-                    scan_id,
+                result_batch = self.add_scan_log(
                     host=current_host,
                     hostname=rhostname,
                     name=rname,
@@ -1069,21 +1070,23 @@ class OSPDopenvas(OSPDaemon):
                     port=msg[2],
                     qod=rqod,
                     test_id=roid,
+                    batch=True,
+                    result_batch=result_batch,
                 )
 
             if msg[0] == 'HOST_DETAIL':
-                self.add_scan_host_detail(
-                    scan_id,
+                result_batch = self.add_scan_host_detail(
                     host=current_host,
                     hostname=rhostname,
                     name=rname,
                     value=msg[4],
+                    batch=True,
+                    result_batch=result_batch,
                 )
 
             if msg[0] == 'ALARM':
                 rseverity = self.get_severity_score(vt_aux)
-                self.add_scan_alarm(
-                    scan_id,
+                result_batch = self.add_scan_alarm(
                     host=current_host,
                     hostname=rhostname,
                     name=rname,
@@ -1092,6 +1095,8 @@ class OSPDopenvas(OSPDaemon):
                     test_id=roid,
                     severity=rseverity,
                     qod=rqod,
+                    batch=True,
+                    result_batch=result_batch,
                 )
 
             # To process non scanned dead hosts when

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1048,6 +1048,11 @@ class OSPDopenvas(OSPDaemon):
 
                 rname = vt_aux.get('name')
 
+            if msg[0] == 'DEADHOST':
+                hosts = msg[3].split(',')
+                for host in hosts:
+                    self.update_progress(scan_id, host, "-1/-1")
+
             if msg[0] == 'ERRMSG':
                 self.add_scan_error(
                     scan_id,

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -40,6 +40,7 @@ from ospd.server import BaseServer
 from ospd.main import main as daemon_main
 from ospd.cvss import CVSS
 from ospd.vtfilter import VtsFilter
+from ospd.resultlist import ResultList
 
 from ospd_openvas import __version__
 from ospd_openvas.errors import OspdOpenvasError
@@ -1026,6 +1027,7 @@ class OSPDopenvas(OSPDaemon):
     ):
         """ Get all result entries from redis kb. """
         res = db.get_result()
+        res_list = ResultList()
         result_list = list()
         host_progress_batch = dict()
         finished_host_batch = list()
@@ -1054,7 +1056,7 @@ class OSPDopenvas(OSPDaemon):
                 rname = vt_aux.get('name')
 
             if msg[0] == 'ERRMSG':
-                result_list = self.add_scan_error_to_list(
+                result_list = res_list.add_scan_error_to_list(
                     result_list,
                     host=current_host,
                     hostname=rhostname,
@@ -1065,7 +1067,7 @@ class OSPDopenvas(OSPDaemon):
                 )
 
             if msg[0] == 'LOG':
-                result_list = self.add_scan_log_to_list(
+                result_list = res_list.add_scan_log_to_list(
                     result_list,
                     host=current_host,
                     hostname=rhostname,
@@ -1077,7 +1079,7 @@ class OSPDopenvas(OSPDaemon):
                 )
 
             if msg[0] == 'HOST_DETAIL':
-                result_list = self.add_scan_host_detail_to_list(
+                result_list = res_list.add_scan_host_detail_to_list(
                     result_list,
                     host=current_host,
                     hostname=rhostname,
@@ -1087,7 +1089,7 @@ class OSPDopenvas(OSPDaemon):
 
             if msg[0] == 'ALARM':
                 rseverity = self.get_severity_score(vt_aux)
-                result_list = self.add_scan_alarm_to_list(
+                result_list = res_list.add_scan_alarm_to_list(
                     result_list,
                     host=current_host,
                     hostname=rhostname,
@@ -1107,7 +1109,7 @@ class OSPDopenvas(OSPDaemon):
                     if _host:
                         host_progress_batch[_host] = 100
                         finished_host_batch.append(_host)
-                        result_list = self.add_scan_log_to_list(
+                        result_list = res_list.add_scan_log_to_list(
                             result_list,
                             host=_host,
                             hostname=rhostname,
@@ -1118,13 +1120,13 @@ class OSPDopenvas(OSPDaemon):
                             test_id='',
                         )
                         timestamp = time.ctime(time.time())
-                        result_list = self.add_scan_log_to_list(
+                        result_list = res_list.add_scan_log_to_list(
                             result_list,
                             host=_host,
                             name='HOST_START',
                             value=timestamp,
                         )
-                        result_list = self.add_scan_log_to_list(
+                        result_list = res_list.add_scan_log_to_list(
                             result_list,
                             host=_host,
                             name='HOST_END',

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1137,6 +1137,10 @@ class OSPDopenvas(OSPDaemon):
             del vt_aux
             res = db.get_result()
 
+        # Insert result batch into the scan collection table.
+        if result_batch:
+            self.scan_collection.add_result_batch(scan_id, result_batch)
+
     def report_openvas_timestamp_scan_host(
         self, scan_db: ScanDB, scan_id: str, host: str
     ):

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1126,7 +1126,7 @@ class OSPDopenvas(OSPDaemon):
             res = db.get_result()
 
         # Insert result batch into the scan collection table.
-        if res_list:
+        if len(res_list):
             self.scan_collection.add_result_list(scan_id, res_list)
 
         if host_progress_batch:

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1048,11 +1048,6 @@ class OSPDopenvas(OSPDaemon):
 
                 rname = vt_aux.get('name')
 
-            if msg[0] == 'DEADHOST':
-                hosts = msg[3].split(',')
-                for host in hosts:
-                    self.update_progress(scan_id, host, "-1/-1")
-
             if msg[0] == 'ERRMSG':
                 self.add_scan_error(
                     scan_id,
@@ -1098,6 +1093,40 @@ class OSPDopenvas(OSPDaemon):
                     severity=rseverity,
                     qod=rqod,
                 )
+
+            # To process non scanned dead hosts when
+            # test_alive_host_only in openvas is enable
+            if msg[0] == 'DEADHOST':
+                hosts = msg[3].split(',')
+                for _host in hosts:
+                    if _host:
+                        self.update_progress(scan_id, _host, "-1/-1")
+                        result_batch = self.add_scan_log(
+                            host=_host,
+                            hostname=rhostname,
+                            name=rname,
+                            value=msg[4],
+                            port=msg[2],
+                            qod=rqod,
+                            test_id='',
+                            batch=True,
+                            result_batch=result_batch,
+                        )
+                        timestamp = time.ctime(time.time())
+                        result_batch = self.add_scan_log(
+                            host=_host,
+                            name='HOST_START',
+                            value=timestamp,
+                            batch=True,
+                            result_batch=result_batch,
+                        )
+                        result_batch = self.add_scan_log(
+                            host=_host,
+                            name='HOST_END',
+                            value=timestamp,
+                            batch=True,
+                            result_batch=result_batch,
+                        )
 
             vt_aux = None
             del vt_aux

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1028,7 +1028,6 @@ class OSPDopenvas(OSPDaemon):
         """ Get all result entries from redis kb. """
         res = db.get_result()
         res_list = ResultList()
-        result_list = list()
         host_progress_batch = dict()
         finished_host_batch = list()
         while res:
@@ -1056,8 +1055,7 @@ class OSPDopenvas(OSPDaemon):
                 rname = vt_aux.get('name')
 
             if msg[0] == 'ERRMSG':
-                result_list = res_list.add_scan_error_to_list(
-                    result_list,
+                res_list.add_scan_error_to_list(
                     host=current_host,
                     hostname=rhostname,
                     name=rname,
@@ -1067,8 +1065,7 @@ class OSPDopenvas(OSPDaemon):
                 )
 
             if msg[0] == 'LOG':
-                result_list = res_list.add_scan_log_to_list(
-                    result_list,
+                res_list.add_scan_log_to_list(
                     host=current_host,
                     hostname=rhostname,
                     name=rname,
@@ -1079,8 +1076,7 @@ class OSPDopenvas(OSPDaemon):
                 )
 
             if msg[0] == 'HOST_DETAIL':
-                result_list = res_list.add_scan_host_detail_to_list(
-                    result_list,
+                res_list.add_scan_host_detail_to_list(
                     host=current_host,
                     hostname=rhostname,
                     name=rname,
@@ -1089,8 +1085,7 @@ class OSPDopenvas(OSPDaemon):
 
             if msg[0] == 'ALARM':
                 rseverity = self.get_severity_score(vt_aux)
-                result_list = res_list.add_scan_alarm_to_list(
-                    result_list,
+                res_list.add_scan_alarm_to_list(
                     host=current_host,
                     hostname=rhostname,
                     name=rname,
@@ -1109,8 +1104,7 @@ class OSPDopenvas(OSPDaemon):
                     if _host:
                         host_progress_batch[_host] = 100
                         finished_host_batch.append(_host)
-                        result_list = res_list.add_scan_log_to_list(
-                            result_list,
+                        res_list.add_scan_log_to_list(
                             host=_host,
                             hostname=rhostname,
                             name=rname,
@@ -1120,17 +1114,11 @@ class OSPDopenvas(OSPDaemon):
                             test_id='',
                         )
                         timestamp = time.ctime(time.time())
-                        result_list = res_list.add_scan_log_to_list(
-                            result_list,
-                            host=_host,
-                            name='HOST_START',
-                            value=timestamp,
+                        res_list.add_scan_log_to_list(
+                            host=_host, name='HOST_START', value=timestamp,
                         )
-                        result_list = res_list.add_scan_log_to_list(
-                            result_list,
-                            host=_host,
-                            name='HOST_END',
-                            value=timestamp,
+                        res_list.add_scan_log_to_list(
+                            host=_host, name='HOST_END', value=timestamp,
                         )
 
             vt_aux = None
@@ -1138,8 +1126,8 @@ class OSPDopenvas(OSPDaemon):
             res = db.get_result()
 
         # Insert result batch into the scan collection table.
-        if result_list:
-            self.scan_collection.add_result_list(scan_id, result_list)
+        if res_list:
+            self.scan_collection.add_result_list(scan_id, res_list)
 
         if host_progress_batch:
             self.set_scan_progress_batch(

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -638,9 +638,8 @@ class TestOspdOpenvas(TestCase):
 
         w.load_vts()
         w.report_openvas_results(mock_db, '123-456', 'localhost')
-
+        result_batch = list()
         mock_add_scan_log.assert_called_with(
-            '123-456',
             host='localhost',
             hostname='',
             name='',
@@ -648,6 +647,8 @@ class TestOspdOpenvas(TestCase):
             qod='',
             test_id='',
             value='Host dead',
+            batch=True,
+            result_batch=result_batch,
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -682,7 +683,7 @@ class TestOspdOpenvas(TestCase):
         w.update_progress('123-456', 'localhost', msg)
 
         mock_set_scan_host_progress.assert_called_with(
-            '123-456', 'localhost', 100
+            '123-456', host='localhost', progress=100
         )
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -631,10 +631,15 @@ class TestOspdOpenvas(TestCase):
     @patch('ospd_openvas.daemon.ResultList.add_scan_log_to_list')
     def test_get_openvas_result(self, mock_add_scan_log_to_list, MockDBClass):
         w = DummyDaemon()
+
+        target_element = w.create_xml_target()
+        targets = OspRequest.process_target_element(target_element)
+        w.create_scan('123-456', targets, None, [])
+
         res_list = ResultList()
-        mock_db = MockDBClass.return_value
 
         results = ["LOG||| |||general/Host_Details||| |||Host dead", None]
+        mock_db = MockDBClass.return_value
         mock_db.get_result.side_effect = results
         mock_add_scan_log_to_list.return_value = None
 
@@ -642,7 +647,6 @@ class TestOspdOpenvas(TestCase):
         w.report_openvas_results(mock_db, '123-456', 'localhost')
         result_list = list()
         mock_add_scan_log_to_list.assert_called_with(
-            result_list,
             host='localhost',
             hostname='',
             name='',

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -627,19 +627,20 @@ class TestOspdOpenvas(TestCase):
         self.assertEqual(mock_path_open.call_count, 1)
 
     @patch('ospd_openvas.daemon.ScanDB')
-    @patch('ospd_openvas.daemon.OSPDaemon.add_scan_log')
-    def test_get_openvas_result(self, mock_add_scan_log, MockDBClass):
+    @patch('ospd_openvas.daemon.OSPDaemon.add_scan_log_to_list')
+    def test_get_openvas_result(self, mock_add_scan_log_to_list, MockDBClass):
         w = DummyDaemon()
         mock_db = MockDBClass.return_value
 
         results = ["LOG||| |||general/Host_Details||| |||Host dead", None]
         mock_db.get_result.side_effect = results
-        mock_add_scan_log.return_value = None
+        mock_add_scan_log_to_list.return_value = None
 
         w.load_vts()
         w.report_openvas_results(mock_db, '123-456', 'localhost')
-        result_batch = list()
-        mock_add_scan_log.assert_called_with(
+        result_list = list()
+        mock_add_scan_log_to_list.assert_called_with(
+            result_list,
             host='localhost',
             hostname='',
             name='',
@@ -647,8 +648,6 @@ class TestOspdOpenvas(TestCase):
             qod='',
             test_id='',
             value='Host dead',
-            batch=True,
-            result_batch=result_batch,
         )
 
     @patch('ospd_openvas.db.KbDB')

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -29,6 +29,7 @@ from unittest.mock import patch, Mock, MagicMock
 
 from ospd.vts import Vts
 from ospd.protocol import OspRequest
+from ospd.resultlist import ResultList
 
 from tests.dummydaemon import DummyDaemon
 from tests.helper import assert_called_once
@@ -627,9 +628,10 @@ class TestOspdOpenvas(TestCase):
         self.assertEqual(mock_path_open.call_count, 1)
 
     @patch('ospd_openvas.daemon.ScanDB')
-    @patch('ospd_openvas.daemon.OSPDaemon.add_scan_log_to_list')
+    @patch('ospd_openvas.daemon.ResultList.add_scan_log_to_list')
     def test_get_openvas_result(self, mock_add_scan_log_to_list, MockDBClass):
         w = DummyDaemon()
+        res_list = ResultList()
         mock_db = MockDBClass.return_value
 
         results = ["LOG||| |||general/Host_Details||| |||Host dead", None]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -29,7 +29,6 @@ from unittest.mock import patch, Mock, MagicMock
 
 from ospd.vts import Vts
 from ospd.protocol import OspRequest
-from ospd.resultlist import ResultList
 
 from tests.dummydaemon import DummyDaemon
 from tests.helper import assert_called_once
@@ -636,8 +635,6 @@ class TestOspdOpenvas(TestCase):
         targets = OspRequest.process_target_element(target_element)
         w.create_scan('123-456', targets, None, [])
 
-        res_list = ResultList()
-
         results = ["LOG||| |||general/Host_Details||| |||Host dead", None]
         mock_db = MockDBClass.return_value
         mock_db.get_result.side_effect = results
@@ -645,7 +642,6 @@ class TestOspdOpenvas(TestCase):
 
         w.load_vts()
         w.report_openvas_results(mock_db, '123-456', 'localhost')
-        result_list = list()
         mock_add_scan_log_to_list.assert_called_with(
             host='localhost',
             hostname='',


### PR DESCRIPTION
This allows to access the scan table less time. As the scan table is in a separated process, accessing the shared memory makes the writing of result for large scan quite slow.
Now this is improved.
This change is especially important since the new test_alive_host_only is implemented in openvas.
Large networks can be scanned and many host can be dead, generating a big amount of "host_details" results for the dead hosts. The dead host list  arrives to the ospd-openvas in list of up to 1000 hosts, which will be inserted and updated at once in the scan table.


Depends on PR greenbone/ospd#242