### PR TITLE
[1.0] Minor tweaks for the ospd-openvas manpage:

### DIFF
--- a/docs/ospd-openvas.8
+++ b/docs/ospd-openvas.8
@@ -141,26 +141,26 @@ Set a timeout on socket operations. Default 10 seconds
 Time in hours a scan is stored before being considered forgotten and being delete from
 the scan table. Default 0, disabled.
 
-.SH MORE INFORMATION ABOUT Greenbone Vulnerability Management
+.SH SEE ALSO
+\fBopenvas(8)\f1, \fBgsad(8)\f1, \fBgvmd(8)\f1, \fBgreenbone-nvt-sync(8)\f1,
+
+.SH MORE INFORMATION
 
 The canonical places where you will find more information
 about OSPD-OpenVAS are:
 
 .RS
-.UR
-https://community.greenbone.net
+.UR https://community.greenbone.net
+Community Portal
 .UE
-(Community site)
 .br
-.UR
-https://github.com/greenbone/
+.UR https://github.com/greenbone
+Development Platform
 .UE
-(Development site)
 .br
-.UR
-https://www.openvas.org/
+.UR https://www.openvas.org
+Traditional home site
 .UE
-(Traditional home site)
 .RE
 
 .SH AUTHORS


### PR DESCRIPTION
- Fix URL manpage syntax
- Add SEE ALSO links to other relevant manpages
- Shortened the MORE INFORMATION headline

Backport of #309 to the ospd-openvas-1.0 branch.