### PR TITLE
Check if the scan was stopped before launching OpenVAS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix nvticache name when for stable version from sources. [#317](https://github.com/greenbone/ospd-openvas/pull/317)
+- Fix stop scan during preferences handling, before spawining OpenVAS. [#332](https://github.com/greenbone/ospd-openvas/pull/332)
 
 [20.8.1]: https://github.com/greenbone/ospd-openvas/compare/v20.8.0...ospd-openvas-20.08
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1254,7 +1254,7 @@ class OSPDopenvas(OSPDaemon):
         # Release memory used for scan preferences.
         del scan_prefs
 
-        if do_not_launch:
+        if do_not_launch or kbdb.scan_is_stopped(openvas_scan_id):
             self.main_db.release_database(kbdb)
             return
 


### PR DESCRIPTION
**What**:
Check if the scan was stopped before launching OpenVAS.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
If the scan was stopped during the preferences handling before spawining the OpenVAS process,
the process was spawned but still marked as stopped.
Now the scan is indeed stopped and the new process is not being spawned.

**How**:
The issue is that ospd-openvas set the task as running, while it is still preparing the scan preferences to be sent to the scanner. In other words, Openvas has not been started when ospd-openvas received the stop command.

With a small scan config, this problem is probably harder to reproduce, since ospd-openvas prepares the preferences and starts Openvas faster

If you see in the logs, you can see that Openvas is started after the stop cmd is received. If you wait until Openvas is indeed started, the scan is stopped as expected.

To reproduce the issue and check the fix:
1. Start a task with a "Full and fast" scan against a /24 network
2. Once the task is displayed as "Running", stop it by clicking on the "Stop" icon.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
