### PR TITLE
Log warning about unsupported scanner configs

### DIFF
--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -32,11 +32,11 @@ from typing import Optional, Dict, List, Tuple
 from base64 import b64decode
 
 from ospd.scan import ScanCollection
+from ospd.ospd import BASE_SCANNER_PARAMS
 from ospd_openvas.openvas import Openvas
 from ospd_openvas.db import KbDB
 from ospd_openvas.nvticache import NVTICache
 from ospd_openvas.vthelper import VtHelper
-
 
 logger = logging.getLogger(__name__)
 
@@ -488,6 +488,14 @@ class PreferenceHandler:
             item_type = ''
             if key in ospd_params:
                 item_type = ospd_params[key].get('type')
+            else:
+                if key not in BASE_SCANNER_PARAMS:
+                    logger.warning(
+                        "%s is a scanner only setting and should not be set "
+                        "by the client. Setting needs to be included in "
+                        "OpenVAS configuration file instead.",
+                        key,
+                    )
             if item_type == 'boolean':
                 val = _from_bool_to_str(value)
             else:


### PR DESCRIPTION
There are some problems with handling scanner params via ospd.

If a boolean openvas scanner setting is supplied via `<scanner_params>` it may not work as expected. Openvas uses `yes` and `no`, while ospd uses `1` and `0` for boolean parameters. So ospd-openvas transforms supported boolean settings from integer to string. For unsupported scanner settings this transformation is not done.
Supplying unsupported integer scanner settings via `<scanner_params>` may currently work as expected though. This can change in the future.

The scanner parameters currently supported by ospd can be retrieved via  <get_scanner_details>.
Unsupported scanner settings should be included in the config file of openvas instead.