### PR TITLE
Support scan config default for Boreas

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1078,6 +1078,7 @@ class OSPDopenvas(OSPDaemon):
         scan_prefs.prepare_scan_params_for_openvas(OSPD_PARAMS)
         scan_prefs.prepare_reverse_lookup_opt_for_openvas()
         scan_prefs.prepare_alive_test_option_for_openvas()
+        scan_prefs.prepare_boreas_alive_test()
 
         # Release memory used for scan preferences.
         del scan_prefs

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -48,7 +48,7 @@ OID_SNMP_AUTH = "1.3.6.1.4.1.25623.1.0.105076"
 OID_PING_HOST = "1.3.6.1.4.1.25623.1.0.100315"
 
 BOREAS_ALIVE_TEST = "ALIVE_TEST"
-BOREAS = "test_alive_hosts_only"
+BOREAS_SETTING_NAME = "test_alive_hosts_only"
 
 
 class AliveTest(IntEnum):
@@ -394,14 +394,14 @@ class PreferenceHandler:
             )
 
     def prepare_boreas_alive_test(self):
-        """ Set alive_test for Boreas if
-        test_alive_hosts_only scanner config was set"""
+        """ Set alive_test for Boreas if boreas scanner config
+        (BOREAS_SETTING_NAME) was set"""
         settings = Openvas.get_settings()
         alive_test = -1
 
         if settings:
-            test_alive_hosts_only = settings.get('test_alive_hosts_only')
-            if not test_alive_hosts_only:
+            boreas = settings.get(BOREAS_SETTING_NAME)
+            if not boreas:
                 return
             alive_test_str = self.target_options.get('alive_test')
             if alive_test_str is not None:
@@ -417,6 +417,8 @@ class PreferenceHandler:
             else:
                 alive_test = AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT
 
