### PR TITLE
Check for empty vts preferences list

### DIFF
--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -281,7 +281,9 @@ class PreferenceHandler:
         items_list = []
         for key, val in self._nvts_params.items():
             items_list.append('%s|||%s' % (key, val))
-        self.kbdb.add_scan_preferences(self._openvas_scan_id, items_list)
+
+        if items_list:
+            self.kbdb.add_scan_preferences(self._openvas_scan_id, items_list)
 
     @staticmethod
     def build_alive_test_opt_as_prefs(

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -583,3 +583,15 @@ class PreferenceHandlerTestCase(TestCase):
             p._openvas_scan_id,
             alive_test_out,
         )
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_prepare_nvt_prefs_no_prefs(self, mock_kb):
+        w = DummyDaemon()
+
+        p = PreferenceHandler('456-789', mock_kb, w.scan_collection, None)
+        p._nvts_params = {}
+        p._openvas_scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        p.prepare_nvt_preferences()
+
+        p.kbdb.add_scan_preferences.assert_not_called()


### PR DESCRIPTION
**What**:
Check for empty vts preferences list before trying to add an empty list into redis.

**Why**:
Adding an empty list is not allowed and raises an exception. Not it is check. This can happen for small scan configs with less VTs without preferences.

<!-- Why are these changes necessary? -->

**How**:
I find this issue running a small scan config with only one selected VT "ssh_authorization.nasl"
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
