### PR TITLE
Modify handling of dead hosts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   a bit different then `pipenv install`. It installs dev packages by default and
   also ospd in editable mode. This means after running poetry install ospd will
   directly be importable in the virtual python environment. [#235](https://github.com/greenbone/ospd-openvas/pull/235)
+- Don't send host details and log messages to the client when Boreas is enabled. [#252](https://github.com/greenbone/ospd-openvas/pull/252)
+- Progress bar calculation do not takes in accound dead hosts. [#252](https://github.com/greenbone/ospd-openvas/pull/252)
 
 ### Fixed
 - Check vt_aux for None before trying to access it. [#177](https://github.com/greenbone/ospd-openvas/pull/177)
@@ -43,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 - Remove use_mac_addr, vhost_ip and vhost scan preferences. [#184](https://github.com/greenbone/ospd-openvas/pull/184)
+- Handling of finished host for resume task. [#252](https://github.com/greenbone/ospd-openvas/pull/252)
 
 ## [1.0.1] (unreleased)
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -809,12 +809,14 @@ class OSPDopenvas(OSPDaemon):
             launched, total = msg.split('/')
         except ValueError:
             return
+
         if float(total) == 0:
             return
         elif float(total) == -1:
-            host_prog = 100
+            host_prog = -1  # Host dead
         else:
             host_prog = (float(launched) / float(total)) * 100
+
         self.set_scan_host_progress(
             scan_id, host=current_host, progress=host_prog
         )

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -34,7 +34,7 @@ from lxml.etree import tostring, SubElement, Element
 
 import psutil
 
-from ospd.ospd import OSPDaemon
+from ospd.ospd import OSPDaemon, PROGRESS_DEAD_HOST
 from ospd.server import BaseServer
 from ospd.main import main as daemon_main
 from ospd.cvss import CVSS
@@ -810,12 +810,15 @@ class OSPDopenvas(OSPDaemon):
         except ValueError:
             return
 
-        if float(total) == 0:
+        try:
+            if float(total) == 0:
+                return
+            elif float(total) == PROGRESS_DEAD_HOST:
+                host_prog = PROGRESS_DEAD_HOST
+            else:
+                host_prog = (float(launched) / float(total)) * 100
+        except TypeError:
             return
-        elif float(total) == -1:
-            host_prog = -1  # Host dead
-        else:
-            host_prog = (float(launched) / float(total)) * 100
 
         self.set_scan_host_progress(
             scan_id, host=current_host, progress=host_prog

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1163,14 +1163,16 @@ class OSPDopenvas(OSPDaemon):
                     )
 
                     if scan_db.host_is_finished(openvas_scan_id):
-                        self.set_scan_host_finished(
-                            scan_id, finished_hosts=current_host
-                        )
                         self.report_openvas_scan_status(
                             scan_db, scan_id, current_host
                         )
+
                         self.report_openvas_timestamp_scan_host(
                             scan_db, scan_id, current_host
+                        )
+
+                        self.sort_host_finished(
+                            scan_id, finished_hosts=current_host
                         )
 
                         kbdb.remove_scan_database(scan_db)

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -927,7 +927,7 @@ class OSPDopenvas(OSPDaemon):
                     qod=rqod,
                 )
 
-            # To process non scanned dead hosts when
+            # To process non-scanned dead hosts when
             # test_alive_host_only in openvas is enable
             if msg[0] == 'DEADHOST':
                 hosts = msg[3].split(',')
@@ -935,22 +935,6 @@ class OSPDopenvas(OSPDaemon):
                     if _host:
                         host_progress_batch[_host] = 100
                         finished_host_batch.append(_host)
-                        res_list.add_scan_log_to_list(
-                            host=_host,
-                            hostname=rhostname,
-                            name=rname,
-                            value=msg[4],
-                            port=msg[2],
-                            qod=rqod,
-                            test_id='',
-                        )
-                        timestamp = time.ctime(time.time())
-                        res_list.add_scan_log_to_list(
-                            host=_host, name='HOST_START', value=timestamp,
-                        )
-                        res_list.add_scan_log_to_list(
-                            host=_host, name='HOST_END', value=timestamp,
-                        )
 
             res = db.get_result()
 

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -451,17 +451,6 @@ class PreferenceHandler:
         stores the list of hosts that must not be scanned in the kb. """
         exclude_hosts = self.scan_collection.get_exclude_hosts(self.scan_id)
 
-        # Get unfinished hosts, in case it is a resumed scan. And added
-        # into exclude_hosts scan preference. Set progress for the finished ones
-        # to 100%.
-        finished_hosts = self.scan_collection.get_hosts_finished(self.scan_id)
-        if finished_hosts:
-            if exclude_hosts:
-                finished_hosts_str = ','.join(finished_hosts)
-                exclude_hosts = exclude_hosts + ',' + finished_hosts_str
-            else:
-                exclude_hosts = ','.join(finished_hosts)
-
         if exclude_hosts:
             pref_val = "exclude_hosts|||" + exclude_hosts
             self.kbdb.add_scan_preferences(self._openvas_scan_id, [pref_val])

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -349,48 +349,8 @@ class PreferenceHandlerTestCase(TestCase):
         w = DummyDaemon()
 
         exc = '192.168.0.1'
-        fin = ['192.168.0.2']
 
         w.scan_collection.get_exclude_hosts = MagicMock(return_value=exc)
-        w.scan_collection.get_hosts_finished = MagicMock(return_value=fin)
-
-        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
-        p.kbdb.add_scan_preferences = MagicMock()
-        p.prepare_host_options_for_openvas()
-
-        p.kbdb.add_scan_preferences.assert_called_with(
-            p._openvas_scan_id, ['exclude_hosts|||192.168.0.1,192.168.0.2'],
-        )
-
-    @patch('ospd_openvas.db.KbDB')
-    def test_set_host_options_no_exclude(self, mock_kb):
-        w = DummyDaemon()
-
-        exc = ''
-        fin = ['192.168.0.2']
-
-        w.scan_collection.get_exclude_hosts = MagicMock(return_value=exc)
-        w.scan_collection.get_hosts_finished = MagicMock(return_value=fin)
-
-        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
-        p.kbdb.add_scan_preferences = MagicMock()
-        p.prepare_host_options_for_openvas()
-
-        p.kbdb.add_scan_preferences.assert_called_with(
-            p._openvas_scan_id, ['exclude_hosts|||192.168.0.2'],
-        )
-
-    @patch('ospd_openvas.db.KbDB')
-    def test_set_host_options_no_finished(self, mock_kb):
-        w = DummyDaemon()
-
-        exc = '192.168.0.1'
-        fin = []
-
-        w.scan_collection.get_exclude_hosts = MagicMock(return_value=exc)
-        w.scan_collection.get_hosts_finished = MagicMock(return_value=fin)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
         p._openvas_scan_id = '456-789'
@@ -406,10 +366,8 @@ class PreferenceHandlerTestCase(TestCase):
         w = DummyDaemon()
 
         exc = ''
-        fin = []
 
         w.scan_collection.get_exclude_hosts = MagicMock(return_value=exc)
-        w.scan_collection.get_hosts_finished = MagicMock(return_value=fin)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
         p._openvas_scan_id = '456-789'


### PR DESCRIPTION
Depends on PR greenbone/ospd#266

A finished host could be alive or dead, when the classic alive test method is uses.
Depending on the host progress it will be set as dead or alive(finished).

When Boreas is used, do not send log and host details message of dead hosts to the client.

In any case, the dead host are not taken in account for the scan progress calculation

