### PR TITLE
Get results from main kb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.4] (unreleased)
+- Get all results from main kb. [#285](https://github.com/greenbone/ospd-openvas/pull/285)
+
+[unreleased]: https://github.com/greenbone/ospd-openvas/compare/ospd-openvas-20.08...master
+
 
 ## [20.8] (unreleased)
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -873,6 +873,7 @@ class OSPDopenvas(OSPDaemon):
             rhostname = msg[2].strip() if msg[2] else ''
             host_is_dead = "Host dead" in msg[5] or msg[0] == "DEADHOST"
             host_deny = "Host access denied" in msg[5]
+            start_end_msg = "HOST_START" == msg[0] or "HOST_END" == msg[0]
             vt_aux = None
 
             # URI is optional and msg list length must be checked
@@ -880,10 +881,20 @@ class OSPDopenvas(OSPDaemon):
             if len(msg) > 6:
                 ruri = msg[6]
 
-            if roid and not host_is_dead and not host_deny:
+            if (
+                roid
+                and not host_is_dead
+                and not host_deny
+                and not start_end_msg
+            ):
                 vt_aux = vthelper.get_single_vt(roid)
 
-            if not vt_aux and not host_is_dead and not host_deny:
+            if (
+                not vt_aux
+                and not host_is_dead
+                and not host_deny
+                and not start_end_msg
+            ):
                 logger.warning('Invalid VT oid %s for a result', roid)
 
             if vt_aux:

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -861,7 +861,6 @@ class OSPDopenvas(OSPDaemon):
         all_results = db.get_result()
         res_list = ResultList()
         total_dead = 0
-        total_results = len(all_results)
         for res in all_results:
             if not res:
                 continue
@@ -964,7 +963,7 @@ class OSPDopenvas(OSPDaemon):
                 scan_id, total_dead=total_dead
             )
 
-        return total_results > 0
+        return len(res_list) > 0
 
     def is_openvas_process_alive(
         self, kbdb: BaseDB, ovas_pid: str, openvas_scan_id: str

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -907,6 +907,11 @@ class OSPDopenvas(OSPDaemon):
                     uri=ruri,
                 )
 
+            if msg[0] == 'HOST_START' or 'HOST_END':
+                res_list.add_scan_log_to_list(
+                    host=current_host, name=msg[0], value=msg[5],
+                )
+
             if msg[0] == 'LOG':
                 res_list.add_scan_log_to_list(
                     host=current_host,
@@ -958,26 +963,6 @@ class OSPDopenvas(OSPDaemon):
             self.scan_collection.set_amount_dead_hosts(
                 scan_id, total_dead=total_dead
             )
-
-        return total_results
-
-    def report_openvas_timestamp_scan_host(
-        self, scan_db: ScanDB, scan_id: str, host: str
-    ):
-        """ Get start and end timestamp of a host scan from redis kb. """
-        timestamp = scan_db.get_host_scan_end_time()
-        if timestamp:
-            self.add_scan_log(
-                scan_id, host=host, name='HOST_END', value=timestamp
-            )
-            return
-
-        timestamp = scan_db.get_host_scan_start_time()
-        if timestamp:
-            self.add_scan_log(
-                scan_id, host=host, name='HOST_START', value=timestamp
-            )
-            return
 
     def is_openvas_process_alive(
         self, kbdb: BaseDB, ovas_pid: str, openvas_scan_id: str

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -796,7 +796,7 @@ class OSPDopenvas(OSPDaemon):
             )
         return has_openvas
 
-    def update_progress(self, scan_id: str, current_host: str, msg: str):
+    def update_progress(self, scan_id: str, msg: str):
         """ Calculate percentage and update the scan status of a host
         for the progress bar.
         Arguments:
@@ -805,7 +805,7 @@ class OSPDopenvas(OSPDaemon):
             msg: String with launched and total plugins.
         """
         try:
-            launched, total = msg.split('/')
+            current_host, launched, total = msg.split('/')
         except ValueError:
             return
 
@@ -823,19 +823,16 @@ class OSPDopenvas(OSPDaemon):
             scan_id, host=current_host, progress=host_prog
         )
 
