### PR TITLE
Minor systemd / config files updates:

### DIFF
--- a/config/ospd-openvas.default
+++ b/config/ospd-openvas.default
@@ -1,4 +1,25 @@
+#
 # The installation prefix to find the ospd-openvas binary.
+#
 PATH=<install-prefix>/bin:<install-prefix>/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:$PATH
 PYTHONPATH=<install-prefix>/lib/python3.5/site-packages:$PYTHONPATH
-OSPD_OPENVAS_ARGS="--unix-socket <install-prefix>/var/run/ospd/ospd-openvas.sock --pid-file <install-prefix>/var/run/ospd/ospd-openvas.pid --log-file <install-prefix>/var/log/gvm/ospd-openvas.log --lock-file-dir <install-prefix>/var/run"
+
+#
+# The user for running the OSPD OpenVAS daemon in the ospd-openvas.service systemd file
+#
+OSPD_OPENVAS_USER="gvm"
+
+#
+# The group for running the OSPD OpenVAS daemon in the ospd-openvas.service systemd file
+#
+OSPD_OPENVAS_GROUP="gvm"
+
+#
+# The location of the OSPD OpenVAS daemon PID file
+#
+OSPD_OPENVAS_PID="<install-prefix>/var/run/ospd/ospd-openvas.pid"
+
+#
+# Additional default parameters
+#
+OSPD_OPENVAS_ARGS="--unix-socket <install-prefix>/var/run/ospd/ospd-openvas.sock --pid-file $OSPD_OPENVAS_PID --log-file <install-prefix>/var/log/gvm/ospd-openvas.log --lock-file-dir <install-prefix>/var/run"

--- a/config/ospd-openvas.service
+++ b/config/ospd-openvas.service
@@ -1,17 +1,18 @@
 [Unit]
 Description=OSPD OpenVAS
 Documentation=man:ospd-openvas(8) man:openvas(8)
-After=network.target networking.service dnsmasq.service redis-server@openvas.service systemd-tmpfiles.service
+After=network.target networking.service redis-server@openvas.service
 Wants=redis-server@openvas.service
 ConditionKernelCommandLine=!recovery
 
 [Service]
 Type=forking
-EnvironmentFile=/etc/default/ospd-openvas.default
+EnvironmentFile=<install-prefix>/etc/default/ospd-openvas.default
 Environment="PATH=$PATH"
 Environment="PYTHONPATH=$PYTHONPATH"
-User=<username>
-Group=<groupname>
+User=$OSPD_OPENVAS_USER
+Group=$OSPD_OPENVAS_GROUP
+PIDFile=$OSPD_OPENVAS_PID
 ExecStart=<install-prefix>/bin/ospd-openvas $OSPD_OPENVAS_ARGS
 SuccessExitStatus=SIGKILL
 # This works asynchronously, but does not take the daemon down during the reload so it's ok.


### PR DESCRIPTION
- Use ospd-openvas.default user and group config variables for
  systemd unit
- Added PIDFile systemd unit option and config file variable
- Remove dnsmasq.service and systemd-tmpfiles.service services
  from "After" string as we don't have any dependency to both
- Mention <install-prefix> in EnvironmentFile of systemd unit

Related: https://github.com/greenbone/gsa/pull/2375, https://github.com/greenbone/gvmd/pull/1240