### PR TITLE
Improve logging for unsatisfied vts dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [20.8.1] (unreleased)
+###
+- Improve logging for unsatisfied vts dependencies[#336](https://github.com/greenbone/ospd-openvas/pull/336)
 
 ### Fixed
 - Fix nvticache name when for stable version from sources. [#317](https://github.com/greenbone/ospd-openvas/pull/317)

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -359,6 +359,8 @@ OSPD_PARAMS = {
     },
 }
 
+VT_BASE_OID = "1.3.6.1.4.1.25623."
+
 
 def safe_int(value: str) -> Optional[int]:
     """Convert a string into an integer and return None in case of errors
@@ -717,7 +719,7 @@ class OSPDopenvas(OSPDaemon):
         vt_deps_xml = Element('dependencies')
         for dep in vt_dependencies:
             _vt_dep = Element('dependency')
-            if "1.3.6.1.4.1.25623." in dep:
+            if VT_BASE_OID in dep:
                 _vt_dep.set('vt_id', dep)
             else:
                 logger.error(

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -717,9 +717,9 @@ class OSPDopenvas(OSPDaemon):
         vt_deps_xml = Element('dependencies')
         for dep in vt_dependencies:
             _vt_dep = Element('dependency')
-            try:
+            if "1.3.6.1.4.1.25623." in dep:
                 _vt_dep.set('vt_id', dep)
-            except (ValueError, TypeError):
+            else:
                 logger.error(
                     'Not possible to add dependency %s for VT %s', dep, vt_id
                 )

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -46,8 +46,12 @@ class VtHelper:
             if 'dependencies' in custom:
                 deps = custom.pop('dependencies')
                 deps_list = deps.split(', ')
-                for dep in deps_list:
-                    vt_dependencies.append(oids.get(dep))
+                for dep_name in deps_list:
+                    dep_oid = oids.get(dep_name)
+                    if dep_oid:
+                        vt_dependencies.append(dep_oid)
+                    else:
+                        vt_dependencies.append(dep_name)
         else:
             vt_dependencies = None
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -461,10 +461,11 @@ class TestOspdOpenvas(TestCase):
 
         out = (
             '<dependencies>'
-            '<dependency vt_id="1.2.3.4"/><dependency vt_id="4.3.2.1"/>'
+            '<dependency vt_id="1.3.6.1.4.1.25623.1.2.3.4"/>'
+            '<dependency vt_id="1.3.6.1.4.1.25623.4.3.2.1"/>'
             '</dependencies>'
         )
-        dep = ['1.2.3.4', '4.3.2.1']
+        dep = ['1.3.6.1.4.1.25623.1.2.3.4', '1.3.6.1.4.1.25623.4.3.2.1']
         res = w.get_dependencies_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', dep
         )
@@ -686,7 +687,9 @@ class TestOspdOpenvas(TestCase):
     @patch('ospd_openvas.daemon.Path.exists')
     @patch('ospd_openvas.daemon.Path.open')
     def test_feed_is_outdated_true(
-        self, mock_path_open: MagicMock, mock_path_exists: MagicMock,
+        self,
+        mock_path_open: MagicMock,
+        mock_path_exists: MagicMock,
     ):
         read_data = 'PLUGIN_SET = "1235";'
 
@@ -709,7 +712,9 @@ class TestOspdOpenvas(TestCase):
     @patch('ospd_openvas.daemon.Path.exists')
     @patch('ospd_openvas.daemon.Path.open')
     def test_feed_is_outdated_false(
-        self, mock_path_open: MagicMock, mock_path_exists: MagicMock,
+        self,
+        mock_path_open: MagicMock,
+        mock_path_exists: MagicMock,
     ):
         mock_path_exists.return_value = True
 
@@ -807,7 +812,8 @@ class TestOspdOpenvas(TestCase):
 
         w.report_openvas_results(MockDBClass, '123-456', 'localhost')
         w.scan_collection.set_amount_dead_hosts.assert_called_with(
-            '123-456', total_dead=4,
+            '123-456',
+            total_dead=4,
         )
 
     @patch('ospd_openvas.daemon.ScanDB')

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -472,6 +472,21 @@ class TestOspdOpenvas(TestCase):
 
         self.assertEqual(res, out)
 
+    def test_get_dependencies_xml_missing_dep(self):
+        w = DummyDaemon()
+
+        out = (
+            '<dependencies>'
+            '<dependency vt_id="1.3.6.1.4.1.25623.1.2.3.4"/>'
+            '</dependencies>'
+        )
+        dep = ['1.3.6.1.4.1.25623.1.2.3.4', 'file_name.nasl']
+        res = w.get_dependencies_vt_as_xml_str(
+            '1.3.6.1.4.1.25623.1.0.100061', dep
+        )
+
+        self.assertEqual(res, out)
+
     def test_get_dependencies_xml_failed(self):
         w = DummyDaemon()
         logging.Logger.error = Mock()


### PR DESCRIPTION
**What**:
Log the file name of the missing dependency.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Because it is currently log only the OID of the problematic VT, but not the name of the missing dependency.
<!-- Why are these changes necessary? -->

**How**:
Modify a nasl script, adding a typo to an existing dependency. Run openvas -u to update the Redis cache. Run <get_vts/> command. You will see in the logs, the name of the missing deps for the modified nasl plugin.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