-    def report_openvas_scan_status(
-        self, scan_db: ScanDB, scan_id: str, current_host: str
-    ):
+    def report_openvas_scan_status(self, kbdb: BaseDB, scan_id: str):
         """ Get all status entries from redis kb.
 
         Arguments:
             scan_id: Scan ID to identify the current scan.
             current_host: Host to be updated.
         """
-        res = scan_db.get_scan_status()
-        while res:
-            self.update_progress(scan_id, current_host, res)
-            res = scan_db.get_scan_status()
+        all_status = kbdb.get_scan_status()
+        for res in all_status:
+            self.update_progress(scan_id, res)
 
     def get_severity_score(self, vt_aux: dict) -> Optional[float]:
         """ Return the severity score for the given oid.

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -46,7 +46,7 @@ from ospd_openvas import __version__
 from ospd_openvas.errors import OspdOpenvasError
 
 from ospd_openvas.nvticache import NVTICache
-from ospd_openvas.db import MainDB, BaseDB, ScanDB
+from ospd_openvas.db import MainDB, BaseDB
 from ospd_openvas.lock import LockFile
 from ospd_openvas.preferencehandler import PreferenceHandler
 from ospd_openvas.openvas import Openvas
@@ -873,7 +873,7 @@ class OSPDopenvas(OSPDaemon):
             rhostname = msg[2].strip() if msg[2] else ''
             host_is_dead = "Host dead" in msg[5] or msg[0] == "DEADHOST"
             host_deny = "Host access denied" in msg[5]
-            start_end_msg = "HOST_START" == msg[0] or "HOST_END" == msg[0]
+            start_end_msg = msg[0] == "HOST_START" or msg[0] == "HOST_END"
             vt_aux = None
 
             # URI is optional and msg list length must be checked
@@ -1124,7 +1124,6 @@ class OSPDopenvas(OSPDaemon):
 
             time.sleep(1)
 
-        no_id_found = False
         while True:
             if not kbdb.target_is_finished(
                 scan_id

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -917,12 +917,12 @@ class OSPDopenvas(OSPDaemon):
                     uri=ruri,
                 )
 
-            if msg[0] == 'HOST_START' or 'HOST_END':
+            elif msg[0] == 'HOST_START' or msg[0] == 'HOST_END':
                 res_list.add_scan_log_to_list(
                     host=current_host, name=msg[0], value=msg[5],
                 )
 
-            if msg[0] == 'LOG':
+            elif msg[0] == 'LOG':
                 res_list.add_scan_log_to_list(
                     host=current_host,
                     hostname=rhostname,
@@ -934,7 +934,7 @@ class OSPDopenvas(OSPDaemon):
                     uri=ruri,
                 )
 
-            if msg[0] == 'HOST_DETAIL':
+            elif msg[0] == 'HOST_DETAIL':
                 res_list.add_scan_host_detail_to_list(
                     host=current_host,
                     hostname=rhostname,
@@ -943,7 +943,7 @@ class OSPDopenvas(OSPDaemon):
                     uri=ruri,
                 )
 
-            if msg[0] == 'ALARM':
+            elif msg[0] == 'ALARM':
                 rseverity = self.get_severity_score(vt_aux)
                 res_list.add_scan_alarm_to_list(
                     host=current_host,
@@ -959,7 +959,7 @@ class OSPDopenvas(OSPDaemon):
 
             # To process non-scanned dead hosts when
             # test_alive_host_only in openvas is enable
-            if msg[0] == 'DEADHOST':
+            elif msg[0] == 'DEADHOST':
                 try:
                     total_dead = int(msg[5])
                 except TypeError:

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -449,20 +449,6 @@ class ScanDB(BaseKbDB):
         """
         return self._get_single_item("internal/ip")
 
