### PR TITLE
Add methods for adding VTs to the redis cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add dedicated port list for alive detection (Boreas only) as scanner preference if supplied via OSP. [#327](https://github.com/greenbone/ospd-openvas/pull/327)
+- Add methods for adding VTs to the redis cache.[#337](https://github.com/greenbone/ospd-openvas/pull/337)
 
 ### Changed
 - Get all results from main kb. [#285](https://github.com/greenbone/ospd-openvas/pull/285)

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -295,17 +295,18 @@ class OpenvasDB:
             value: Elements to add to the key.
         """
         if not ctx:
-            raise RequiredArgument('add_list_item', 'ctx')
+            raise RequiredArgument('add_single_item', 'ctx')
         if not name:
-            raise RequiredArgument('add_list_item', 'name')
+            raise RequiredArgument('add_single_item', 'name')
         if not values:
-            raise RequiredArgument('add_list_item', 'value')
+            raise RequiredArgument('add_single_item', 'value')
 
         ctx.rpush(name, *set(values))
 
     @staticmethod
     def set_single_item(ctx: RedisCtx, name: str, value: Iterable):
-        """Set (replace) a single KB element.
+        """Set (replace) a single KB element. If the same key exists
+        in the kb, it is completed removed. Values added are unique.
 
         Arguments:
             ctx: Redis context to use.

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -261,8 +261,33 @@ class OpenvasDB:
         return ctx.lindex(name, index)
 
     @staticmethod
-    def add_single_item(ctx: RedisCtx, name: str, values: Iterable):
+    def add_single_list(ctx: RedisCtx, name: str, values: Iterable):
         """Add a single KB element with one or more values.
+        The values can be repeated. If the key already exists will
+        be removed an completely replaced.
+
+        Arguments:
+            ctx: Redis context to use.
+            name: key name of a list.
+            value: Elements to add to the key.
+        """
+        if not ctx:
+            raise RequiredArgument('add_single_list', 'ctx')
+        if not name:
+            raise RequiredArgument('add_single_list', 'name')
+        if not values:
+            raise RequiredArgument('add_single_list', 'value')
+
+        pipe = ctx.pipeline()
+        pipe.delete(name)
+        pipe.rpush(name, *values)
+        pipe.execute()
+
+    @staticmethod
+    def add_single_item(ctx: RedisCtx, name: str, values: Iterable):
+        """Add a single KB element with one or more values. Don't add
+        duplicated values during this operation, but if the the same
+        values already exists under the key, this will not be overwritten.
 
         Arguments:
             ctx: Redis context to use.

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -23,6 +23,8 @@ import logging
 
 from typing import List, Dict, Optional, Iterator, Tuple
 
+from ospd.errors import RequiredArgument
+from ospd_openvas.errors import OspdOpenvasError
 from ospd_openvas.db import NVT_META_FIELDS, OpenvasDB, MainDB, BaseDB, RedisCtx
 
 NVTI_CACHE_NAME = "nvticache"
@@ -306,3 +308,15 @@ class NVTICache(BaseDB):
 
     def force_reload(self):
         self._main_db.release_database(self)
+
+    def add_vt_to_cache(self, vt_id: str, vt: List[str]):
+        if not vt_id:
+            raise RequiredArgument('add_vt_to_cache', 'vt_id')
+        if not vt:
+            raise RequiredArgument('add_vt_to_cache', 'vt')
+        if not isinstance(vt, list) or len(vt) != 15:
+            raise OspdOpenvasError(
+                'Error trying to load the VT' ' {} in cache'.format(vt)
+            )
+
+        OpenvasDB.add_single_list(self.ctx, vt_id, vt)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -164,11 +164,23 @@ class TestOpenvasDB(TestCase):
         self.assertEqual(value, 'a')
         ctx.lindex.assert_called_once_with('a', 0)
 
+    def test_add_single_list(self, mock_redis):
+        ctx = mock_redis.return_value
+        pipeline = ctx.pipeline.return_value
+        pipeline.delete.return_value = None
+        pipeline.execute.return_value = (None, 0)
+
+        OpenvasDB.add_single_list(ctx, 'a', ['12', '11', '12'])
+
+        pipeline.delete.assert_called_once_with('a')
+        pipeline.rpush.assert_called_once_with('a', '12', '11', '12')
+        assert_called(pipeline.execute)
+
     def test_add_single_item(self, mock_redis):
         ctx = mock_redis.return_value
         ctx.rpush.return_value = 1
 
-        OpenvasDB.add_single_item(ctx, 'a', ['12'])
+        OpenvasDB.add_single_item(ctx, 'a', ['12', '12'])
 
         ctx.rpush.assert_called_once_with('a', '12')
 
@@ -350,7 +362,12 @@ class ScanDBTestCase(TestCase):
 
         ret = self.db.get_result()
 
-        self.assertEqual(ret, ['some result',])
+        self.assertEqual(
+            ret,
+            [
+                'some result',
+            ],
+        )
         mock_openvas_db.pop_list_items.assert_called_with(
             self.ctx, 'internal/results'
         )
@@ -393,7 +410,12 @@ class KbDBTestCase(TestCase):
 
         ret = self.db.get_result()
 
-        self.assertEqual(ret, ['some results',])
+        self.assertEqual(
+            ret,
+            [
+                'some results',
+            ],
+        )
         mock_openvas_db.pop_list_items.assert_called_with(
             self.ctx, 'internal/results'
         )

--- a/tests/test_nvti_cache.py
+++ b/tests/test_nvti_cache.py
@@ -84,8 +84,10 @@ class TestNVTICache(TestCase):
         logging.Logger.error = Mock()
 
         tags = 'tag1'
-        ret = NVTICache._parse_metadata_tags(  # pylint: disable=protected-access
-            tags, '1.2.3'
+        ret = (
+            NVTICache._parse_metadata_tags(  # pylint: disable=protected-access
+                tags, '1.2.3'
+            )
         )
 
         self.assertEqual(ret, {})
@@ -93,16 +95,20 @@ class TestNVTICache(TestCase):
 
     def test_parse_metadata_tag(self, MockOpenvasDB):
         tags = 'tag1=value1'
-        ret = NVTICache._parse_metadata_tags(  # pylint: disable=protected-access
-            tags, '1.2.3'
+        ret = (
+            NVTICache._parse_metadata_tags(  # pylint: disable=protected-access
+                tags, '1.2.3'
+            )
         )
 
         self.assertEqual(ret, {'tag1': 'value1'})
 
     def test_parse_metadata_tags(self, MockOpenvasDB):
         tags = 'tag1=value1|foo=bar'
-        ret = NVTICache._parse_metadata_tags(  # pylint: disable=protected-access
-            tags, '1.2.3'
+        ret = (
+            NVTICache._parse_metadata_tags(  # pylint: disable=protected-access
+                tags, '1.2.3'
+            )
         )
 
         self.assertEqual(ret, {'tag1': 'value1', 'foo': 'bar'})
@@ -310,3 +316,48 @@ class TestNVTICache(TestCase):
         self.nvti.flush()
 
         self.nvti._ctx.flushdb.assert_called_with()
+
+    def test_add_vt(self, MockOpenvasDB):
+        MockOpenvasDB.add_single_list = Mock()
+
+        self.nvti.add_vt_to_cache(
+            '1234',
+            [
+                'a',
+                'b',
+                'c',
+                'd',
+                'e',
+                'f',
+                'g',
+                'h',
+                'i',
+                'j',
+                'k',
+                'l',
+                'm',
+                'n',
+                'o',
+            ],
+        )
+        MockOpenvasDB.add_single_list.assert_called_with(
+            'foo',
+            '1234',
+            [
+                'a',
+                'b',
+                'c',
+                'd',
+                'e',
+                'f',
+                'g',
+                'h',
+                'i',
+                'j',
+                'k',
+                'l',
+                'm',
+                'n',
+                'o',
+            ],
+        )


### PR DESCRIPTION
**What**:
Add methods for adding VTs to the redis cache.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Currently there isn't a method to add elements under a key in redis with the same value, since the methods are being added as set, which does not allow duplicated entries.

<!-- Why are these changes necessary? -->

**How**:
``` python
from ospd_openvas import db
from ospd_openvas import nvticache

db_c = db.MainDB()
cache = nvticache.NVTICache(db_c)

nt_list = ['some_file.csv', '', '', '', '', '', '', "cvss_base_vector=AV:N/AC:L/Au:N/C:P/I:N/A:N|last_modification=1600178364|creation_date=1600178364|summary=The remote host is missing an update for package(s) announced advisory.|vuldetect=Checks if a vulnerable package version is present on the target host.|insight=Some insight (CVE-1234)|affected=affected|solution=Please install the updated package(s).|solution_type=VendorFix|qod_type=package", 'CVE-1234', '', 'URL:https://developer.com', '3', '0', 'Some family', 'Some vt name)']

cache.add_vt_to_cache(vt_id='1234', vt=nt_list)
``` 
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
