### PR TITLE
Fix warning messages for DEADHOST result from boreas

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -869,7 +869,7 @@ class OSPDopenvas(OSPDaemon):
             rqod = ''
             rname = ''
             rhostname = msg[1].strip() if msg[1] else ''
-            host_is_dead = "Host dead" in msg[4]
+            host_is_dead = "Host dead" in msg[4] or msg[0] == "DEADHOST"
             host_deny = "Host access denied" in msg[4]
             vt_aux = None
 


### PR DESCRIPTION
When Boreas sends the amount of DEADHOST, the result message does not have an vt OID and a warning was logged, which was wrong. Now, no warning is shown for DEADHOST results