### PR TITLE
Add Python 3.8 to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,12 @@ executors:
         environment:
             PIPENV_VENV_IN_PROJECT: true
     working_directory: ~/repo
+  python-38:
+    docker:
+      - image: circleci/python:3.8
+        environment:
+            PIPENV_VENV_IN_PROJECT: true
+    working_directory: ~/repo
 
 commands:
   build:
@@ -110,6 +116,14 @@ jobs:
     executor: python-37
     steps:
       - test-with-codecov
+  build-38:
+    executor: python-38
+    steps:
+      - build
+  test-38:
+    executor: python-38
+    steps:
+      - test
 
 workflows:
   version: 2
@@ -122,3 +136,5 @@ workflows:
       - test-36
       - build-37
       - test-37
+      - build-38
+      - test-38


### PR DESCRIPTION
Run builds and tests on Python 3.8 too.