### PR TITLE
Make all ospd-openvas config files more consistent:

### DIFF
--- a/config/ospd-openvas.default
+++ b/config/ospd-openvas.default
@@ -1,3 +1,4 @@
 # The installation prefix to find the ospd-openvas binary.
 PATH=<install-prefix>/bin:<install-prefix>/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$PATH
 PYTHONPATH=<install-prefix>/lib/python3.5/site-packages:$PYTHONPATH
+OSPD_OPENVAS_ARGS="--unix-socket <install-prefix>/var/run/ospd/ospd-openvas.sock --pid-file <install-prefix>/var/run/ospd/ospd-openvas.pid --log-file <install-prefix>/var/log/gvm/ospd-openvas.log --lock-file-dir <install-prefix>/var/run"

--- a/config/ospd-openvas.service
+++ b/config/ospd-openvas.service
@@ -12,7 +12,7 @@ Environment="PATH=$PATH"
 Environment="PYTHONPATH=$PYTHONPATH"
 User=<username>
 Group=<groupname>
-ExecStart=<install-prefix>/bin/ospd-openvas
+ExecStart=<install-prefix>/bin/ospd-openvas $OSPD_OPENVAS_ARGS
 SuccessExitStatus=SIGKILL
 # This works asynchronously, but does not take the daemon down during the reload so it's ok.
 Restart=always

--- a/config/ospd.conf
+++ b/config/ospd.conf
@@ -1,6 +1,7 @@
 [OSPD - openvas]
-log_level = DEBUG
+log_level = INFO
 socket_mode = 0o770
-unix_socket = /var/run/ospd/openvas.sock
-pid_file = /var/run/openvas.pid
-log_file = <install-prefix>/var/log/gvm/openvas.log
+unix_socket = <install-prefix>/var/run/ospd/ospd-openvas.sock
+pid_file = <install-prefix>/var/run/ospd/ospd-openvas.pid
+log_file = <install-prefix>/var/log/gvm/ospd-openvas.log
+lock_file_dir = <install-prefix>/var/run


### PR DESCRIPTION
- Don't use a DEBUG level in the example config file
- Add various default and more sane config parameters
  to the environment file
- Pass the arguments of the environment file to the systemd
  service

This has various reasons:

1. We shouldn't tell the user to use `/var/run/ospd/ospd.sock` and/or `/var/run/ospd.sock` because there might be multiple OSPD scanners in the future
2. Similar to 1. for `/var/run/ospd.pid`
3. All other GVM components (gvmd, greenbone-nvt-sync) are expecting the `feed-update.lock` in `<install-prefix>/var/run` with GVM-20.08 (see https://github.com/greenbone/gvmd/pull/1059 and https://github.com/greenbone/openvas/pull/507) but the current default is `/var/run/ospd`