### PR TITLE
Set new amount of dead hosts for alive detection to enable smooth progress bar

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1167,6 +1167,8 @@ class OSPDopenvas(OSPDaemon):
 
             # Scan end. No kb in use for this scan id
             if kbdb.target_is_finished(scan_id):
+                self.report_openvas_results(kbdb, scan_id)
+                self.report_openvas_scan_status(kbdb, scan_id)
                 break
 
         # Delete keys from KB related to this scan task.

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -970,7 +970,7 @@ class OSPDopenvas(OSPDaemon):
             self.scan_collection.add_result_list(scan_id, res_list)
 
         if total_dead:
-            self.scan_collection.set_amount_dead_hosts(
+            self.scan_collection.set_amount_dead_hosts_alive_detection(
                 scan_id, total_dead=total_dead
             )
 


### PR DESCRIPTION
Boreas does send updated amount of dead hosts continuously. The old amount of dead hosts as detected by boreas is
replaced by the new amount every time set_amount_dead_hosts_alive_detection is called.

Depends on: 
* https://github.com/greenbone/ospd/pull/298
* https://github.com/greenbone/gvm-libs/pull/373