### PR TITLE
Allow to change encoding used to store a key-value pair in redis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix snmp credentials. [#186](https://github.com/greenbone/ospd-openvas/pull/186)
 - Escape script name before adding the result in an xml entity. [#188](https://github.com/greenbone/ospd-openvas/pull/188)
 - Fix handling of denied hosts. [#263](https://github.com/greenbone/ospd-openvas/pull/263)
+- Fix handling of special chars in credentials. [#294](https://github.com/greenbone/ospd-openvas/pull/294)
 
 ### Removed
 - Remove use_mac_addr, vhost_ip and vhost scan preferences. [#184](https://github.com/greenbone/ospd-openvas/pull/184)

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -86,7 +86,7 @@ class OpenvasDB:
 
         Arguments:
             dbnum: The db number to connect to.
-            encoding: The enconding to be used to read and write.
+            encoding: The encoding to be used to read and write.
 
         Return a new redis context on success.
         """
@@ -374,7 +374,7 @@ class BaseKbDB(BaseDB):
     def _add_single_item(
         self, name: str, values: Iterable, utf8_enc: Optional[bool] = False
     ):
-        ''' Changing the encoding format of an existent redis context
+        ''' Changing the encoding format of an existing redis context
         is not possible. Therefore a new temporary redis context is
         created to store key-values encoded with utf-8.'''
         if utf8_enc:
@@ -518,7 +518,7 @@ class KbDB(BaseKbDB):
         self, openvas_scan_id: str, preferences: Iterable
     ):
         ''' Force the usage of the utf-8 encoding, since some credentials
-        contains specials chars not supported by latin-1 enconding. '''
+        contain special chars not supported by latin-1 encoding. '''
         self._add_single_item(
             'internal/{}/scanprefs'.format(openvas_scan_id),
             preferences,

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -79,11 +79,14 @@ class OpenvasDB:
         return cls._db_address
 
     @classmethod
-    def create_context(cls, dbnum: Optional[int] = 0) -> RedisCtx:
+    def create_context(
+        cls, dbnum: Optional[int] = 0, encoding: Optional[str] = 'latin-1'
+    ) -> RedisCtx:
         """ Connect to redis to the given database or to the default db 0 .
 
         Arguments:
             dbnum: The db number to connect to.
+            encoding: The enconding to be used to read and write.
 
         Return a new redis context on success.
         """
@@ -94,7 +97,7 @@ class OpenvasDB:
                     unix_socket_path=cls.get_database_address(),
                     db=dbnum,
                     socket_timeout=SOCKET_TIMEOUT,
-                    encoding="latin-1",
+                    encoding=encoding,
                     decode_responses=True,
                 )
                 ctx.keys("test")
@@ -368,8 +371,17 @@ class BaseDB:
 
 
 class BaseKbDB(BaseDB):
-    def _add_single_item(self, name: str, values: Iterable):
-        OpenvasDB.add_single_item(self.ctx, name, values)
+    def _add_single_item(
+        self, name: str, values: Iterable, utf8_enc: Optional[bool] = False
+    ):
+        ''' Changing the encoding format of an existent redis context
+        is not possible. Therefore a new temporary redis context is
+        created to store key-values encoded with utf-8.'''
+        if utf8_enc:
+            ctx = OpenvasDB.create_context(self.index, encoding='utf-8')
+            OpenvasDB.add_single_item(ctx, name, values)
+        else:
+            OpenvasDB.add_single_item(self.ctx, name, values)
 
     def _set_single_item(self, name: str, value: Iterable):
         """ Set (replace) a single KB element.
@@ -500,6 +512,17 @@ class KbDB(BaseKbDB):
     def add_scan_preferences(self, openvas_scan_id: str, preferences: Iterable):
         self._add_single_item(
             'internal/{}/scanprefs'.format(openvas_scan_id), preferences
+        )
+
+    def add_credentials_to_scan_preferences(
+        self, openvas_scan_id: str, preferences: Iterable
+    ):
+        ''' Force the usage of the utf-8 encoding, since some credentials contains specials
+        chars not supported by latin-1 enconding. '''
+        self._add_single_item(
+            'internal/{}/scanprefs'.format(openvas_scan_id),
+            preferences,
+            utf8_enc=True,
         )
 
     def add_scan_process_id(self, pid: int):

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -517,8 +517,8 @@ class KbDB(BaseKbDB):
     def add_credentials_to_scan_preferences(
         self, openvas_scan_id: str, preferences: Iterable
     ):
-        ''' Force the usage of the utf-8 encoding, since some credentials contains specials
-        chars not supported by latin-1 enconding. '''
+        ''' Force the usage of the utf-8 encoding, since some credentials
+        contains specials chars not supported by latin-1 enconding. '''
         self._add_single_item(
             'internal/{}/scanprefs'.format(openvas_scan_id),
             preferences,

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -628,7 +628,7 @@ class PreferenceHandler:
         if credentials:
             cred_prefs = self.build_credentials_as_prefs(credentials)
             if cred_prefs:
-                self.kbdb.add_scan_preferences(
+                self.kbdb.add_credentials_to_scan_preferences(
                     self._openvas_scan_id, cred_prefs
                 )
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -484,6 +484,25 @@ class KbDBTestCase(TestCase):
             self.ctx, 'internal/foo/scanprefs', prefs
         )
 
+    @patch('ospd_openvas.db.OpenvasDB')
+    def test_add_credentials_to_scan_preferences(
+        self, mock_redis, mock_openvas_db
+    ):
+        prefs = ['foo', 'bar']
+
+        ctx = mock_redis.return_value
+        mock_openvas_db.create_context.return_value = ctx
+
+        self.db.add_credentials_to_scan_preferences('scan_id', prefs)
+
+        mock_openvas_db.create_context.assert_called_with(
+            self.db.index, encoding='utf-8'
+        )
+
+        mock_openvas_db.add_single_item.assert_called_with(
+            ctx, 'internal/scan_id/scanprefs', prefs
+        )
+
     def test_add_scan_process_id(self, mock_openvas_db):
         self.db.add_scan_process_id(123)
 


### PR DESCRIPTION
Some credentials contains utf-8 chars, while the default for openvas
is latin-1. This allows to change the encoding when storing credentials.