### PR TITLE
Depend on unreleased version of ospd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     python_requires='>=3.5',
-    install_requires=['ospd>=20.8.0', 'redis>=3.0.1', 'psutil', 'packaging'],
+    install_requires=['ospd>20.8.1', 'redis>=3.0.1', 'psutil', 'packaging'],
     entry_points={'console_scripts': ['ospd-openvas=ospd_openvas.daemon:main']},
     test_suite="tests",
 )


### PR DESCRIPTION
**What**:

Require an unreleased version of ospd for using the 20.8 branch.

**Why**:

The ospd-20.8 branch contains API changes required for using the current
development version. Therefore require a version of ospd greater then
the last release.