-    def get_host_scan_start_time(self) -> Optional[str]:
-        """ Get the timestamp of the scan start from redis.
-
-        Return a string with the timestamp of the scan start.
-        """
-        return OpenvasDB.get_last_list_item(self.ctx, "internal/start_time")
-
-    def get_host_scan_end_time(self) -> Optional[str]:
-        """ Get the timestamp of the scan end from redis.
-
-        Return a string with the timestamp of scan end .
-        """
-        return OpenvasDB.get_last_list_item(self.ctx, "internal/end_time")
-
     def host_is_finished(self, openvas_scan_id: str) -> bool:
         """ Returns true if the scan of the host is finished """
         status = self.get_status(openvas_scan_id)

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -446,21 +446,6 @@ class ScanDB(BaseKbDB):
         self.index = kbindex
         return self
 
-    def get_scan_id(self):
-        return self._get_single_item('internal/scan_id')
-
-    def get_host_ip(self) -> Optional[str]:
-        """ Get the ip of host_kb.
-
-        Return a string with the ip of the host being scanned.
-        """
-        return self._get_single_item("internal/ip")
-
-    def host_is_finished(self, openvas_scan_id: str) -> bool:
-        """ Returns true if the scan of the host is finished """
-        status = self.get_status(openvas_scan_id)
-        return status == 'finished'
-
 
 class KbDB(BaseKbDB):
     def get_scan_databases(self) -> Iterator[ScanDB]:

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -192,9 +192,12 @@ class OpenvasDB:
 
         # The results are left-pushed. To preserver the order
         # the result list must be reversed.
-        results.reverse()
+        if redis_return_code:
+            results.reverse()
+        else:
+            results = []
 
-        return results if redis_return_code else []
+        return results
 
     @staticmethod
     def get_key_count(ctx: RedisCtx, pattern: Optional[str] = None) -> int:

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -190,6 +190,10 @@ class OpenvasDB:
         pipe.delete(name)
         results, redis_return_code = pipe.execute()
 
+        # The results are left-pushed. To preserver the order
+        # the result list must be reversed.
+        results.reverse()
+
         return results if redis_return_code else []
 
     @staticmethod

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -399,6 +399,9 @@ class BaseKbDB(BaseDB):
         """
         return OpenvasDB.get_list_item(self.ctx, name)
 
+    def _pop_list_items(self, name: str) -> List:
+        return OpenvasDB.pop_list_items(self.ctx, name)
+
     def _remove_list_item(self, key: str, value: str):
         """ Remove item from the key list.
 
@@ -413,7 +416,7 @@ class BaseKbDB(BaseDB):
 
         Return the oldest scan results
         """
-        return OpenvasDB.pop_list_items(self.ctx, "internal/results")
+        return self._pop_list_items("internal/results")
 
     def get_status(self, openvas_scan_id: str) -> Optional[str]:
         """ Return the status of the host scan """
@@ -438,13 +441,6 @@ class ScanDB(BaseKbDB):
 
     def get_scan_id(self):
         return self._get_single_item('internal/scan_id')
-
-    def get_scan_status(self) -> Optional[str]:
-        """ Get and remove the oldest host scan status from the list.
-
-        Return a string which represents the host scan status.
-        """
-        return OpenvasDB.get_last_list_item(self.ctx, "internal/status")
 
     def get_host_ip(self) -> Optional[str]:
         """ Get the ip of host_kb.
