### PR TITLE
Check if Notus is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Get all results from main kb. [#285](https://github.com/greenbone/ospd-openvas/pull/285)
 - Extend severities with origin and date. [#192](https://github.com/greenbone/ospd-openvas/pull/192)
 - Rename the Notus Metadata Handler file to just "Metadata" [#351](https://github.com/greenbone/ospd-openvas/pull/351)
+- Check if Notus is enabled before loading metadata. [#364](https://github.com/greenbone/ospd-openvas/pull/364)
 
 ### Removed
 - Remove methods handling the nvticache name. [#318](https://github.com/greenbone/ospd-openvas/pull/318)

--- a/ospd_openvas/notus/metadata.py
+++ b/ospd_openvas/notus/metadata.py
@@ -378,6 +378,10 @@ class NotusMetadataHandler:
         and write this information to the Redis KB.
         """
 
+        # Check if Notus is enabled
+        if not self.openvas_setting.get("table_driven_lsc"):
+            return
+
         logger.debug("Starting the Notus metadata load up")
         # Get a list of all CSV files in that directory with their absolute path
         csv_abs_filepaths_list = self._get_csv_filepaths()

--- a/tests/notus/test_notus.py
+++ b/tests/notus/test_notus.py
@@ -32,7 +32,7 @@ from ospd_openvas.notus.metadata import (
 from ospd_openvas.errors import OspdOpenvasError
 
 
-class LockFileTestCase(unittest.TestCase):
+class NotusTestCase(unittest.TestCase):
     @patch('ospd_openvas.nvticache.NVTICache')
     def setUp(self, MockNvti):
         self.nvti = MockNvti()
@@ -293,10 +293,13 @@ class LockFileTestCase(unittest.TestCase):
 
         self.assertEqual(ret, [path])
 
-    def test_update_metadata_warning(self):
+    @patch('ospd_openvas.notus.metadata.Openvas')
+    def test_update_metadata_warning(self, MockOpenvas):
         notus = NotusMetadataHandler()
         logging.Logger.warning = MagicMock()
         path = Path("./tests/notus/example.csv").resolve()
+        openvas = MockOpenvas()
+        openvas.get_settings.return_value = {'table_driven_lsc': 1}
 
         notus._get_csv_filepaths = MagicMock(return_value=[path])
         notus.is_checksum_correct = MagicMock(return_value=False)
@@ -306,10 +309,13 @@ class LockFileTestCase(unittest.TestCase):
             f'Checksum for %s failed', path
         )
 
-    def test_update_metadata_field_name_failed(self):
+    @patch('ospd_openvas.notus.metadata.Openvas')
+    def test_update_metadata_field_name_failed(self, MockOpenvas):
         notus = NotusMetadataHandler(metadata_path="./tests/notus")
         logging.Logger.warning = MagicMock()
         path = Path("./tests/notus/example.csv").resolve()
+        openvas = MockOpenvas()
+        openvas.get_settings.return_value = {'table_driven_lsc': 1}
 
         notus._get_csv_filepaths = MagicMock(return_value=[path])
         notus.is_checksum_correct = MagicMock(return_value=True)
@@ -321,10 +327,13 @@ class LockFileTestCase(unittest.TestCase):
             f'Field names check for %s failed', path
         )
 
-    def test_update_metadata_failed(self):
+    @patch('ospd_openvas.notus.metadata.Openvas')
+    def test_update_metadata_failed(self, MockOpenvas):
         notus = NotusMetadataHandler(metadata_path="./tests/notus")
         logging.Logger.warning = MagicMock()
         path = Path("./tests/notus/example.csv").resolve()
+        openvas = MockOpenvas()
+        openvas.get_settings.return_value = {'table_driven_lsc': 1}
 
         notus._get_csv_filepaths = MagicMock(return_value=[path])
         notus.is_checksum_correct = MagicMock(return_value=True)
@@ -337,11 +346,19 @@ class LockFileTestCase(unittest.TestCase):
             "Some advaisory was not loaded from %s", path.name
         )
 
-    def test_update_metadata_success(self):
+    def test_update_metadata_disabled(self):
+        notus = NotusMetadataHandler(metadata_path="./tests/notus")
+        ret = notus.update_metadata()
+        self.assertIsNone(ret)
+
+    @patch('ospd_openvas.notus.metadata.Openvas')
+    def test_update_metadata_success(self, MockOpenvas):
         notus = NotusMetadataHandler(metadata_path="./tests/notus")
         logging.Logger.warning = MagicMock()
         path = Path("./tests/notus/example.csv").resolve()
         purepath = PurePath(path).name
+        openvas = MockOpenvas()
+        openvas.get_settings.return_value = {'table_driven_lsc': 1}
 
         notus._get_csv_filepaths = MagicMock(return_value=[path])
         notus.is_checksum_correct = MagicMock(return_value=True)


### PR DESCRIPTION
**What**:
Uses the new scanner only option "table_driven_lsc" to check if
notus is enabled. If it is enabled, it loads the Notus metadata
into the redis cache.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To upload the Notus metadata if required
<!-- Why are these changes necessary? -->

**How**:
Enable/disable Notus in the openvas configuration file and check the logs during plugins load up.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
