### PR TITLE
Always send ALIVE_TEST when getting alive_test.

### DIFF
--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -379,34 +379,29 @@ class PreferenceHandler:
         return target_opt_prefs_list
 
     def prepare_alive_test_option_for_openvas(self):
-        """ Set alive test option. Overwrite the scan config settings.
-        Check if test_alive_hosts_only feature of openvas is active.
-        If active, put ALIVE_TEST enum in preferences. """
+        """ Set ALIVE_TEST option in case "alive_test" was set for the target.
+        Overwrite the scan config settings. """
         settings = Openvas.get_settings()
         if settings:
-            test_alive_hosts_only = settings.get('test_alive_hosts_only')
-            if test_alive_hosts_only:
-                if self.target_options.get('alive_test'):
-                    try:
-                        alive_test = int(self.target_options.get('alive_test'))
-                    except ValueError:
-                        logger.debug(
-                            'Alive test settings not applied. '
-                            'Invalid alive test value %s',
-                            self.target_options.get('alive_test'),
-                        )
-                    # Put ALIVE_TEST enum in db, this is then taken
-                    # by openvas to determine the method to use
-                    # for the alive test.
-                    if alive_test >= 1 and alive_test <= 31:
-                        item = 'ALIVE_TEST|||%s' % str(alive_test)
-                        self.kbdb.add_scan_preferences(
-                            self._openvas_scan_id, [item]
-                        )
-            elif self.target_options.get('alive_test'):
+            if self.target_options.get('alive_test'):
+                try:
+                    alive_test = int(self.target_options.get('alive_test'))
+                except ValueError:
+                    logger.debug(
+                        'Alive test settings not applied. '
+                        'Invalid alive test value %s',
+                        self.target_options.get('alive_test'),
+                    )
+
                 alive_test_opt = self.build_alive_test_opt_as_prefs(
                     self.target_options
                 )
+
+                # Put ALIVE_TEST enum in db, this is then taken by openvas
+                # to determine the method to use for the alive test.
+                if alive_test >= 1 and alive_test <= 31:
+                    alive_test_opt.append('ALIVE_TEST|||%s' % str(alive_test))
+
                 self.kbdb.add_scan_preferences(
                     self._openvas_scan_id, alive_test_opt
                 )


### PR DESCRIPTION
In case the alive_test is set for the target, then
always copy it over to the ALIVE_TEST scan preference.
Before, it was only send when also the setting
test_alive_hosts_only was true.

This helps openvas to decide on its own about using
ALIVE_TEST or not.