+        # If a valid alive_test was set then the bit mask
+        # has value between 31 (11111) and 1 (10000)
         if 1 <= alive_test <= 31:
             pref = "{pref_key}|||{pref_value}".format(
                 pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -47,10 +47,14 @@ OID_ESXI_AUTH = "1.3.6.1.4.1.25623.1.0.105058"
 OID_SNMP_AUTH = "1.3.6.1.4.1.25623.1.0.105076"
 OID_PING_HOST = "1.3.6.1.4.1.25623.1.0.100315"
 
+BOREAS_ALIVE_TEST = "ALIVE_TEST"
+BOREAS = "test_alive_hosts_only"
+
 
 class AliveTest(IntEnum):
     """ Alive Tests. """
 
+    ALIVE_TEST_SCAN_CONFIG_DEFAULT = 0
     ALIVE_TEST_TCP_ACK_SERVICE = 1
     ALIVE_TEST_ICMP = 2
     ALIVE_TEST_ARP = 4
@@ -379,37 +383,52 @@ class PreferenceHandler:
         return target_opt_prefs_list
 
     def prepare_alive_test_option_for_openvas(self):
-        """ Set alive test option. Overwrite the scan config settings.
-        Check if test_alive_hosts_only feature of openvas is active.
-        If active, put ALIVE_TEST enum in preferences. """
+        """ Set alive test option. Overwrite the scan config settings."""
         settings = Openvas.get_settings()
+        if settings and self.target_options.get('alive_test'):
+            alive_test_opt = self.build_alive_test_opt_as_prefs(
+                self.target_options
+            )
+            self.kbdb.add_scan_preferences(
+                self._openvas_scan_id, alive_test_opt
+            )
+
+    def prepare_boreas_alive_test(self):
+        """ Set alive_test for Boreas if
+        test_alive_hosts_only scanner config was set"""
+        settings = Openvas.get_settings()
+        alive_test = -1
+
         if settings:
             test_alive_hosts_only = settings.get('test_alive_hosts_only')
-            if test_alive_hosts_only:
-                if self.target_options.get('alive_test'):
-                    try:
-                        alive_test = int(self.target_options.get('alive_test'))
-                    except ValueError:
-                        logger.debug(
-                            'Alive test settings not applied. '
-                            'Invalid alive test value %s',
-                            self.target_options.get('alive_test'),
-                        )
-                    # Put ALIVE_TEST enum in db, this is then taken
-                    # by openvas to determine the method to use
-                    # for the alive test.
-                    if alive_test >= 1 and alive_test <= 31:
-                        item = 'ALIVE_TEST|||%s' % str(alive_test)
-                        self.kbdb.add_scan_preferences(
-                            self._openvas_scan_id, [item]
-                        )
-            elif self.target_options.get('alive_test'):
-                alive_test_opt = self.build_alive_test_opt_as_prefs(
-                    self.target_options
-                )
-                self.kbdb.add_scan_preferences(
-                    self._openvas_scan_id, alive_test_opt
-                )
+            if not test_alive_hosts_only:
+                return
+            alive_test_str = self.target_options.get('alive_test')
+            if alive_test_str is not None:
+                try:
+                    alive_test = int(alive_test_str)
+                except ValueError:
+                    logger.debug(
+                        'Alive test preference for Boreas not set. '
+                        'Invalid alive test value %s.',
+                        alive_test_str,
+                    )
+            # ALIVE_TEST_SCAN_CONFIG_DEFAULT if no alive_test provided
+            else:
+                alive_test = AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT
+
+        if 1 <= alive_test <= 31:
+            pref = "{pref_key}|||{pref_value}".format(
+                pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
+            )
+            self.kbdb.add_scan_preferences(self._openvas_scan_id, [pref])
+
+        if alive_test == AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT:
+            alive_test = AliveTest.ALIVE_TEST_ICMP
+            pref = "{pref_key}|||{pref_value}".format(
+                pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
+            )
+            self.kbdb.add_scan_preferences(self._openvas_scan_id, [pref])
 
     def prepare_reverse_lookup_opt_for_openvas(self):
         """ Set reverse lookup options in the kb"""

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -32,7 +32,7 @@ import ospd_openvas.db
 from ospd_openvas.openvas import Openvas
 from ospd_openvas.preferencehandler import (
     AliveTest,
-    BOREAS,
+    BOREAS_SETTING_NAME,
     BOREAS_ALIVE_TEST,
     PreferenceHandler,
 )
@@ -427,7 +427,7 @@ class PreferenceHandlerTestCase(TestCase):
 
     @patch('ospd_openvas.db.KbDB')
     def test_set_boreas_alive_test_with_settings(self, mock_kb):
-        # No BOREAS config setting set
+        # No Boreas config setting (BOREAS_SETTING_NAME) set
         w = DummyDaemon()
         ov_setting = {'not_the_correct_setting': 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
@@ -438,11 +438,11 @@ class PreferenceHandlerTestCase(TestCase):
 
             p.kbdb.add_scan_preferences.assert_not_called()
 
-        # BOREAS set but invalid alive_test.
+        # Boreas config setting set but invalid alive_test.
         w = DummyDaemon()
         t_opt = {'alive_test': "error"}
         w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
-        ov_setting = {BOREAS: 1}
+        ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
             p._openvas_scan_id = '456-789'
@@ -455,7 +455,7 @@ class PreferenceHandlerTestCase(TestCase):
         w = DummyDaemon()
         t_opt = {'alive_test': AliveTest.ALIVE_TEST_TCP_SYN_SERVICE}
         w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
-        ov_setting = {BOREAS: 1}
+        ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
             p._openvas_scan_id = '456-789'
@@ -469,7 +469,7 @@ class PreferenceHandlerTestCase(TestCase):
         w = DummyDaemon()
         t_opt = {'alive_test': AliveTest.ALIVE_TEST_ICMP}
         w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
-        ov_setting = {BOREAS: 1}
+        ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
             p._openvas_scan_id = '456-789'
@@ -483,7 +483,7 @@ class PreferenceHandlerTestCase(TestCase):
         w = DummyDaemon()
         t_opt = {'alive_test': AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT}
         w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
-        ov_setting = {BOREAS: 1}
+        ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
             p._openvas_scan_id = '456-789'


### PR DESCRIPTION
Scan Config Default is an implicit alive_test method with value 0. If alive_test is 0 then only the defaults from ping_host.nasl are used. ICMP is set as default in ping_host.nasl. Other methods can be used by overwriting the defaults of ping_host.nasl. Therefore no explicit value for "Scan Config Default" was ever set because it was not needed.

Boreas (new method for alive detection) has no default alive_test set internally therefore an explicit alive_test is always needed.
Now ICMP is set for alive_test==0. This way "Scan Config Default" can be simulated.