### PR TITLE
Support the new severity tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support CVSSv3 and accept new tags for severity vector, origin, date. [#346](https://github.com/greenbone/ospd-openvas/pull/346)
 - Add the Notus Metadata Handler for uploading VT metadata into Redis and performing checksum checks. [#348](https://github.com/greenbone/ospd-openvas/pull/348)
 - Add test and code improvements related to Notus Metadata Handler. [#352](https://github.com/greenbone/ospd-openvas/pull/352)
+- Add support for new severity tags to Notus. [#357](https://github.com/greenbone/ospd-openvas/pull/357)
 
 ### Changed
 - Get all results from main kb. [#285](https://github.com/greenbone/ospd-openvas/pull/285)

--- a/ospd_openvas/notus/metadata.py
+++ b/ospd_openvas/notus/metadata.py
@@ -46,8 +46,9 @@ EXPECTED_FIELD_NAMES_LIST = [
     "LAST_MODIFICATION",
     "SOURCE_PKGS",
     "ADVISORY_ID",
-    "CVSS_BASE_VECTOR",
-    "CVSS_BASE",
+    "SEVERITY_ORIGIN",
+    "SEVERITY_DATE",
+    "SEVERITY_VECTOR",
     "ADVISORY_XREF",
     "DESCRIPTION",
     "INSIGHT",
@@ -304,13 +305,16 @@ class NotusMetadataHandler:
             advisory_metadata_list.append(DEPENDENCIES)
             # Tags
             tags_string = (
-                "cvss_base_vector={}|last_modification={}|"
+                "severity_origin={}|severity_date={}|"
+                "severity_vector={}|last_modification={}|"
                 "creation_date={}|summary={}|vuldetect={}|"
                 "insight={}|affected={}|solution={}|"
                 "solution_type={}|qod_type={}"
             )
             tags_string = tags_string.format(
-                advisory_dict["CVSS_BASE_VECTOR"],
+                advisory_dict["SEVERITY_ORIGIN"],
+                advisory_dict["SEVERITY_DATE"],
+                advisory_dict["SEVERITY_VECTOR"],
                 advisory_dict["LAST_MODIFICATION"],
                 advisory_dict["CREATION_DATE"],
                 advisory_dict["DESCRIPTION"],

--- a/tests/notus/example.csv
+++ b/tests/notus/example.csv
@@ -1,4 +1,4 @@
 # General metadata:
 {'VULDETECT': 'Checks if a vulnerable package version is present on the target host.', 'SOLUTION': 'Please install the updated package(s).', 'SOLUTION_TYPE': 'VendorFix', 'QOD_TYPE': 'package'}
-OID,TITLE,CREATION_DATE,LAST_MODIFICATION,SOURCE_PKGS,ADVISORY_ID,CVSS_BASE_VECTOR,CVSS_BASE,ADVISORY_XREF,DESCRIPTION,INSIGHT,AFFECTED,CVE_LIST,BINARY_PACKAGES_FOR_RELEASES,XREFS
-1.3.6.1.4.1.25623.1.1.2.2020.1234,VendorOS: Security Advisory for git (VendorOS-2020-1234),1600269468,1601380531,['git'],VendorOS-2020-1234,AV:N/AC:L/Au:N/C:C/I:C/A:C,10.0,https://example.com,The remote host is missing an update.,"buffer overflow",'p1' package(s) on VendorOS V2.0SP1,"['CVE-2020-1234']","{'VendorOS V2.0SP1': ['p1-1.1']}",[]
+OID,TITLE,CREATION_DATE,LAST_MODIFICATION,SOURCE_PKGS,ADVISORY_ID,SEVERITY_ORIGIN,SEVERITY_DATE,SEVERITY_VECTOR,ADVISORY_XREF,DESCRIPTION,INSIGHT,AFFECTED,CVE_LIST,BINARY_PACKAGES_FOR_RELEASES,XREFS
+1.3.6.1.4.1.25623.1.1.2.2020.1234,VendorOS: Security Advisory for git (VendorOS-2020-1234),1600269468,1601380531,['git'],VendorOS-2020-1234,CVE-2020-1234,1600269300,CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H,https://example.com,The remote host is missing an update.,"buffer overflow",'p1' package(s) on VendorOS V2.0SP1,"['CVE-2020-1234']","{'VendorOS V2.0SP1': ['p1-1.1']}",[]

--- a/tests/notus/test_notus.py
+++ b/tests/notus/test_notus.py
@@ -81,7 +81,7 @@ class LockFileTestCase(unittest.TestCase):
     def test_is_checksum_correct_enabled_true(self):
         notus = NotusMetadataHandler(nvti=self.nvti)
         notus.nvti.get_file_checksum.return_value = (
-            "aafbaf3fac1c64a4006a02ed4657b975f47b07cd2915c8186ff1739ac6216e72"
+            "2f561b9be5d1a1194f49cd5a6a024dee15a0c0bc7d94287266d0e6358e737f4e"
         )
         notus._openvas_settings_dict = {'nasl_no_signature_check': 0}
 
@@ -228,8 +228,9 @@ class LockFileTestCase(unittest.TestCase):
             "LAST_MODIFICATION",
             "SOURCE_PKGS",
             "ADVISORY_ID",
-            "CVSS_BASE_VECTOR",
-            "CVSS_BASE",
+            "SEVERITY_ORIGIN",
+            "SEVERITY_DATE",
+            "SEVERITY_VECTOR",
             "ADVISORY_XREF",
             "DESCRIPTION",
             "INSIGHT",
@@ -238,7 +239,6 @@ class LockFileTestCase(unittest.TestCase):
             "BINARY_PACKAGES_FOR_RELEASES",
             "XREFS",
         ]
-
         self.assertTrue(notus._check_field_names_lsc(field_names_list))
 
     def test_check_field_names_lsc_unordered(self):
@@ -250,8 +250,9 @@ class LockFileTestCase(unittest.TestCase):
             "LAST_MODIFICATION",
             "SOURCE_PKGS",
             "ADVISORY_ID",
-            "CVSS_BASE_VECTOR",
-            "CVSS_BASE",
+            "SEVERITY_ORIGIN",
+            "SEVERITY_DATE",
+            "SEVERITY_VECTOR",
             "ADVISORY_XREF",
             "DESCRIPTION",
             "INSIGHT",


### PR DESCRIPTION
**What**:
Support the new severity tags severity_origin, severity_date and severity_vector.
Also, remove the old tags  cvss_score and cvss_base_vector, since
Notus is only available in 21.04 and later.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
