### PR TITLE
Added Documentation and Wants line to the systemd unit file

### DIFF
--- a/config/ospd-openvas.service
+++ b/config/ospd-openvas.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=OSPD OpenVAS
+Documentation=man:ospd-openvas(8) man:openvas(8)
 After=network.target networking.service dnsmasq.service redis-server@openvas.service systemd-tmpfiles.service
+Wants=redis-server@openvas.service
 ConditionKernelCommandLine=!recovery
 
 [Service]


### PR DESCRIPTION
Both lines are described here:

https://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BUnit%5D%20Section%20Options

While pip / setuptools currently doesn't allow to install the included manpage of ospd-openvas we still can link to it.

The "Wants" was added because ospd-openvas (or better the called `openvas` command line tool) can't work without a started redis-server.