### PR TITLE
Consider individually supplied alive test methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add dedicated port list for alive detection (Boreas only) as scanner preference if supplied via OSP. [#327](https://github.com/greenbone/ospd-openvas/pull/327)
 - Add methods for adding VTs to the redis cache.[#337](https://github.com/greenbone/ospd-openvas/pull/337)
+- Add support for supplying alive test methods via seperate elements. [#331](https://github.com/greenbone/ospd-openvas/pull/331)
 
 ### Changed
 - Get all results from main kb. [#285](https://github.com/greenbone/ospd-openvas/pull/285)

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -425,11 +425,15 @@ class PreferenceHandler:
     def prepare_alive_test_option_for_openvas(self):
         """ Set alive test option. Overwrite the scan config settings."""
         settings = Openvas.get_settings()
-        if settings and self.target_options.get('alive_test'):
+        if settings and (
+            self.target_options.get('alive_test')
+            or self.target_options.get('alive_test_methods')
+        ):
             alive_test_opt = self.build_alive_test_opt_as_prefs(
                 self.target_options
             )
-            self.kbdb.add_scan_preferences(self.scan_id, alive_test_opt)
+            if alive_test_opt:
+                self.kbdb.add_scan_preferences(self.scan_id, alive_test_opt)
 
     def prepare_boreas_alive_test(self):
         """Set alive_test for Boreas if boreas scanner config

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -101,10 +101,7 @@ class PreferenceHandler:
         )
         return self._target_options
 
-    def _get_vts_in_groups(
-        self,
-        filters: List[str],
-    ) -> List[str]:
+    def _get_vts_in_groups(self, filters: List[str],) -> List[str]:
         """Return a list of vts which match with the given filter.
 
         Arguments:
@@ -154,16 +151,12 @@ class PreferenceHandler:
         """Check if the value of a vt parameter matches with
         the type founded.
         """
-        if (
-            param_type
-            in [
-                'entry',
-                'password',
-                'radio',
-                'sshlogin',
-            ]
-            and isinstance(vt_param_value, str)
-        ):
+        if param_type in [
+            'entry',
+            'password',
+            'radio',
+            'sshlogin',
+        ] and isinstance(vt_param_value, str):
             return None
         elif param_type == 'checkbox' and (
             vt_param_value == '0' or vt_param_value == '1'
@@ -185,8 +178,7 @@ class PreferenceHandler:
         return 1
 
     def _process_vts(
-        self,
-        vts: Dict[str, Dict[str, str]],
+        self, vts: Dict[str, Dict[str, str]],
     ) -> Tuple[List[str], Dict[str, str]]:
         """ Add single VTs and their parameters. """
         vts_list = []
@@ -289,9 +281,32 @@ class PreferenceHandler:
             in string format to be added to the redis KB.
         """
         target_opt_prefs_list = []
-        if target_options and target_options.get('alive_test'):
+
+        alive_test = target_options.get('alive_test')
+        alive_test_methods = target_options.get('alive_test_methods')
+        if target_options and alive_test is None and alive_test_methods:
+            alive_test_enum = AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT
+            if target_options.get('icmp') == '1':
+                alive_test_enum = alive_test_enum | AliveTest.ALIVE_TEST_ICMP
+            if target_options.get('tcp_syn') == '1':
+                alive_test_enum = (
+                    alive_test_enum | AliveTest.ALIVE_TEST_TCP_SYN_SERVICE
+                )
+            if target_options.get('tcp_ack') == '1':
+                alive_test_enum = (
+                    alive_test_enum | AliveTest.ALIVE_TEST_TCP_ACK_SERVICE
+                )
+            if target_options.get('arp') == '1':
+                alive_test_enum = alive_test_enum | AliveTest.ALIVE_TEST_ARP
+            if target_options.get('consider_alive') == '1':
+                alive_test_enum = (
+                    alive_test_enum | AliveTest.ALIVE_TEST_CONSIDER_ALIVE
+                )
+            alive_test = alive_test_enum
+
+        if target_options and alive_test:
             try:
-                alive_test = int(target_options.get('alive_test'))
+                alive_test = int(alive_test)
             except ValueError:
                 logger.debug(
                     'Alive test settings not applied. '
@@ -405,7 +420,35 @@ class PreferenceHandler:
             if not boreas:
                 return
             alive_test_ports = self.target_options.get('alive_test_ports')
+
             alive_test_str = self.target_options.get('alive_test')
+            alive_test_methods = self.target_options.get('alive_test_methods')
+            if alive_test_str is None and alive_test_methods:
+                alive_test_bitmask = AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT
+                if self.target_options.get('icmp') == '1':
+                    alive_test_bitmask = (
+                        alive_test_bitmask | AliveTest.ALIVE_TEST_ICMP
+                    )
+                if self.target_options.get('tcp_syn') == '1':
+                    alive_test_bitmask = (
+                        alive_test_bitmask
+                        | AliveTest.ALIVE_TEST_TCP_SYN_SERVICE
+                    )
+                if self.target_options.get('tcp_ack') == '1':
+                    alive_test_bitmask = (
+                        alive_test_bitmask
+                        | AliveTest.ALIVE_TEST_TCP_ACK_SERVICE
+                    )
+                if self.target_options.get('arp') == '1':
+                    alive_test_bitmask = (
+                        alive_test_bitmask | AliveTest.ALIVE_TEST_ARP
+                    )
+                if self.target_options.get('consider_alive') == '1':
+                    alive_test_bitmask = (
+                        alive_test_bitmask | AliveTest.ALIVE_TEST_CONSIDER_ALIVE
+                    )
+                alive_test_str = alive_test_bitmask
+
             if alive_test_str is not None:
                 try:
                     alive_test = int(alive_test_str)

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -443,6 +443,8 @@ class PreferenceHandler:
             boreas = settings.get(BOREAS_SETTING_NAME)
             if not boreas:
                 return
+        else:
+            return
 
         if target_options:
             alive_test_ports = target_options.get('alive_test_ports')
@@ -460,41 +462,43 @@ class PreferenceHandler:
                     consider_alive=target_options.get('consider_alive') == '1',
                 )
 
-            if alive_test is not None:
-                try:
-                    alive_test = int(alive_test)
-                except ValueError:
-                    logger.debug(
-                        'Alive test preference for Boreas not set. '
-                        'Invalid alive test value %s.',
-                        alive_test,
-                    )
-            # ALIVE_TEST_SCAN_CONFIG_DEFAULT if no alive_test provided
-            else:
+        if alive_test is not None:
+            try:
+                alive_test = int(alive_test)
+            except ValueError:
+                logger.debug(
+                    'Alive test preference for Boreas not set. '
+                    'Invalid alive test value %s.',
+                    alive_test,
+                )
+                # Use default alive test as fall back
                 alive_test = AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT
+        # Use default alive test if no valid alive_test was provided
+        else:
+            alive_test = AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT
 
-            # If a valid alive_test was set then the bit mask
-            # has value between 31 (11111) and 1 (10000)
-            if 1 <= alive_test <= 31:
-                pref = "{pref_key}|||{pref_value}".format(
-                    pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
-                )
-                self.kbdb.add_scan_preferences(self.scan_id, [pref])
+        # If a valid alive_test was set then the bit mask
+        # has value between 31 (11111) and 1 (10000)
+        if 1 <= alive_test <= 31:
+            pref = "{pref_key}|||{pref_value}".format(
+                pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
+            )
+            self.kbdb.add_scan_preferences(self.scan_id, [pref])
 
-            if alive_test == AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT:
-                alive_test = AliveTest.ALIVE_TEST_ICMP
-                pref = "{pref_key}|||{pref_value}".format(
-                    pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
-                )
-                self.kbdb.add_scan_preferences(self.scan_id, [pref])
+        if alive_test == AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT:
+            alive_test = AliveTest.ALIVE_TEST_ICMP
+            pref = "{pref_key}|||{pref_value}".format(
+                pref_key=BOREAS_ALIVE_TEST, pref_value=alive_test
+            )
+            self.kbdb.add_scan_preferences(self.scan_id, [pref])
 
-            # Add portlist if present. Validity is checked on Boreas side.
-            if alive_test_ports is not None:
-                pref = "{pref_key}|||{pref_value}".format(
-                    pref_key=BOREAS_ALIVE_TEST_PORTS,
-                    pref_value=alive_test_ports,
-                )
-                self.kbdb.add_scan_preferences(self.scan_id, [pref])
+        # Add portlist if present. Validity is checked on Boreas side.
+        if alive_test_ports is not None:
+            pref = "{pref_key}|||{pref_value}".format(
+                pref_key=BOREAS_ALIVE_TEST_PORTS,
+                pref_value=alive_test_ports,
+            )
+            self.kbdb.add_scan_preferences(self.scan_id, [pref])
 
     def prepare_reverse_lookup_opt_for_openvas(self):
         """ Set reverse lookup options in the kb"""

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -740,6 +740,40 @@ class PreferenceHandlerTestCase(TestCase):
             p.kbdb.add_scan_preferences.assert_not_called()
 
     @patch('ospd_openvas.db.KbDB')
+    def test_set_alive_no_invalid_alive_test(self, mock_kb):
+        w = DummyDaemon()
+
+        t_opt = {'alive_test': -1}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+
+        ov_setting = {'some_setting': 1}
+
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_alive_test_option_for_openvas()
+
+            p.kbdb.add_scan_preferences.assert_not_called()
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_set_alive_no_invalid_alive_test_no_enum(self, mock_kb):
+        w = DummyDaemon()
+
+        t_opt = {'alive_test_methods': '1', 'icmp': '-1'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+
+        ov_setting = {'some_setting': 1}
+
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_alive_test_option_for_openvas()
+
+            p.kbdb.add_scan_preferences.assert_not_called()
+
+    @patch('ospd_openvas.db.KbDB')
     def test_set_alive_pinghost(self, mock_kb):
         w = DummyDaemon()
 
@@ -768,6 +802,54 @@ class PreferenceHandlerTestCase(TestCase):
                 p.scan_id,
                 alive_test_out,
             )
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_prepare_alive_test_not_supplied_as_enum(self, mock_kb):
+        w = DummyDaemon()
+
+        alive_test_out = [
+            "1.3.6.1.4.1.25623.1.0.100315:1:checkbox:Do a TCP ping|||no",
+            "1.3.6.1.4.1.25623.1.0.100315:2:checkbox:TCP ping tries also TCP-SYN ping|||no",
+            "1.3.6.1.4.1.25623.1.0.100315:7:checkbox:TCP ping tries only TCP-SYN ping|||no",
+            "1.3.6.1.4.1.25623.1.0.100315:3:checkbox:Do an ICMP ping|||yes",
+            "1.3.6.1.4.1.25623.1.0.100315:4:checkbox:Use ARP|||no",
+            "1.3.6.1.4.1.25623.1.0.100315:5:checkbox:Mark unrechable Hosts as dead (not scanning)|||yes",
+        ]
+
+        t_opt = {'alive_test_methods': '1', 'icmp': '1'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+
+        ov_setting = {'some_setting': 1}
+
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_alive_test_option_for_openvas()
+
+            p.kbdb.add_scan_preferences.assert_called_with(
+                p.scan_id,
+                alive_test_out,
+            )
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_prepare_alive_test_no_enum_no_alive_test(self, mock_kb):
+        w = DummyDaemon()
+
+        t_opt = {'alive_test_methods': '1', 'icmp': '0'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+
+        ov_setting = {'some_setting': 1}
+
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_alive_test_option_for_openvas()
+
+            p.kbdb.add_scan_preferences.assert_not_called()
 
     def test_alive_test_methods_to_bit_field(self):
 

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -243,7 +243,8 @@ class PreferenceHandlerTestCase(TestCase):
         p.prepare_target_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p.scan_id, ['TARGET|||192.168.0.1'],
+            p.scan_id,
+            ['TARGET|||192.168.0.1'],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -258,7 +259,8 @@ class PreferenceHandlerTestCase(TestCase):
         p.prepare_ports_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p.scan_id, ['port_range|||80,443'],
+            p.scan_id,
+            ['port_range|||80,443'],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -271,7 +273,8 @@ class PreferenceHandlerTestCase(TestCase):
         p.prepare_main_kbindex_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p.scan_id, ['ov_maindbid|||2'],
+            p.scan_id,
+            ['ov_maindbid|||2'],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -364,7 +367,8 @@ class PreferenceHandlerTestCase(TestCase):
         p.prepare_host_options_for_openvas()
 
         p.kbdb.add_scan_preferences.assert_called_with(
-            p.scan_id, ['exclude_hosts|||192.168.0.1'],
+            p.scan_id,
+            ['exclude_hosts|||192.168.0.1'],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -423,7 +427,10 @@ class PreferenceHandlerTestCase(TestCase):
 
         p.kbdb.add_scan_preferences.assert_called_with(
             p.scan_id,
-            ['reverse_lookup_only|||yes', 'reverse_lookup_unify|||no',],
+            [
+                'reverse_lookup_only|||yes',
+                'reverse_lookup_unify|||no',
+            ],
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -431,6 +438,8 @@ class PreferenceHandlerTestCase(TestCase):
         # No Boreas config setting (BOREAS_SETTING_NAME) set
         w = DummyDaemon()
         ov_setting = {'not_the_correct_setting': 1}
+        t_opt = {}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
             p.scan_id = '456-789'
@@ -450,7 +459,8 @@ class PreferenceHandlerTestCase(TestCase):
             p.kbdb.add_scan_preferences = MagicMock()
             p.prepare_boreas_alive_test()
 
-            p.kbdb.add_scan_preferences.assert_not_called()
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||2'])]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
 
         # ALIVE_TEST_TCP_SYN_SERVICE as alive test.
         w = DummyDaemon()
@@ -571,5 +581,6 @@ class PreferenceHandlerTestCase(TestCase):
             p.prepare_alive_test_option_for_openvas()
 
             p.kbdb.add_scan_preferences.assert_called_with(
-                p.scan_id, alive_test_out,
+                p.scan_id,
+                alive_test_out,
             )

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -526,6 +526,147 @@ class PreferenceHandlerTestCase(TestCase):
             p.kbdb.add_scan_preferences.assert_has_calls(calls)
 
     @patch('ospd_openvas.db.KbDB')
+    def test_set_boreas_alive_test_not_as_enum(self, mock_kb):
+        # No Boreas config setting (BOREAS_SETTING_NAME) set
+        w = DummyDaemon()
+        ov_setting = {'not_the_correct_setting': 1}
+        t_opt = {}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            p.kbdb.add_scan_preferences.assert_not_called()
+
+        # Boreas config setting set but invalid alive_test.
+        w = DummyDaemon()
+        t_opt = {'alive_test_methods': "1", 'arp': '-1'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        ov_setting = {BOREAS_SETTING_NAME: 1}
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||2'])]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
+
+        # ICMP was chosen as alive test.
+        w = DummyDaemon()
+        t_opt = {'alive_test_methods': "1", 'icmp': '1'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        ov_setting = {BOREAS_SETTING_NAME: 1}
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||2'])]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
+
+        # tcp_syn as alive test.
+        w = DummyDaemon()
+        t_opt = {'alive_test_methods': "1", 'tcp_syn': '1'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        ov_setting = {BOREAS_SETTING_NAME: 1}
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||16'])]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
+
+        # tcp_ack as alive test.
+        w = DummyDaemon()
+        t_opt = {'alive_test_methods': "1", 'tcp_ack': '1'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        ov_setting = {BOREAS_SETTING_NAME: 1}
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||1'])]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
+
+        # arp as alive test.
+        w = DummyDaemon()
+        t_opt = {'alive_test_methods': "1", 'arp': '1'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        ov_setting = {BOREAS_SETTING_NAME: 1}
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||4'])]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
+
+        # arp as alive test.
+        w = DummyDaemon()
+        t_opt = {'alive_test_methods': "1", 'consider_alive': '1'}
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        ov_setting = {BOREAS_SETTING_NAME: 1}
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||8'])]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
+
+        # all alive test methods
+        w = DummyDaemon()
+        t_opt = {
+            'alive_test_methods': "1",
+            'icmp': '1',
+            'tcp_ack': '1',
+            'tcp_syn': '1',
+            'arp': '1',
+            'consider_alive': '1',
+        }
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        ov_setting = {BOREAS_SETTING_NAME: 1}
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            calls = [call(p.scan_id, [BOREAS_ALIVE_TEST + '|||31'])]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
+
+        # TCP-SYN alive test and dedicated port list for alive scan provided.
+        w = DummyDaemon()
+        t_opt = {
+            'alive_test_ports': "80,137",
+            'alive_test_methods': "1",
+            'tcp_syn': '1',
+        }
+        w.scan_collection.get_target_options = MagicMock(return_value=t_opt)
+        ov_setting = {BOREAS_SETTING_NAME: 1}
+        with patch.object(Openvas, 'get_settings', return_value=ov_setting):
+            p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+            p.scan_id = '456-789'
+            p.kbdb.add_scan_preferences = MagicMock()
+            p.prepare_boreas_alive_test()
+
+            calls = [
+                call(p.scan_id, [BOREAS_ALIVE_TEST + '|||16']),
+                call(p.scan_id, [BOREAS_ALIVE_TEST_PORTS + '|||80,137']),
+            ]
+            p.kbdb.add_scan_preferences.assert_has_calls(calls)
+
+    @patch('ospd_openvas.db.KbDB')
     def test_set_boreas_alive_test_without_settings(self, mock_kb):
         w = DummyDaemon()
         t_opt = {'alive_test': 16}

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -36,6 +36,7 @@ from ospd_openvas.preferencehandler import (
     BOREAS_ALIVE_TEST,
     BOREAS_ALIVE_TEST_PORTS,
     PreferenceHandler,
+    alive_test_methods_to_bit_field,
 )
 
 
@@ -584,3 +585,79 @@ class PreferenceHandlerTestCase(TestCase):
                 p.scan_id,
                 alive_test_out,
             )
+
+    def test_alive_test_methods_to_bit_field(self):
+
+        self.assertEqual(
+            AliveTest.ALIVE_TEST_TCP_ACK_SERVICE,
+            alive_test_methods_to_bit_field(
+                icmp=False,
+                tcp_ack=True,
+                tcp_syn=False,
+                arp=False,
+                consider_alive=False,
+            ),
+        )
+
+        self.assertEqual(
+            AliveTest.ALIVE_TEST_ICMP,
+            alive_test_methods_to_bit_field(
+                icmp=True,
+                tcp_ack=False,
+                tcp_syn=False,
+                arp=False,
+                consider_alive=False,
+            ),
+        )
+
+        self.assertEqual(
+            AliveTest.ALIVE_TEST_ARP,
+            alive_test_methods_to_bit_field(
+                icmp=False,
+                tcp_ack=False,
+                tcp_syn=False,
+                arp=True,
+                consider_alive=False,
+            ),
+        )
+
+        self.assertEqual(
+            AliveTest.ALIVE_TEST_CONSIDER_ALIVE,
+            alive_test_methods_to_bit_field(
+                icmp=False,
+                tcp_ack=False,
+                tcp_syn=False,
+                arp=False,
+                consider_alive=True,
+            ),
+        )
+
+        self.assertEqual(
+            AliveTest.ALIVE_TEST_TCP_SYN_SERVICE,
+            alive_test_methods_to_bit_field(
+                icmp=False,
+                tcp_ack=False,
+                tcp_syn=True,
+                arp=False,
+                consider_alive=False,
+            ),
+        )
+
+        all_alive_test_methods = (
+            AliveTest.ALIVE_TEST_SCAN_CONFIG_DEFAULT
+            | AliveTest.ALIVE_TEST_TCP_ACK_SERVICE
+            | AliveTest.ALIVE_TEST_ICMP
+            | AliveTest.ALIVE_TEST_ARP
+            | AliveTest.ALIVE_TEST_CONSIDER_ALIVE
+            | AliveTest.ALIVE_TEST_TCP_SYN_SERVICE
+        )
+        self.assertEqual(
+            all_alive_test_methods,
+            alive_test_methods_to_bit_field(
+                icmp=True,
+                tcp_ack=True,
+                tcp_syn=True,
+                arp=True,
+                consider_alive=True,
+            ),
+        )


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Alive test methods can now be specified not only via bit field but also via single xml elements for every method. This PR allows the use of these single elements.

Alive test supplied via <alive_test> takes precedence over alive test methods supplied vi <alive_test_methods> element.

PR also fixes stack trace when invalid alive test is supplied.

Dependend on:
https://github.com/greenbone/ospd/pull/329

**Why**:

<!-- Why are these changes necessary? -->

Better usability.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
Tested with python-gvm and following target description with different configurations.

```
<target>
    <alive_test_methods>
        <icmp>0</icmp>
        <tcp_ack>0</tcp_ack>
        <tcp_syn>0</tcp_syn>
        <arp>0</arp>
        <consider_alive>0</consider_alive>
    </alive_test_methods>
    <hosts>127.0.0.1</hosts>
</target>
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
