### PR TITLE
Support CVSSv3 and use new tags for severity vector, origin, date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add dedicated port list for alive detection (Boreas only) as scanner preference if supplied via OSP. [#327](https://github.com/greenbone/ospd-openvas/pull/327)
 - Add methods for adding VTs to the redis cache.[#337](https://github.com/greenbone/ospd-openvas/pull/337)
 - Add support for supplying alive test methods via seperate elements. [#331](https://github.com/greenbone/ospd-openvas/pull/331)
+- Add support CVSSv3 and accept new tags for severity vector, origin, date. [#346](https://github.com/greenbone/ospd-openvas/pull/346)
 
 ### Changed
 - Get all results from main kb. [#285](https://github.com/greenbone/ospd-openvas/pull/285)

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1000,6 +1000,8 @@ class OSPDopenvas(OSPDaemon):
 
             if severity_type == "cvss_base_v2" and severity_vector:
                 return CVSS.cvss_base_v2_value(severity_vector)
+            elif severity_type == "cvss_base_v3" and severity_vector:
+                return CVSS.cvss_base_v3_value(severity_vector)
 
         return None
 

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -85,8 +85,8 @@ class VtHelper:
             qod_v = custom.pop('qod')
 
         severity = dict()
-        if 'severity_score' in custom:
-            severity_vector = custom.pop('severity_score')
+        if 'severity_vector' in custom:
+            severity_vector = custom.pop('severity_vector')
         else:
             severity_vector = custom.pop('cvss_base_vector')
         severity['severity_base_vector'] = severity_vector

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -85,16 +85,23 @@ class VtHelper:
             qod_v = custom.pop('qod')
 
         severity = dict()
-        if 'severity_base_vector' in custom:
-            severity_vector = custom.pop('severity_base_vector')
+        if 'severity_score' in custom:
+            severity_vector = custom.pop('severity_score')
         else:
             severity_vector = custom.pop('cvss_base_vector')
         severity['severity_base_vector'] = severity_vector
-        if 'severity_type' in custom:
-            severity_type = custom.pop('severity_type')
+
+        if "CVSS:3" in severity_vector:
+            severity_type = 'cvss_base_v3'
         else:
             severity_type = 'cvss_base_v2'
         severity['severity_type'] = severity_type
+
+        if 'severity_date' in custom:
+            severity['severity_date'] = custom.pop('severity_date')
+        else:
+            severity['severity_date'] = vt_creation_time
+
         if 'severity_origin' in custom:
             severity['severity_origin'] = custom.pop('severity_origin')
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -945,3 +945,26 @@ class TestFilters(TestCase):
             vts_collection, "modification_time>10"
         )
         self.assertIn('1.3.6.1.4.1.25623.1.0.100061', res)
+
+    def test_get_severity_score_v2(self):
+        w = DummyDaemon()
+        vtaux = {
+            'severities': {
+                'severity_type': 'cvss_base_v2',
+                'severity_base_vector': 'AV:N/AC:L/Au:N/C:P/I:N/A:N',
+            }
+        }
+
+        a = w.get_severity_score(vtaux)
+        self.assertEqual(w.get_severity_score(vtaux), 5.0)
+
+    def test_get_severity_score_v3(self):
+        w = DummyDaemon()
+        vtaux = {
+            'severities': {
+                'severity_type': 'cvss_base_v3',
+                'severity_base_vector': 'CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L',
+            }
+        }
+
+        self.assertEqual(w.get_severity_score(vtaux), 2.9)

--- a/tests/test_vthelper.py
+++ b/tests/test_vthelper.py
@@ -100,7 +100,7 @@ class VtHelperTestCase(TestCase):
             'category': '3',
             'creation_date': '1237458156',
             'cvss_base_vector': 'AV:N/AC:L/Au:N/C:N/I:N/A:N',
-            'severity_score': 'CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L',
+            'severity_vector': 'CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L',
             'severity_date': '1237458156',
             'severity_origin': 'Greenbone',
             'excluded_keys': 'Settings/disable_cgi_scanning',

--- a/tests/test_vthelper.py
+++ b/tests/test_vthelper.py
@@ -93,3 +93,122 @@ class VtHelperTestCase(TestCase):
 
         for _, values in vthelper.get_vt_iterator(vt_selection=vt):
             self.assertIs(values, None)
+
+    def test_get_single_vt_severity_cvssv3(self):
+        w = DummyDaemon()
+        w.nvti.get_nvt_metadata.return_value = {
+            'category': '3',
+            'creation_date': '1237458156',
+            'cvss_base_vector': 'AV:N/AC:L/Au:N/C:N/I:N/A:N',
+            'severity_score': 'CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L',
+            'severity_date': '1237458156',
+            'severity_origin': 'Greenbone',
+            'excluded_keys': 'Settings/disable_cgi_scanning',
+            'family': 'Product detection',
+            'filename': 'mantis_detect.nasl',
+            'last_modification': ('1533906565'),
+            'name': 'Mantis Detection',
+            'qod_type': 'remote_banner',
+            'required_ports': 'Services/www, 80',
+            'solution': 'some solution',
+            'solution_type': 'WillNotFix',
+            'solution_method': 'DebianAPTUpgrade',
+            'impact': 'some impact',
+            'insight': 'some insight',
+            'summary': ('some summary'),
+            'affected': 'some affection',
+            'timeout': '0',
+            'vt_params': {
+                '1': {
+                    'id': '1',
+                    'default': '',
+                    'description': 'Description',
+                    'name': 'Data length :',
+                    'type': 'entry',
+                },
+                '2': {
+                    'id': '2',
+                    'default': 'no',
+                    'description': 'Description',
+                    'name': 'Do not randomize the  order  in  which ports are scanned',  # pylint: disable=line-too-long
+                    'type': 'checkbox',
+                },
+            },
+            'refs': {
+                'bid': [''],
+                'cve': [''],
+                'xref': ['URL:http://www.mantisbt.org/'],
+            },
+        }
+
+        vthelper = VtHelper(w.nvti)
+
+        res = vthelper.get_single_vt("1.3.6.1.4.1.25623.1.0.100061")
+        assert_called_once(w.nvti.get_nvt_metadata)
+
+        severities = res.get('severities')
+        self.assertEqual(
+            "CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L",
+            severities.get('severity_base_vector'),
+        )
+        self.assertEqual("cvss_base_v3", severities.get('severity_type'))
+        self.assertEqual("Greenbone", severities.get('severity_origin'))
+        self.assertEqual("1237458156", severities.get('severity_date'))
+
+    def test_get_single_vt_severity_cvssv2(self):
+        w = DummyDaemon()
+        w.nvti.get_nvt_metadata.return_value = {
+            'category': '3',
+            'creation_date': '1237458156',
+            'cvss_base_vector': 'AV:N/AC:L/Au:N/C:N/I:N/A:N',
+            'excluded_keys': 'Settings/disable_cgi_scanning',
+            'family': 'Product detection',
+            'filename': 'mantis_detect.nasl',
+            'last_modification': ('1533906565'),
+            'name': 'Mantis Detection',
+            'qod_type': 'remote_banner',
+            'required_ports': 'Services/www, 80',
+            'solution': 'some solution',
+            'solution_type': 'WillNotFix',
+            'solution_method': 'DebianAPTUpgrade',
+            'impact': 'some impact',
+            'insight': 'some insight',
+            'summary': ('some summary'),
+            'affected': 'some affection',
+            'timeout': '0',
+            'vt_params': {
+                '1': {
+                    'id': '1',
+                    'default': '',
+                    'description': 'Description',
+                    'name': 'Data length :',
+                    'type': 'entry',
+                },
+                '2': {
+                    'id': '2',
+                    'default': 'no',
+                    'description': 'Description',
+                    'name': 'Do not randomize the  order  in  which ports are scanned',  # pylint: disable=line-too-long
+                    'type': 'checkbox',
+                },
+            },
+            'refs': {
+                'bid': [''],
+                'cve': [''],
+                'xref': ['URL:http://www.mantisbt.org/'],
+            },
+        }
+
+        vthelper = VtHelper(w.nvti)
+
+        res = vthelper.get_single_vt("1.3.6.1.4.1.25623.1.0.100061")
+        assert_called_once(w.nvti.get_nvt_metadata)
+
+        severities = res.get('severities')
+        self.assertEqual(
+            "AV:N/AC:L/Au:N/C:N/I:N/A:N",
+            severities.get('severity_base_vector'),
+        )
+        self.assertEqual("cvss_base_v2", severities.get('severity_type'))
+        self.assertEqual(None, severities.get('severity_origin'))
+        self.assertEqual("1237458156", severities.get('severity_date'))


### PR DESCRIPTION
**What**:
If new tags are present, check also the type and set it.
Otherwise, it asumes cvss v2, don't set an origin and use the creation time for
the severity date element.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Because CVSSv3 support is required.

<!-- Why are these changes necessary? -->

**How**:
Add to some script the following tags (in the example the script with OID:1.3.6.1.4.1.25623.1.0.100082):

```
  script_tag(name:"severity_score", value:"CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L");
  script_tag(name:"severity_origin", value:"greenbone");
  script_tag(name:"severity_date", value:"1603191789");
```
To check the output 

```
gvm-cli --protocol OSP --timeout 120 socket --socketpath=/var/run/ospd/openvas.sock --xml "<get_vts vt_id='1.3.6.1.4.1.25623.1.0.100082'/>" |xmlstarlet fo
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
