### PR TITLE
[20.08] Minor tweaks for the ospd-openvas manpage:

### DIFF
--- a/docs/ospd-openvas.8
+++ b/docs/ospd-openvas.8
@@ -166,27 +166,26 @@ available, the scan is queued. Default 0, disabled.
 Maximum number allowed of queued scans before starting to reject new scans.
 Default 0, disabled.
 
+.SH SEE ALSO
+\fBopenvas(8)\f1, \fBgsad(8)\f1, \fBgvmd(8)\f1, \fBgreenbone-nvt-sync(8)\f1,
 
-.SH MORE INFORMATION ABOUT Greenbone Vulnerability Management
+.SH MORE INFORMATION
 
 The canonical places where you will find more information
 about OSPD-OpenVAS are:
 
 .RS
-.UR
-https://community.greenbone.net
+.UR https://community.greenbone.net
+Community Portal
 .UE
-(Community site)
 .br
-.UR
-https://github.com/greenbone/
+.UR https://github.com/greenbone
+Development Platform
 .UE
-(Development site)
 .br
-.UR
-https://www.openvas.org/
+.UR https://www.openvas.org
+Traditional home site
 .UE
-(Traditional home site)
 .RE
 
 .SH AUTHORS


### PR DESCRIPTION
- Fix URL manpage syntax
- Add SEE ALSO links to other relevant manpages
- Shortened the MORE INFORMATION headline

The final manpage can be verified with something like e.g.:

```
man docs/ospd-openvas.8
```

Related: https://github.com/greenbone/openvas/pull/569