### PR TITLE
Remove globalscanid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 - Remove methods handling the nvticache name. [#318](https://github.com/greenbone/ospd-openvas/pull/318)
 - Remove py35 and py36 support. [#319](https://github.com/greenbone/ospd-openvas/pull/319)
+- Remove globalscanid. [#326](https://github.com/greenbone/ospd-openvas/pull/326)
 
 [unreleased]: https://github.com/greenbone/ospd-openvas/compare/ospd-openvas-20.08...master
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1175,7 +1175,7 @@ class OSPDopenvas(OSPDaemon):
             except TypeError:
                 logger.debug(
                     'Scan with ID %s never started and stopped unexpectedly',
-                    openvas_scan_id,
+                    scan_id,
                 )
 
             if parent:

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -80,20 +80,15 @@ class PreferenceHandler:
         self.kbdb = kbdb
         self.scan_collection = scan_collection
 
-        self._openvas_scan_id = None
-
         self._target_options = None
 
         self.nvti = nvticache
 
-    def prepare_openvas_scan_id_for_openvas(self):
+    def prepare_scan_id_for_openvas(self):
         """ Create the openvas scan id and store it in the redis kb.
         Return the openvas scan_id.
         """
-        self._openvas_scan_id = str(uuid.uuid4())
-        self.kbdb.add_scan_id(self.scan_id, self._openvas_scan_id)
-
-        return self._openvas_scan_id
+        self.kbdb.add_scan_id(self.scan_id)
 
     @property
     def target_options(self) -> Dict:
@@ -256,12 +251,12 @@ class PreferenceHandler:
             # Add nvts list
             separ = ';'
             plugin_list = 'plugin_set|||%s' % separ.join(nvts_list)
-            self.kbdb.add_scan_preferences(self._openvas_scan_id, [plugin_list])
+            self.kbdb.add_scan_preferences(self.scan_id, [plugin_list])
 
             # Add nvts parameters
             for key, val in nvts_params.items():
                 item = '%s|||%s' % (key, val)
-                self.kbdb.add_scan_preferences(self._openvas_scan_id, [item])
+                self.kbdb.add_scan_preferences(self.scan_id, [item])
 
             nvts_params = None
             nvts_list = None
@@ -388,9 +383,7 @@ class PreferenceHandler:
             alive_test_opt = self.build_alive_test_opt_as_prefs(
                 self.target_options
             )
-            self.kbdb.add_scan_preferences(
-                self._openvas_scan_id, alive_test_opt
-            )
+            self.kbdb.add_scan_preferences(self.scan_id, alive_test_opt)
 
     def prepare_boreas_alive_test(self):
         """ Set alive_test for Boreas if boreas scanner config
@@ -422,14 +415,14 @@ class PreferenceHandler:
             pref = "{pref_key}|||{pref_value}".format(
                 pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
             )
-            self.kbdb.add_scan_preferences(self._openvas_scan_id, [pref])
+            self.kbdb.add_scan_preferences(self.scan_id, [pref])
 
         if alive_test == AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT:
             alive_test = AliveTest.ALIVE_TEST_ICMP
             pref = "{pref_key}|||{pref_value}".format(
                 pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
             )
-            self.kbdb.add_scan_preferences(self._openvas_scan_id, [pref])
+            self.kbdb.add_scan_preferences(self.scan_id, [pref])
 
     def prepare_reverse_lookup_opt_for_openvas(self):
         """ Set reverse lookup options in the kb"""
@@ -447,7 +440,7 @@ class PreferenceHandler:
             rev_lookup_unify = _from_bool_to_str(_rev_lookup_unify)
             items.append('reverse_lookup_unify|||%s' % rev_lookup_unify)
 
-            self.kbdb.add_scan_preferences(self._openvas_scan_id, items)
+            self.kbdb.add_scan_preferences(self.scan_id, items)
 
     def prepare_target_for_openvas(self):
         """ Get the target from the scan collection and set the target
@@ -455,14 +448,14 @@ class PreferenceHandler:
 
         target = self.scan_collection.get_host_list(self.scan_id)
         target_aux = 'TARGET|||%s' % target
-        self.kbdb.add_scan_preferences(self._openvas_scan_id, [target_aux])
+        self.kbdb.add_scan_preferences(self.scan_id, [target_aux])
 
     def prepare_ports_for_openvas(self) -> str:
         """ Get the port list from the scan collection and store the list
         in the kb. """
         ports = self.scan_collection.get_ports(self.scan_id)
         port_range = 'port_range|||%s' % ports
-        self.kbdb.add_scan_preferences(self._openvas_scan_id, [port_range])
+        self.kbdb.add_scan_preferences(self.scan_id, [port_range])
 
         return ports
 
@@ -473,7 +466,7 @@ class PreferenceHandler:
 
         if exclude_hosts:
             pref_val = "exclude_hosts|||" + exclude_hosts
-            self.kbdb.add_scan_preferences(self._openvas_scan_id, [pref_val])
+            self.kbdb.add_scan_preferences(self.scan_id, [pref_val])
 
     def prepare_scan_params_for_openvas(self, ospd_params: Dict[str, Dict]):
         """ Get the scan parameters from the scan collection and store them
@@ -504,7 +497,7 @@ class PreferenceHandler:
             prefs_val.append(key + "|||" + val)
 
         if prefs_val:
-            self.kbdb.add_scan_preferences(self._openvas_scan_id, prefs_val)
+            self.kbdb.add_scan_preferences(self.scan_id, prefs_val)
 
     @staticmethod
     def build_credentials_as_prefs(credentials: Dict) -> List[str]:
@@ -631,7 +624,7 @@ class PreferenceHandler:
             cred_prefs = self.build_credentials_as_prefs(credentials)
             if cred_prefs:
                 self.kbdb.add_credentials_to_scan_preferences(
-                    self._openvas_scan_id, cred_prefs
+                    self.scan_id, cred_prefs
                 )
 
         if credentials and not cred_prefs:
@@ -643,4 +636,4 @@ class PreferenceHandler:
         """ Store main_kbindex as global preference in the
         kb, used by OpenVAS"""
         ov_maindbid = 'ov_maindbid|||%d' % self.kbdb.index
-        self.kbdb.add_scan_preferences(self._openvas_scan_id, [ov_maindbid])
+        self.kbdb.add_scan_preferences(self.scan_id, [ov_maindbid])

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -24,7 +24,6 @@ collection and store the data in a redis KB in the right format to be used by
 OpenVAS. """
 
 import logging
-import uuid
 import binascii
 
 from enum import IntEnum

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -23,6 +23,7 @@
 
 import io
 import logging
+import psutil
 
 from unittest import TestCase
 from unittest.mock import patch, Mock, MagicMock
@@ -862,12 +863,13 @@ class TestOspdOpenvas(TestCase):
 
         self.assertTrue(ret)
 
+    @patch('psutil.Process')
     @patch('ospd_openvas.db.KbDB')
-    def test_openvas_is_alive_still(self, mock_db):
+    def test_openvas_is_alive_still(self, mock_db, mock_psutil):
         w = DummyDaemon()
-        # mock_psutil = MockPsutil.return_value
+        mock_psutil.side_effect = TypeError
         mock_db.scan_is_stopped.return_value = False
-        ret = w.is_openvas_process_alive(mock_db, '1234', 'a1-b2-c3-d4')
+        ret = w.is_openvas_process_alive(mock_db, '1234', 'a1-b2-c3-d3')
 
         self.assertFalse(ret)
 

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -237,12 +237,12 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_host_list = MagicMock(return_value='192.168.0.1')
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         p.prepare_target_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p._openvas_scan_id, ['TARGET|||192.168.0.1'],
+            p.scan_id, ['TARGET|||192.168.0.1'],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -252,12 +252,12 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_ports = MagicMock(return_value='80,443')
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         p.prepare_ports_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p._openvas_scan_id, ['port_range|||80,443'],
+            p.scan_id, ['port_range|||80,443'],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -270,7 +270,7 @@ class PreferenceHandlerTestCase(TestCase):
         p.prepare_main_kbindex_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p._openvas_scan_id, ['ov_maindbid|||2'],
+            p.scan_id, ['ov_maindbid|||2'],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -304,7 +304,7 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
 
@@ -328,7 +328,7 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
 
@@ -343,7 +343,7 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
 
@@ -358,12 +358,12 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_exclude_hosts = MagicMock(return_value=exc)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         p.prepare_host_options_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p._openvas_scan_id, ['exclude_hosts|||192.168.0.1'],
+            p.scan_id, ['exclude_hosts|||192.168.0.1'],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -375,7 +375,7 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_exclude_hosts = MagicMock(return_value=exc)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         p.prepare_host_options_for_openvas()
 
@@ -400,12 +400,12 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_options = MagicMock(return_value=opt)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         p.prepare_scan_params_for_openvas(OSPD_PARAMS_MOCK)
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p._openvas_scan_id, ['drop_privileges|||yes']
+            p.scan_id, ['drop_privileges|||yes']
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -416,12 +416,12 @@ class PreferenceHandlerTestCase(TestCase):
         w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-        p._openvas_scan_id = '456-789'
+        p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         p.prepare_reverse_lookup_opt_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p._openvas_scan_id,
+            p.scan_id,
             ['reverse_lookup_only|||yes', 'reverse_lookup_unify|||no',],
         )
 
@@ -432,7 +432,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {'not_the_correct_setting': 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-            p._openvas_scan_id = '456-789'
+            p.scan_id = '456-789'
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_boreas_alive_test()
 
@@ -445,7 +445,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-            p._openvas_scan_id = '456-789'
+            p.scan_id = '456-789'
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_boreas_alive_test()
 
@@ -458,11 +458,11 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-            p._openvas_scan_id = '456-789'
+            p.scan_id = '456-789'
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_boreas_alive_test()
 
-            calls = [call(p._openvas_scan_id, [BOREAS_ALIVE_TEST + '|||16'])]
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||16'])]
             p.kbdb.add_scan_preferences.assert_has_calls(calls)
 
         # ICMP was chosen as alive test.
@@ -472,11 +472,11 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-            p._openvas_scan_id = '456-789'
+            p.scan_id = '456-789'
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_boreas_alive_test()
 
-            calls = [call(p._openvas_scan_id, [BOREAS_ALIVE_TEST + '|||2'])]
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||2'])]
             p.kbdb.add_scan_preferences.assert_has_calls(calls)
 
         # "Scan Config Default" as alive_test.
@@ -486,11 +486,11 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-            p._openvas_scan_id = '456-789'
+            p.scan_id = '456-789'
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_boreas_alive_test()
 
-            calls = [call(p._openvas_scan_id, [BOREAS_ALIVE_TEST + '|||2'])]
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||2'])]
             p.kbdb.add_scan_preferences.assert_has_calls(calls)
 
     @patch('ospd_openvas.db.KbDB')
@@ -501,7 +501,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-            p._openvas_scan_id = '456-789'
+            p.scan_id = '456-789'
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_boreas_alive_test()
 
@@ -518,7 +518,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
-            p._openvas_scan_id = '456-789'
+            p.scan_id = '456-789'
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_alive_test_option_for_openvas()
 
@@ -545,10 +545,10 @@ class PreferenceHandlerTestCase(TestCase):
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
 
-            p._openvas_scan_id = '456-789'
+            p.scan_id = '456-789'
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_alive_test_option_for_openvas()
 
             p.kbdb.add_scan_preferences.assert_called_with(
-                p._openvas_scan_id, alive_test_out,
+                p.scan_id, alive_test_out,
             )


### PR DESCRIPTION


**What**:
Use the scan_id received from the client.
Now the scan_id for a single task is unified and it is the same one for
openvas.


**Why**:
The globalscanid was left from the old multi target support.

**How**:
In logs, or with ps, you can see that the scan id used by openvas is the same as the task id used by gvmd.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
