### PR TITLE
Drop network scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove use_mac_addr, vhost_ip and vhost scan preferences. [#184](https://github.com/greenbone/ospd-openvas/pull/184)
 - Handling of finished host for resume task. [#252](https://github.com/greenbone/ospd-openvas/pull/252)
 - Don't release vts explicitly. [#261](https://github.com/greenbone/ospd-openvas/pull/261)
+- Drop handling of network_scan. [#265](https://github.com/greenbone/ospd-openvas/pull/265)
 
 ## [1.0.1] (unreleased)
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -102,13 +102,6 @@ OSPD_PARAMS = {
         'mandatory': 1,
         'description': '',
     },
-    'network_scan': {
-        'type': 'boolean',
-        'name': 'network_scan',
-        'default': 0,
-        'mandatory': 1,
-        'description': '',
-    },
     'non_simult_ports': {
         'type': 'string',
         'name': 'non_simult_ports',

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -66,13 +66,6 @@ OSPD_PARAMS_OUT = {
         'mandatory': 1,
         'description': '',
     },
-    'network_scan': {
-        'type': 'boolean',
-        'name': 'network_scan',
-        'default': 0,
-        'mandatory': 1,
-        'description': '',
-    },
     'non_simult_ports': {
         'type': 'string',
         'name': 'non_simult_ports',


### PR DESCRIPTION
Remove handling of "network_scan" setting of openvas because openvas does not support it anymore.