### PR TITLE
Set dedicated port list for alive detection as scan pref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.4] (unreleased)
 
+### Added
+- Add dedicated port list for alive detection (Boreas only) as scanner preference if supplied via OSP. [#327](https://github.com/greenbone/ospd-openvas/pull/327)
+
 ### Changed
 - Get all results from main kb. [#285](https://github.com/greenbone/ospd-openvas/pull/285)
 

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -47,6 +47,7 @@ OID_SNMP_AUTH = "1.3.6.1.4.1.25623.1.0.105076"
 OID_PING_HOST = "1.3.6.1.4.1.25623.1.0.100315"
 
 BOREAS_ALIVE_TEST = "ALIVE_TEST"
+BOREAS_ALIVE_TEST_PORTS = "ALIVE_TEST_PORTS"
 BOREAS_SETTING_NAME = "test_alive_hosts_only"
 
 
@@ -389,11 +390,13 @@ class PreferenceHandler:
         (BOREAS_SETTING_NAME) was set"""
         settings = Openvas.get_settings()
         alive_test = -1
+        alive_test_ports = None
 
         if settings:
             boreas = settings.get(BOREAS_SETTING_NAME)
             if not boreas:
                 return
+            alive_test_ports = self.target_options.get('alive_test_ports')
             alive_test_str = self.target_options.get('alive_test')
             if alive_test_str is not None:
                 try:
@@ -420,6 +423,13 @@ class PreferenceHandler:
             alive_test = AliveTest.ALIVE_TEST_ICMP
             pref = "{pref_key}|||{pref_value}".format(
                 pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
+            )
+            self.kbdb.add_scan_preferences(self.scan_id, [pref])
+
+        # Add portlist if present. Validity is checked on Boreas side.
+        if alive_test_ports is not None:
+            pref = "{pref_key}|||{pref_value}".format(
+                pref_key=BOREAS_ALIVE_TEST_PORTS, pref_value=alive_test_ports
             )
             self.kbdb.add_scan_preferences(self.scan_id, [pref])
 


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Set the dedicated port list for alive detection which got provided via OSP as scanner pref. Boreas can then use it for alive detection.

Depends on:
https://github.com/greenbone/ospd/pull/323
https://github.com/greenbone/gvm-libs/pull/391

**Why**:

<!-- Why are these changes necessary? -->

It enhances the flexibility when doing alive scans.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Used gvm-cli for scans. Added <alive_test_ports>22,80<alive_test_ports> and checked with a print if these ports were actually set.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
