### PR TITLE
Wait for the scanner to finish cleanly on a scan_stop, before cleaning the main scan db.

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1155,7 +1155,7 @@ class OSPDopenvas(OSPDaemon):
                 self.main_db.release_database(kbdb)
                 return
 
-            time.sleep(3)
+            time.sleep(1)
             # Check if the client stopped the whole scan
             if kbdb.scan_is_stopped(openvas_scan_id):
                 # clean main_db, but wait for scanner to finish.

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1158,7 +1158,9 @@ class OSPDopenvas(OSPDaemon):
             time.sleep(3)
             # Check if the client stopped the whole scan
             if kbdb.scan_is_stopped(openvas_scan_id):
-                # clean main_db
+                # clean main_db, but wait for scanner to finish.
+                while not kbdb.target_is_finished(scan_id):
+                    time.sleep(1)
                 self.main_db.release_database(kbdb)
                 return
 


### PR DESCRIPTION
Also, reduce the wait time in the loop to get the results.