### PR TITLE
Check if the cache is available before starting an update.

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -405,6 +405,9 @@ class OSPDopenvas(OSPDaemon):
         Wait until all the running scans finished. Set a flag to announce there
         is a pending feed update, which avoids to start a new scan.
         """
+        if not self.vts.is_cache_available:
+            return
+
         current_feed = self.nvti.get_feed_version()
         is_outdated = self.feed_is_outdated(current_feed)
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -581,6 +581,15 @@ class TestOspdOpenvas(TestCase):
         self.assertEqual(mock_path_exists.call_count, 1)
         self.assertEqual(mock_path_open.call_count, 1)
 
+    def test_check_feed_cache_unavailable(self):
+        w = DummyDaemon()
+        w.vts.is_cache_available = False
+        w.feed_is_outdated = Mock()
+        res = w.check_feed()
+
+        self.assertFalse(res)
+        w.feed_is_outdated.assert_not_called()
+
     @patch('ospd_openvas.daemon.ScanDB')
     @patch('ospd_openvas.daemon.ResultList.add_scan_log_to_list')
     def test_get_openvas_result(self, mock_add_scan_log_to_list, MockDBClass):


### PR DESCRIPTION
Osdp will set the flag is_cache_available to false when it is handling a get_vts request.

It uses the new vts.is_cache_available and not the already existent initialized flag because this is used "in the opposite direction". While initialized flag is use to allow response to the client, is_cache_available is used to avoid action over redis during a request with generates a conflict, like get_vts.

Depends on PR greenbone/ospd#258