### PR TITLE
Apply alive test preferences if one method was selected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix nvticache name when for stable version from sources. [#317](https://github.com/greenbone/ospd-openvas/pull/317)
 - Fix stop scan during preferences handling, before spawining OpenVAS. [#332](https://github.com/greenbone/ospd-openvas/pull/332)
+- Fix alive test preferences when a non default method is selected. [#334](https://github.com/greenbone/ospd-openvas/pull/334)
 
 [20.8.1]: https://github.com/greenbone/ospd-openvas/compare/v20.8.0...ospd-openvas-20.08
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1249,6 +1249,11 @@ class OSPDopenvas(OSPDaemon):
         scan_prefs.prepare_scan_params_for_openvas(OSPD_PARAMS)
         scan_prefs.prepare_reverse_lookup_opt_for_openvas()
         scan_prefs.prepare_alive_test_option_for_openvas()
+
+        # VT preferences are stored after all preferences have been processed,
+        # since alive tests preferences have to be able to overwrite default
+        # preferences of ping_host.nasl for the classic method.
+        scan_prefs.prepare_nvt_preferences()
         scan_prefs.prepare_boreas_alive_test()
 
         # Release memory used for scan preferences.

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -83,6 +83,7 @@ class PreferenceHandler:
         self._openvas_scan_id = None
 
         self._target_options = None
+        self._nvts_params = None
 
         self.nvti = nvticache
 
@@ -255,23 +256,17 @@ class PreferenceHandler:
         return vts_list, vts_params
 
     def prepare_plugins_for_openvas(self) -> bool:
-        """Get the plugin list to be launched from the Scan Collection
-        and prepare the vts preferences. Store the data in the kb.
+        """Get the plugin list and it preferences from the Scan Collection.
+        The plugin list is inmediately stored in the kb.
         """
         nvts = self.scan_collection.get_vts(self.scan_id)
         if nvts:
-            nvts_list, nvts_params = self._process_vts(nvts)
+            nvts_list, self._nvts_params = self._process_vts(nvts)
             # Add nvts list
             separ = ';'
             plugin_list = 'plugin_set|||%s' % separ.join(nvts_list)
             self.kbdb.add_scan_preferences(self._openvas_scan_id, [plugin_list])
 
-            # Add nvts parameters
-            for key, val in nvts_params.items():
-                item = '%s|||%s' % (key, val)
-                self.kbdb.add_scan_preferences(self._openvas_scan_id, [item])
-
-            nvts_params = None
             nvts_list = None
             item = None
             plugin_list = None
@@ -280,6 +275,15 @@ class PreferenceHandler:
             return True
 
         return False
+
+    def prepare_nvt_preferences(self):
+        """Prepare the vts preferences. Store the data in the kb.
+        Store the data in the kb.
+        """
+
+        for key, val in self._nvts_params.items():
+            item = '%s|||%s' % (key, val)
+            self.kbdb.add_scan_preferences(self._openvas_scan_id, [item])
 
     @staticmethod
     def build_alive_test_opt_as_prefs(
@@ -293,7 +297,8 @@ class PreferenceHandler:
             A list with the target options related to alive test method
             in string format to be added to the redis KB.
         """
-        target_opt_prefs_list = []
+        target_opt_prefs_list = {}
+
         if target_options and target_options.get('alive_test'):
             try:
                 alive_test = int(target_options.get('alive_test'))
@@ -305,6 +310,8 @@ class PreferenceHandler:
                 )
                 return target_opt_prefs_list
 
+            # No alive test or wrong value, uses the default
+            # preferences sent by the client.
             if alive_test < 1 or alive_test > 31:
                 return target_opt_prefs_list
 
@@ -315,12 +322,9 @@ class PreferenceHandler:
                 value = "yes"
             else:
                 value = "no"
-            target_opt_prefs_list.append(
-                OID_PING_HOST
-                + ':1:checkbox:'
-                + 'Do a TCP ping|||'
-                + '{0}'.format(value)
-            )
+            target_opt_prefs_list[
+                OID_PING_HOST + ':1:checkbox:' + 'Do a TCP ping'
+            ] = value
 
             if (
                 alive_test & AliveTest.ALIVE_TEST_TCP_SYN_SERVICE
@@ -329,12 +333,11 @@ class PreferenceHandler:
                 value = "yes"
             else:
                 value = "no"
-            target_opt_prefs_list.append(
+            target_opt_prefs_list[
                 OID_PING_HOST
                 + ':2:checkbox:'
-                + 'TCP ping tries also TCP-SYN ping|||'
-                + '{0}'.format(value)
-            )
+                + 'TCP ping tries also TCP-SYN ping'
+            ] = value
 
             if (alive_test & AliveTest.ALIVE_TEST_TCP_SYN_SERVICE) and not (
                 alive_test & AliveTest.ALIVE_TEST_TCP_ACK_SERVICE
@@ -342,51 +345,44 @@ class PreferenceHandler:
                 value = "yes"
             else:
                 value = "no"
-            target_opt_prefs_list.append(
+            target_opt_prefs_list[
                 OID_PING_HOST
                 + ':7:checkbox:'
-                + 'TCP ping tries only TCP-SYN ping|||'
-                + '{0}'.format(value)
-            )
+                + 'TCP ping tries only TCP-SYN ping'
+            ] = value
 
             if alive_test & AliveTest.ALIVE_TEST_ICMP:
                 value = "yes"
             else:
                 value = "no"
-            target_opt_prefs_list.append(
-                OID_PING_HOST
-                + ':3:checkbox:'
-                + 'Do an ICMP ping|||'
-                + '{0}'.format(value)
-            )
+            target_opt_prefs_list[
+                OID_PING_HOST + ':3:checkbox:' + 'Do an ICMP ping'
+            ] = value
 
             if alive_test & AliveTest.ALIVE_TEST_ARP:
                 value = "yes"
             else:
                 value = "no"
-            target_opt_prefs_list.append(
-                OID_PING_HOST
-                + ':4:checkbox:'
-                + 'Use ARP|||'
-                + '{0}'.format(value)
-            )
+            target_opt_prefs_list[
+                OID_PING_HOST + ':4:checkbox:' + 'Use ARP'
+            ] = value
 
             if alive_test & AliveTest.ALIVE_TEST_CONSIDER_ALIVE:
                 value = "no"
             else:
                 value = "yes"
-            target_opt_prefs_list.append(
+            target_opt_prefs_list[
                 OID_PING_HOST
                 + ':5:checkbox:'
-                + 'Mark unrechable Hosts as dead (not scanning)|||'
-                + '{0}'.format(value)
-            )
+                + 'Mark unrechable Hosts as dead (not scanning)'
+            ] = value
 
             # Also select a method, otherwise Ping Host logs a warning.
             if alive_test == AliveTest.ALIVE_TEST_CONSIDER_ALIVE:
-                target_opt_prefs_list.append(
-                    OID_PING_HOST + ':1:checkbox:' + 'Do a TCP ping|||yes'
-                )
+                target_opt_prefs_list[
+                    OID_PING_HOST + ':1:checkbox:' + 'Do a TCP ping'
+                ] = 'yes'
+
         return target_opt_prefs_list
 
     def prepare_alive_test_option_for_openvas(self):
@@ -396,9 +392,7 @@ class PreferenceHandler:
             alive_test_opt = self.build_alive_test_opt_as_prefs(
                 self.target_options
             )
-            self.kbdb.add_scan_preferences(
-                self._openvas_scan_id, alive_test_opt
-            )
+            self._nvts_params.update(alive_test_opt)
 
     def prepare_boreas_alive_test(self):
         """Set alive_test for Boreas if boreas scanner config


### PR DESCRIPTION
**What**:
The selected alive test option overwrite the default settings.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The issue was that the preferences where added twice, but always
the default ones were used because were found first.
<!-- Why are these changes necessary? -->

**How**:
Run a scan with some alive test method different to the default one. An easy tests is to select "consider alive" against a dead hosts.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