@@ -531,6 +527,13 @@ class KbDB(BaseKbDB):
         """
         status = self._get_single_item('internal/%s' % openvas_scan_id)
         return status == 'stop_all'
+
+    def get_scan_status(self) -> List:
+        """ Get and remove the oldest host scan status from the list.
+
+        Return a string which represents the host scan status.
+        """
+        return self._pop_list_items("internal/status")
 
 
 class MainDB(BaseDB):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -583,7 +583,7 @@ class TestOspdOpenvas(TestCase):
         self.assertFalse(res)
         w.feed_is_outdated.assert_not_called()
 
-    @patch('ospd_openvas.daemon.ScanDB')
+    @patch('ospd_openvas.daemon.BaseDB')
     @patch('ospd_openvas.daemon.ResultList.add_scan_log_to_list')
     def test_get_openvas_result(self, mock_add_scan_log_to_list, MockDBClass):
         w = DummyDaemon()
@@ -610,7 +610,7 @@ class TestOspdOpenvas(TestCase):
             value='Host dead',
         )
 
-    @patch('ospd_openvas.daemon.ScanDB')
+    @patch('ospd_openvas.daemon.BaseDB')
     @patch('ospd_openvas.daemon.ResultList.add_scan_error_to_list')
     def test_get_openvas_result_host_deny(
         self, mock_add_scan_error_to_list, MockDBClass
@@ -638,7 +638,7 @@ class TestOspdOpenvas(TestCase):
             value='Host access denied.',
         )
 
-    @patch('ospd_openvas.daemon.ScanDB')
+    @patch('ospd_openvas.daemon.BaseDB')
     def test_get_openvas_result_dead_hosts(self, MockDBClass):
         w = DummyDaemon()
         target_element = w.create_xml_target()
@@ -656,7 +656,7 @@ class TestOspdOpenvas(TestCase):
             '123-456', total_dead=4,
         )
 
-    @patch('ospd_openvas.daemon.ScanDB')
+    @patch('ospd_openvas.daemon.BaseDB')
     @patch('ospd_openvas.daemon.ResultList.add_scan_log_to_list')
     def test_get_openvas_result_host_start(
         self, mock_add_scan_log_to_list, MockDBClass
@@ -679,7 +679,7 @@ class TestOspdOpenvas(TestCase):
             host='192.168.10.124', name='HOST_START', value='today 1',
         )
 
-    @patch('ospd_openvas.daemon.ScanDB')
+    @patch('ospd_openvas.daemon.BaseDB')
     @patch('ospd_openvas.daemon.ResultList.add_scan_alarm_to_list')
     def test_result_without_vt_oid(
         self, mock_add_scan_alarm_to_list, MockDBClass

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -196,6 +196,37 @@ class TestOpenvasDB(TestCase):
         with self.assertRaises(RequiredArgument):
             OpenvasDB.set_single_item(ctx, '1', None)
 
+    def test_pop_list_items_no_results(self, mock_redis):
+        ctx = mock_redis.return_value
+        pipeline = ctx.pipeline.return_value
+        pipeline.lrange.return_value = None
+        pipeline.delete.return_value = None
+        pipeline.execute.return_value = (None, 0)
+
+        ret = OpenvasDB.pop_list_items(ctx, 'foo')
+
+        self.assertEqual(ret, [])
+
+        pipeline.lrange.assert_called_once_with('foo', 0, -1)
+        pipeline.delete.assert_called_once_with('foo')
+        assert_called(pipeline.execute)
+
+    def test_pop_list_items_with_results(self, mock_redis):
+        ctx = mock_redis.return_value
+        pipeline = ctx.pipeline.return_value
+        pipeline.lrange.return_value = None
+        pipeline.delete.return_value = None
+        pipeline.execute.return_value = [['c', 'b', 'a'], 2]
+
+        ret = OpenvasDB.pop_list_items(ctx, 'results')
+
+        # reversed list
+        self.assertEqual(ret, ['a', 'b', 'c'])
+
+        pipeline.lrange.assert_called_once_with('results', 0, -1)
+        pipeline.delete.assert_called_once_with('results')
+        assert_called(pipeline.execute)
+
     def test_set_single_item(self, mock_redis):
         ctx = mock_redis.return_value
         pipeline = ctx.pipeline.return_value
@@ -352,36 +383,6 @@ class ScanDBTestCase(TestCase):
             self.ctx, 'internal/scan_id'
         )
 
-    def test_get_scan_status(self, mock_openvas_db):
-        mock_openvas_db.get_last_list_item.return_value = 'foo'
-
-        ret = self.db.get_scan_status()
-
-        self.assertEqual(ret, 'foo')
-        mock_openvas_db.get_last_list_item.assert_called_with(
-            self.ctx, 'internal/status'
-        )
-
-    def test_get_host_scan_start_time(self, mock_openvas_db):
-        mock_openvas_db.get_last_list_item.return_value = 'some start time'
-
-        ret = self.db.get_host_scan_start_time()
-
-        self.assertEqual(ret, 'some start time')
-        mock_openvas_db.get_last_list_item.assert_called_with(
-            self.ctx, 'internal/start_time'
-        )
-
-    def test_get_host_scan_end_time(self, mock_openvas_db):
-        mock_openvas_db.get_last_list_item.return_value = 'some end time'
-
-        ret = self.db.get_host_scan_end_time()
-
-        self.assertEqual(ret, 'some end time')
-        mock_openvas_db.get_last_list_item.assert_called_with(
-            self.ctx, 'internal/end_time'
-        )
-
     def test_get_host_ip(self, mock_openvas_db):
         mock_openvas_db.get_single_item.return_value = '192.168.0.1'
 
@@ -445,6 +446,21 @@ class KbDBTestCase(TestCase):
         self.assertEqual(ret, 'some status')
         mock_openvas_db.get_single_item.assert_called_with(
             self.ctx, 'internal/foo'
+        )
+
+    def test_get_scan_status(self, mock_openvas_db):
+        status = [
+            '192.168.0.1/10/120',
+            '192.168.0.2/35/120',
+        ]
+
+        mock_openvas_db.pop_list_items.return_value = status
+
+        ret = self.db.get_scan_status()
+
+        self.assertEqual(ret, status)
+        mock_openvas_db.pop_list_items.assert_called_with(
+            self.ctx, 'internal/status'
         )
 
     def test_flush(self, mock_openvas_db):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -373,46 +373,6 @@ class ScanDBTestCase(TestCase):
 
         mock_openvas_db.select_database.assert_called_with(self.ctx, 11)
 
-    def test_get_scan_id(self, mock_openvas_db):
-        mock_openvas_db.get_single_item.return_value = 'foo'
-
-        ret = self.db.get_scan_id()
-
-        self.assertEqual(ret, 'foo')
-        mock_openvas_db.get_single_item.assert_called_with(
-            self.ctx, 'internal/scan_id'
-        )
-
-    def test_get_host_ip(self, mock_openvas_db):
-        mock_openvas_db.get_single_item.return_value = '192.168.0.1'
-
-        ret = self.db.get_host_ip()
-
-        self.assertEqual(ret, '192.168.0.1')
-        mock_openvas_db.get_single_item.assert_called_with(
-            self.ctx, 'internal/ip'
-        )
-
-    def test_host_is_finished_false(self, mock_openvas_db):
-        mock_openvas_db.get_single_item.return_value = 'foo'
-
-        ret = self.db.host_is_finished('bar')
-
-        self.assertFalse(ret)
-        mock_openvas_db.get_single_item.assert_called_with(
-            self.ctx, 'internal/bar'
-        )
-
-    def test_host_is_finished_true(self, mock_openvas_db):
-        mock_openvas_db.get_single_item.return_value = 'finished'
-
-        ret = self.db.host_is_finished('bar')
-
-        self.assertTrue(ret)
-        mock_openvas_db.get_single_item.assert_called_with(
-            self.ctx, 'internal/bar'
-        )
-
     def test_flush(self, mock_openvas_db):
         self.db.flush()
 


### PR DESCRIPTION
OpenVAS stores now the results in the main task DB and all results are stored in the same internal/results kb in the main kb.
This allows to get all results stored in redis for all target's hosts at once. Also, avoid to loop looking for results in each single host kb.
Because it does not check the host kbs, ospd-openvas does not release them anymore and this is done by OpenVAS, unless in edge cases in which a scan is stopped or OpenVAS dies unexpectedly, ospd-openvas does the redis cleanup.