### PR TITLE
Add missing scanner params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   managing the version information in ospd-openvas [#238](https://github.com/greenbone/ospd-openvas/pull/238)
 - Pass store directory to OSPDaemon init [#266](https://github.com/greenbone/ospd-openvas/pull/266)
 - Add URI field to results for file path or webservice URL [#271](https://github.com/greenbone/ospd-openvas/pull/271)
+- Add element to OSPD_PARAMS entries to indicate visibility for client. [#293](https://github.com/greenbone/ospd-openvas/pull/293)
 
 ### Changed
 - Less strict checks for the nvti cache version

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -231,11 +231,11 @@ OSPD_PARAMS = {
         'mandatory': 0,
         'visible_for_client': 0,
         'description': (
-            'Is maximum number of hosts to test at the same time which'
-            + 'should be given to the client (which can override it).'
-            + 'This value must be computed given  your bandwidth,'
-            + 'the number of hosts you want to test, your amount of'
-            + 'memory and the horsepower of your processor(s).'
+            'The maximum number of hosts to test at the same time which '
+            + 'should be given to the client (which can override it). '
+            + 'This value must be computed given your bandwidth, '
+            + 'the number of hosts you want to test, your amount of '
+            + 'memory and the performance of your processor(s).'
         ),
     },
     'max_checks': {
@@ -245,14 +245,14 @@ OSPD_PARAMS = {
         'mandatory': 0,
         'visible_for_client': 0,
         'description': (
-            'is the number of plugins that will run against each host being'
-            + ' tested. Note that the total number of process will be max'
-            + ' checks x max_hosts so you need to find a balance between'
-            + ' these two options. Note that launching too many plugins at'
-            + ' the same time may disable the remote host, either temporarily'
-            + ' (ie: inetd closes its ports) or definitely (the remote host'
-            + ' crash because it is asked to do too many things at the'
-            + ' same time), so be careful.'
+            'The number of plugins that will run against each host being '
+            + 'tested. Note that the total number of process will be max '
+            + 'checks x max_hosts so you need to find a balance between '
+            + 'these two options. Note that launching too many plugins at '
+            + 'the same time may disable the remote host, either temporarily '
+            + '(ie: inetd closes its ports) or definitely (the remote host '
+            + 'crash because it is asked to do too many things at the '
+            + 'same time), so be careful.'
         ),
     },
     'port_range': {
@@ -268,7 +268,7 @@ OSPD_PARAMS = {
             + 'ranges of ports ("1-1500,32000-33000"). Note that you can '
             + 'specify UDP and TCP ports by prefixing each range by T or U. '
             + 'For instance, the following range will make openvas scan UDP '
-            + ' ports 1 to 1024 and TCP ports 1 to 65535 : '
+            + 'ports 1 to 1024 and TCP ports 1 to 65535 : '
             + '"T:1-65535,U:1-1024".'
         ),
     },
@@ -294,7 +294,7 @@ OSPD_PARAMS = {
         'visible_for_client': 0,
         'description': (
             'Name of the network interface that will be used as the source '
-            + 'of connections established by OpenVAS. The scan won\'t be '
+            + 'of connections established by openvas. The scan won\'t be '
             + 'launched if the value isn\'t authorized according to '
             + '(sys_)ifaces_allow / (sys_)ifaces_deny if present.'
         ),

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -96,13 +96,6 @@ OSPD_PARAMS = {
             + 'wait for when doing a recv()'
         ),
     },
-    'drop_privileges': {
-        'type': 'boolean',
-        'name': 'drop_privileges',
-        'default': 0,
-        'mandatory': 1,
-        'description': '',
-    },
     'non_simult_ports': {
         'type': 'string',
         'name': 'non_simult_ports',

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -77,6 +77,7 @@ OSPD_PARAMS = {
         'name': 'auto_enable_dependencies',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Automatically enable the plugins that are depended on',
     },
     'cgi_path': {
@@ -84,6 +85,7 @@ OSPD_PARAMS = {
         'name': 'cgi_path',
         'default': '/cgi-bin:/scripts',
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Look for default CGIs in /cgi-bin and /scripts',
     },
     'checks_read_timeout': {
@@ -91,6 +93,7 @@ OSPD_PARAMS = {
         'name': 'checks_read_timeout',
         'default': 5,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': (
             'Number  of seconds that the security checks will '
             + 'wait for when doing a recv()'
@@ -101,6 +104,7 @@ OSPD_PARAMS = {
         'name': 'non_simult_ports',
         'default': '139, 445, 3389, Services/irc',
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': (
             'Prevent to make two connections on the same given '
             + 'ports at the same time.'
@@ -111,6 +115,7 @@ OSPD_PARAMS = {
         'name': 'open_sock_max_attempts',
         'default': 5,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': (
             'Number of unsuccessful retries to open the socket '
             + 'before to set the port as closed.'
@@ -121,6 +126,7 @@ OSPD_PARAMS = {
         'name': 'timeout_retry',
         'default': 5,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': (
             'Number of retries when a socket connection attempt ' + 'timesout.'
         ),
@@ -130,6 +136,7 @@ OSPD_PARAMS = {
         'name': 'optimize_test',
         'default': 5,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': (
             'By default, openvas does not trust the remote ' + 'host banners.'
         ),
@@ -139,6 +146,7 @@ OSPD_PARAMS = {
         'name': 'plugins_timeout',
         'default': 5,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'This is the maximum lifetime, in seconds of a plugin.',
     },
     'report_host_details': {
@@ -146,6 +154,7 @@ OSPD_PARAMS = {
         'name': 'report_host_details',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': '',
     },
     'safe_checks': {
@@ -153,6 +162,7 @@ OSPD_PARAMS = {
         'name': 'safe_checks',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': (
             'Disable the plugins with potential to crash '
             + 'the remote services'
@@ -163,6 +173,7 @@ OSPD_PARAMS = {
         'name': 'scanner_plugins_timeout',
         'default': 36000,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Like plugins_timeout, but for ACT_SCANNER plugins.',
     },
     'time_between_request': {
@@ -170,6 +181,7 @@ OSPD_PARAMS = {
         'name': 'time_between_request',
         'default': 0,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': (
             'Allow to set a wait time between two actions '
             + '(open, send, close).'
@@ -180,6 +192,7 @@ OSPD_PARAMS = {
         'name': 'unscanned_closed',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': '',
     },
     'unscanned_closed_udp': {
@@ -187,6 +200,7 @@ OSPD_PARAMS = {
         'name': 'unscanned_closed_udp',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': '',
     },
     'expand_vhosts': {
@@ -194,6 +208,7 @@ OSPD_PARAMS = {
         'name': 'expand_vhosts',
         'default': 1,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'Whether to expand the target hosts '
         + 'list of vhosts with values gathered from sources '
         + 'such as reverse-lookup queries and VT checks '
@@ -204,9 +219,135 @@ OSPD_PARAMS = {
         'name': 'test_empty_vhost',
         'default': 0,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'If  set  to  yes, the scanner will '
         + 'also test the target by using empty vhost value '
         + 'in addition to the targets associated vhost values.',
+    },
+    'max_hosts': {
+        'type': 'integer',
+        'name': 'max_hosts',
+        'default': 30,
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Is maximum number of hosts to test at the same time which'
+            + 'should be given to the client (which can override it).'
+            + 'This value must be computed given  your bandwidth,'
+            + 'the number of hosts you want to test, your amount of'
+            + 'memory and the horsepower of your processor(s).'
+        ),
+    },
+    'max_checks': {
+        'type': 'integer',
+        'name': 'max_checks',
+        'default': 10,
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'is the number of plugins that will run against each host being'
+            + ' tested. Note that the total number of process will be max'
+            + ' checks x max_hosts so you need to find a balance between'
+            + ' these two options. Note that launching too many plugins at'
+            + ' the same time may disable the remote host, either temporarily'
+            + ' (ie: inetd closes its ports) or definitely (the remote host'
+            + ' crash because it is asked to do too many things at the'
+            + ' same time), so be careful.'
+        ),
+    },
+    'port_range': {
+        'type': 'string',
+        'name': 'port_range',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'This is the default range of ports that the scanner plugins will '
+            + 'probe. The syntax of this option is flexible, it can be a '
+            + 'single range ("1-1500"), several ports ("21,23,80"), several '
+            + 'ranges of ports ("1-1500,32000-33000"). Note that you can '
+            + 'specify UDP and TCP ports by prefixing each range by T or U. '
+            + 'For instance, the following range will make openvas scan UDP '
+            + ' ports 1 to 1024 and TCP ports 1 to 65535 : '
+            + '"T:1-65535,U:1-1024".'
+        ),
+    },
+    'test_alive_hosts_only': {
+        'type': 'boolean',
+        'name': 'test_alive_hosts_only',
+        'default': 0,
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'If this option is set, openvas will scan the target list for '
+            + 'alive hosts in a separate process while only testing those '
+            + 'hosts which are identified as alive. This boosts the scan '
+            + 'speed of target ranges with a high amount of dead hosts '
+            + 'significantly.'
+        ),
+    },
+    'source_iface': {
+        'type': 'string',
+        'name': 'source_iface',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Name of the network interface that will be used as the source '
+            + 'of connections established by OpenVAS. The scan won\'t be '
+            + 'launched if the value isn\'t authorized according to '
+            + '(sys_)ifaces_allow / (sys_)ifaces_deny if present.'
+        ),
+    },
+    'ifaces_allow': {
+        'type': 'string',
+        'name': 'ifaces_allow',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Comma-separated list of interfaces names that are authorized '
+            + 'as source_iface values.'
+        ),
+    },
+    'ifaces_deny': {
+        'type': 'string',
+        'name': 'ifaces_deny',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Comma-separated list of interfaces names that are not '
+            + 'authorized as source_iface values.'
+        ),
+    },
+    'hosts_allow': {
+        'type': 'string',
+        'name': 'hosts_allow',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Comma-separated list of the only targets that are authorized '
+            + 'to be scanned. Supports the same syntax as the list targets. '
+            + 'Both target hostnames and the address to which they resolve '
+            + 'are checked. Hostnames in hosts_allow list are not resolved '
+            + 'however.'
+        ),
+    },
+    'hosts_deny': {
+        'type': 'string',
+        'name': 'hosts_deny',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Comma-separated list of targets that are not authorized to '
+            + 'be scanned. Supports the same syntax as the list targets. '
+            + 'Both target hostnames and the address to which they resolve '
+            + 'are checked. Hostnames in hosts_deny list are not '
+            + 'resolved however.'
+        ),
     },
 }
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -77,7 +77,7 @@ OSPD_PARAMS = {
         'name': 'auto_enable_dependencies',
         'default': 1,
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': 'Automatically enable the plugins that are depended on',
     },
     'cgi_path': {
@@ -85,7 +85,7 @@ OSPD_PARAMS = {
         'name': 'cgi_path',
         'default': '/cgi-bin:/scripts',
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': 'Look for default CGIs in /cgi-bin and /scripts',
     },
     'checks_read_timeout': {
@@ -93,7 +93,7 @@ OSPD_PARAMS = {
         'name': 'checks_read_timeout',
         'default': 5,
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': (
             'Number  of seconds that the security checks will '
             + 'wait for when doing a recv()'
@@ -104,7 +104,7 @@ OSPD_PARAMS = {
         'name': 'non_simult_ports',
         'default': '139, 445, 3389, Services/irc',
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': (
             'Prevent to make two connections on the same given '
             + 'ports at the same time.'
@@ -115,7 +115,7 @@ OSPD_PARAMS = {
         'name': 'open_sock_max_attempts',
         'default': 5,
         'mandatory': 0,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': (
             'Number of unsuccessful retries to open the socket '
             + 'before to set the port as closed.'
@@ -126,7 +126,7 @@ OSPD_PARAMS = {
         'name': 'timeout_retry',
         'default': 5,
         'mandatory': 0,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': (
             'Number of retries when a socket connection attempt ' + 'timesout.'
         ),
@@ -136,7 +136,7 @@ OSPD_PARAMS = {
         'name': 'optimize_test',
         'default': 5,
         'mandatory': 0,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': (
             'By default, openvas does not trust the remote ' + 'host banners.'
         ),
@@ -146,7 +146,7 @@ OSPD_PARAMS = {
         'name': 'plugins_timeout',
         'default': 5,
         'mandatory': 0,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': 'This is the maximum lifetime, in seconds of a plugin.',
     },
     'report_host_details': {
@@ -154,7 +154,7 @@ OSPD_PARAMS = {
         'name': 'report_host_details',
         'default': 1,
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': '',
     },
     'safe_checks': {
@@ -162,7 +162,7 @@ OSPD_PARAMS = {
         'name': 'safe_checks',
         'default': 1,
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': (
             'Disable the plugins with potential to crash '
             + 'the remote services'
@@ -173,7 +173,7 @@ OSPD_PARAMS = {
         'name': 'scanner_plugins_timeout',
         'default': 36000,
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': 'Like plugins_timeout, but for ACT_SCANNER plugins.',
     },
     'time_between_request': {
@@ -181,7 +181,7 @@ OSPD_PARAMS = {
         'name': 'time_between_request',
         'default': 0,
         'mandatory': 0,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': (
             'Allow to set a wait time between two actions '
             + '(open, send, close).'
@@ -192,7 +192,7 @@ OSPD_PARAMS = {
         'name': 'unscanned_closed',
         'default': 1,
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': '',
     },
     'unscanned_closed_udp': {
@@ -200,7 +200,7 @@ OSPD_PARAMS = {
         'name': 'unscanned_closed_udp',
         'default': 1,
         'mandatory': 1,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': '',
     },
     'expand_vhosts': {
@@ -208,7 +208,7 @@ OSPD_PARAMS = {
         'name': 'expand_vhosts',
         'default': 1,
         'mandatory': 0,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': 'Whether to expand the target hosts '
         + 'list of vhosts with values gathered from sources '
         + 'such as reverse-lookup queries and VT checks '
@@ -219,7 +219,7 @@ OSPD_PARAMS = {
         'name': 'test_empty_vhost',
         'default': 0,
         'mandatory': 0,
-        'visible_for_client': 1,
+        'visible_for_client': True,
         'description': 'If  set  to  yes, the scanner will '
         + 'also test the target by using empty vhost value '
         + 'in addition to the targets associated vhost values.',
@@ -229,7 +229,7 @@ OSPD_PARAMS = {
         'name': 'max_hosts',
         'default': 30,
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'The maximum number of hosts to test at the same time which '
             + 'should be given to the client (which can override it). '
@@ -243,7 +243,7 @@ OSPD_PARAMS = {
         'name': 'max_checks',
         'default': 10,
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'The number of plugins that will run against each host being '
             + 'tested. Note that the total number of process will be max '
@@ -260,7 +260,7 @@ OSPD_PARAMS = {
         'name': 'port_range',
         'default': '',
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'This is the default range of ports that the scanner plugins will '
             + 'probe. The syntax of this option is flexible, it can be a '
@@ -277,7 +277,7 @@ OSPD_PARAMS = {
         'name': 'test_alive_hosts_only',
         'default': 0,
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'If this option is set, openvas will scan the target list for '
             + 'alive hosts in a separate process while only testing those '
@@ -291,7 +291,7 @@ OSPD_PARAMS = {
         'name': 'source_iface',
         'default': '',
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'Name of the network interface that will be used as the source '
             + 'of connections established by openvas. The scan won\'t be '
@@ -304,7 +304,7 @@ OSPD_PARAMS = {
         'name': 'ifaces_allow',
         'default': '',
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'Comma-separated list of interfaces names that are authorized '
             + 'as source_iface values.'
@@ -315,7 +315,7 @@ OSPD_PARAMS = {
         'name': 'ifaces_deny',
         'default': '',
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'Comma-separated list of interfaces names that are not '
             + 'authorized as source_iface values.'
@@ -326,7 +326,7 @@ OSPD_PARAMS = {
         'name': 'hosts_allow',
         'default': '',
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'Comma-separated list of the only targets that are authorized '
             + 'to be scanned. Supports the same syntax as the list targets. '
@@ -340,7 +340,7 @@ OSPD_PARAMS = {
         'name': 'hosts_deny',
         'default': '',
         'mandatory': 0,
-        'visible_for_client': 0,
+        'visible_for_client': False,
         'description': (
             'Comma-separated list of targets that are not authorized to '
             + 'be scanned. Supports the same syntax as the list targets. '

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -500,6 +500,10 @@ class PreferenceHandler:
                 val = _from_bool_to_str(value)
             else:
                 val = str(value)
+            # Do not add options which only have the empty string as value.
+            # We may run into problems on openvas side otherwise.
+            if val == '':
+                continue
             prefs_val.append(key + "|||" + val)
 
         self.kbdb.add_scan_preferences(self._openvas_scan_id, prefs_val)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -59,17 +59,21 @@ OSPD_PARAMS_OUT = {
         'default': 5,
         'mandatory': 1,
         'visible_for_client': 1,
-        'description': 'Number  of seconds that the security checks will '
-        'wait for when doing a recv()',
+        'description': (
+            'Number  of seconds that the security checks will '
+            + 'wait for when doing a recv()'
+        ),
     },
     'non_simult_ports': {
         'type': 'string',
         'name': 'non_simult_ports',
-        'default': '22',
+        'default': '139, 445, 3389, Services/irc',
         'mandatory': 1,
         'visible_for_client': 1,
-        'description': 'Prevent to make two connections on the same given '
-        'ports at the same time.',
+        'description': (
+            'Prevent to make two connections on the same given '
+            + 'ports at the same time.'
+        ),
     },
     'open_sock_max_attempts': {
         'type': 'integer',
@@ -77,8 +81,10 @@ OSPD_PARAMS_OUT = {
         'default': 5,
         'mandatory': 0,
         'visible_for_client': 1,
-        'description': 'Number of unsuccessful retries to open the socket '
-        'before to set the port as closed.',
+        'description': (
+            'Number of unsuccessful retries to open the socket '
+            + 'before to set the port as closed.'
+        ),
     },
     'timeout_retry': {
         'type': 'integer',
@@ -86,8 +92,9 @@ OSPD_PARAMS_OUT = {
         'default': 5,
         'mandatory': 0,
         'visible_for_client': 1,
-        'description': 'Number of retries when a socket connection attempt '
-        'timesout.',
+        'description': (
+            'Number of retries when a socket connection attempt ' + 'timesout.'
+        ),
     },
     'optimize_test': {
         'type': 'integer',
@@ -95,8 +102,9 @@ OSPD_PARAMS_OUT = {
         'default': 5,
         'mandatory': 0,
         'visible_for_client': 1,
-        'description': 'By default, openvas does not trust the remote '
-        'host banners.',
+        'description': (
+            'By default, openvas does not trust the remote ' + 'host banners.'
+        ),
     },
     'plugins_timeout': {
         'type': 'integer',
@@ -120,8 +128,10 @@ OSPD_PARAMS_OUT = {
         'default': 1,
         'mandatory': 1,
         'visible_for_client': 1,
-        'description': 'Disable the plugins with potential to crash '
-        'the remote services',
+        'description': (
+            'Disable the plugins with potential to crash '
+            + 'the remote services'
+        ),
     },
     'scanner_plugins_timeout': {
         'type': 'integer',
@@ -137,8 +147,10 @@ OSPD_PARAMS_OUT = {
         'default': 0,
         'mandatory': 0,
         'visible_for_client': 1,
-        'description': 'Allow to set a wait time between two actions '
-        '(open, send, close).',
+        'description': (
+            'Allow to set a wait time between two actions '
+            + '(open, send, close).'
+        ),
     },
     'unscanned_closed': {
         'type': 'boolean',
@@ -184,11 +196,11 @@ OSPD_PARAMS_OUT = {
         'mandatory': 0,
         'visible_for_client': 0,
         'description': (
-            'Is maximum number of hosts to test at the same time which'
-            + 'should be given to the client (which can override it).'
-            + 'This value must be computed given  your bandwidth,'
-            + 'the number of hosts you want to test, your amount of'
-            + 'memory and the horsepower of your processor(s).'
+            'The maximum number of hosts to test at the same time which '
+            + 'should be given to the client (which can override it). '
+            + 'This value must be computed given your bandwidth, '
+            + 'the number of hosts you want to test, your amount of '
+            + 'memory and the performance of your processor(s).'
         ),
     },
     'max_checks': {
@@ -198,14 +210,14 @@ OSPD_PARAMS_OUT = {
         'mandatory': 0,
         'visible_for_client': 0,
         'description': (
-            'is the number of plugins that will run against each host being'
-            + ' tested. Note that the total number of process will be max'
-            + ' checks x max_hosts so you need to find a balance between'
-            + ' these two options. Note that launching too many plugins at'
-            + ' the same time may disable the remote host, either temporarily'
-            + ' (ie: inetd closes its ports) or definitely (the remote host'
-            + ' crash because it is asked to do too many things at the'
-            + ' same time), so be careful.'
+            'The number of plugins that will run against each host being '
+            + 'tested. Note that the total number of process will be max '
+            + 'checks x max_hosts so you need to find a balance between '
+            + 'these two options. Note that launching too many plugins at '
+            + 'the same time may disable the remote host, either temporarily '
+            + '(ie: inetd closes its ports) or definitely (the remote host '
+            + 'crash because it is asked to do too many things at the '
+            + 'same time), so be careful.'
         ),
     },
     'port_range': {
@@ -221,7 +233,7 @@ OSPD_PARAMS_OUT = {
             + 'ranges of ports ("1-1500,32000-33000"). Note that you can '
             + 'specify UDP and TCP ports by prefixing each range by T or U. '
             + 'For instance, the following range will make openvas scan UDP '
-            + ' ports 1 to 1024 and TCP ports 1 to 65535 : '
+            + 'ports 1 to 1024 and TCP ports 1 to 65535 : '
             + '"T:1-65535,U:1-1024".'
         ),
     },
@@ -247,7 +259,7 @@ OSPD_PARAMS_OUT = {
         'visible_for_client': 0,
         'description': (
             'Name of the network interface that will be used as the source '
-            + 'of connections established by OpenVAS. The scan won\'t be '
+            + 'of connections established by openvas. The scan won\'t be '
             + 'launched if the value isn\'t authorized according to '
             + '(sys_)ifaces_allow / (sys_)ifaces_deny if present.'
         ),
@@ -309,7 +321,7 @@ class TestOspdOpenvas(TestCase):
     @patch('ospd_openvas.daemon.Openvas')
     def test_set_params_from_openvas_settings(self, mock_openvas: Openvas):
         mock_openvas.get_settings.return_value = {
-            'non_simult_ports': '22',
+            'non_simult_ports': '139, 445, 3389, Services/irc',
             'plugins_folder': '/foo/bar',
         }
         w = DummyDaemon()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -42,6 +42,7 @@ OSPD_PARAMS_OUT = {
         'name': 'auto_enable_dependencies',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Automatically enable the plugins that are depended on',
     },
     'cgi_path': {
@@ -49,6 +50,7 @@ OSPD_PARAMS_OUT = {
         'name': 'cgi_path',
         'default': '/cgi-bin:/scripts',
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Look for default CGIs in /cgi-bin and /scripts',
     },
     'checks_read_timeout': {
@@ -56,21 +58,16 @@ OSPD_PARAMS_OUT = {
         'name': 'checks_read_timeout',
         'default': 5,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Number  of seconds that the security checks will '
         'wait for when doing a recv()',
-    },
-    'drop_privileges': {
-        'type': 'boolean',
-        'name': 'drop_privileges',
-        'default': 0,
-        'mandatory': 1,
-        'description': '',
     },
     'non_simult_ports': {
         'type': 'string',
         'name': 'non_simult_ports',
         'default': '22',
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Prevent to make two connections on the same given '
         'ports at the same time.',
     },
@@ -79,6 +76,7 @@ OSPD_PARAMS_OUT = {
         'name': 'open_sock_max_attempts',
         'default': 5,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'Number of unsuccessful retries to open the socket '
         'before to set the port as closed.',
     },
@@ -87,6 +85,7 @@ OSPD_PARAMS_OUT = {
         'name': 'timeout_retry',
         'default': 5,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'Number of retries when a socket connection attempt '
         'timesout.',
     },
@@ -95,6 +94,7 @@ OSPD_PARAMS_OUT = {
         'name': 'optimize_test',
         'default': 5,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'By default, openvas does not trust the remote '
         'host banners.',
     },
@@ -103,6 +103,7 @@ OSPD_PARAMS_OUT = {
         'name': 'plugins_timeout',
         'default': 5,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'This is the maximum lifetime, in seconds of a plugin.',
     },
     'report_host_details': {
@@ -110,6 +111,7 @@ OSPD_PARAMS_OUT = {
         'name': 'report_host_details',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': '',
     },
     'safe_checks': {
@@ -117,6 +119,7 @@ OSPD_PARAMS_OUT = {
         'name': 'safe_checks',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Disable the plugins with potential to crash '
         'the remote services',
     },
@@ -125,6 +128,7 @@ OSPD_PARAMS_OUT = {
         'name': 'scanner_plugins_timeout',
         'default': 36000,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': 'Like plugins_timeout, but for ACT_SCANNER plugins.',
     },
     'time_between_request': {
@@ -132,6 +136,7 @@ OSPD_PARAMS_OUT = {
         'name': 'time_between_request',
         'default': 0,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'Allow to set a wait time between two actions '
         '(open, send, close).',
     },
@@ -140,6 +145,7 @@ OSPD_PARAMS_OUT = {
         'name': 'unscanned_closed',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': '',
     },
     'unscanned_closed_udp': {
@@ -147,6 +153,7 @@ OSPD_PARAMS_OUT = {
         'name': 'unscanned_closed_udp',
         'default': 1,
         'mandatory': 1,
+        'visible_for_client': 1,
         'description': '',
     },
     'expand_vhosts': {
@@ -154,6 +161,7 @@ OSPD_PARAMS_OUT = {
         'name': 'expand_vhosts',
         'default': 1,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'Whether to expand the target hosts '
         + 'list of vhosts with values gathered from sources '
         + 'such as reverse-lookup queries and VT checks '
@@ -164,9 +172,135 @@ OSPD_PARAMS_OUT = {
         'name': 'test_empty_vhost',
         'default': 0,
         'mandatory': 0,
+        'visible_for_client': 1,
         'description': 'If  set  to  yes, the scanner will '
         + 'also test the target by using empty vhost value '
         + 'in addition to the targets associated vhost values.',
+    },
+    'max_hosts': {
+        'type': 'integer',
+        'name': 'max_hosts',
+        'default': 30,
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Is maximum number of hosts to test at the same time which'
+            + 'should be given to the client (which can override it).'
+            + 'This value must be computed given  your bandwidth,'
+            + 'the number of hosts you want to test, your amount of'
+            + 'memory and the horsepower of your processor(s).'
+        ),
+    },
+    'max_checks': {
+        'type': 'integer',
+        'name': 'max_checks',
+        'default': 10,
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'is the number of plugins that will run against each host being'
+            + ' tested. Note that the total number of process will be max'
+            + ' checks x max_hosts so you need to find a balance between'
+            + ' these two options. Note that launching too many plugins at'
+            + ' the same time may disable the remote host, either temporarily'
+            + ' (ie: inetd closes its ports) or definitely (the remote host'
+            + ' crash because it is asked to do too many things at the'
+            + ' same time), so be careful.'
+        ),
+    },
+    'port_range': {
+        'type': 'string',
+        'name': 'port_range',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'This is the default range of ports that the scanner plugins will '
+            + 'probe. The syntax of this option is flexible, it can be a '
+            + 'single range ("1-1500"), several ports ("21,23,80"), several '
+            + 'ranges of ports ("1-1500,32000-33000"). Note that you can '
+            + 'specify UDP and TCP ports by prefixing each range by T or U. '
+            + 'For instance, the following range will make openvas scan UDP '
+            + ' ports 1 to 1024 and TCP ports 1 to 65535 : '
+            + '"T:1-65535,U:1-1024".'
+        ),
+    },
+    'test_alive_hosts_only': {
+        'type': 'boolean',
+        'name': 'test_alive_hosts_only',
+        'default': 0,
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'If this option is set, openvas will scan the target list for '
+            + 'alive hosts in a separate process while only testing those '
+            + 'hosts which are identified as alive. This boosts the scan '
+            + 'speed of target ranges with a high amount of dead hosts '
+            + 'significantly.'
+        ),
+    },
+    'source_iface': {
+        'type': 'string',
+        'name': 'source_iface',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Name of the network interface that will be used as the source '
+            + 'of connections established by OpenVAS. The scan won\'t be '
+            + 'launched if the value isn\'t authorized according to '
+            + '(sys_)ifaces_allow / (sys_)ifaces_deny if present.'
+        ),
+    },
+    'ifaces_allow': {
+        'type': 'string',
+        'name': 'ifaces_allow',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Comma-separated list of interfaces names that are authorized '
+            + 'as source_iface values.'
+        ),
+    },
+    'ifaces_deny': {
+        'type': 'string',
+        'name': 'ifaces_deny',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Comma-separated list of interfaces names that are not '
+            + 'authorized as source_iface values.'
+        ),
+    },
+    'hosts_allow': {
+        'type': 'string',
+        'name': 'hosts_allow',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Comma-separated list of the only targets that are authorized '
+            + 'to be scanned. Supports the same syntax as the list targets. '
+            + 'Both target hostnames and the address to which they resolve '
+            + 'are checked. Hostnames in hosts_allow list are not resolved '
+            + 'however.'
+        ),
+    },
+    'hosts_deny': {
+        'type': 'string',
+        'name': 'hosts_deny',
+        'default': '',
+        'mandatory': 0,
+        'visible_for_client': 0,
+        'description': (
+            'Comma-separated list of targets that are not authorized to '
+            + 'be scanned. Supports the same syntax as the list targets. '
+            + 'Both target hostnames and the address to which they resolve '
+            + 'are checked. Hostnames in hosts_deny list are not '
+            + 'resolved however.'
+        ),
     },
 }
 


### PR DESCRIPTION
* Add all `openvas` scanner parameters which are not `openvas` only parameters.
* Add flag for for parameters so we have the possibility of not showing all parameters to clients.
* Delete scanner only param `drop_privileges` from params dict.

Related PR:
https://github.com/greenbone/ospd/pull/301