### PR TITLE
Don't expose notus driver VTs to clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rename the Notus Metadata Handler file to just "Metadata" [#351](https://github.com/greenbone/ospd-openvas/pull/351)
 - Check if Notus is enabled before loading metadata. [#364](https://github.com/greenbone/ospd-openvas/pull/364)
 - Launch NVTs or Notus driver, depending on availability. [#366](https://github.com/greenbone/ospd-openvas/pull/366)
+- Don't expose Notus driver VTs to clients. [#367](https://github.com/greenbone/ospd-openvas/pull/367)
 
 ### Removed
 - Remove methods handling the nvticache name. [#318](https://github.com/greenbone/ospd-openvas/pull/318)

--- a/ospd_openvas/notus/metadata.py
+++ b/ospd_openvas/notus/metadata.py
@@ -457,17 +457,17 @@ class NotusMetadataHandler:
     def get_family_driver_linkers(self) -> Optional[Dict]:
         """Get the a collection of advisory families supported
         by Notus and the linked OID of the driver script to run
-        the Notus scanner for the given family"""
+        the Notus scanner for the given family
 
-        # Check if Notus is enabled
-        if not self.openvas_setting.get("table_driven_lsc"):
-            return
+        This method always returns a dict with the supported families,
+        even if Notus Scanner is disabled.
+        """
 
         # Get a list of all CSV files in that directory with their absolute path
         csv_abs_filepaths_list = self._get_csv_filepaths()
 
-        # Read each CSV file
         family_driver_linkers = {}
+        # Read each CSV file
         for csv_abs_path in csv_abs_filepaths_list:
             # Check the checksums, unless they have been disabled
             if not self.is_checksum_correct(csv_abs_path):

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -23,6 +23,7 @@ from hashlib import sha256
 from typing import Optional, Dict, List, Tuple, Iterator
 
 from ospd_openvas.nvticache import NVTICache
+from ospd_openvas.notus.metadata import NotusMetadataHandler
 
 
 class VtHelper:
@@ -154,6 +155,15 @@ class VtHelper:
 
         return vt
 
+    def get_notus_driver_oids(self) -> List[str]:
+        """Return a list of oid corresponding to notus driver which
+        are considered backend entities and must not be exposed to
+        the OSP client."""
+        notus = NotusMetadataHandler()
+        lsc_families_and_drivers = notus.get_family_driver_linkers()
+
+        return lsc_families_and_drivers.values()
+
     def get_vt_iterator(
         self, vt_selection: List[str] = None, details: bool = True
     ) -> Iterator[Tuple[str, Dict]]:
@@ -169,7 +179,11 @@ class VtHelper:
             if details:
                 oids = vt_collection
 
+        # Notus driver oid list which are not sent.
+        drivers = self.get_notus_driver_oids()
         for vt_id in vt_selection:
+            if vt_id in drivers:
+                continue
             vt = self.get_single_vt(vt_id, oids)
             yield (vt_id, vt)
 
@@ -177,9 +191,14 @@ class VtHelper:
         """ Calculate the vts collection sha256 hash. """
         m = sha256()  # pylint: disable=invalid-name
 
+        # Notus driver oid list which are not sent.
+        drivers = self.get_notus_driver_oids()
+
         # for a reproducible hash calculation
         # the vts must already be sorted in the dictionary.
         for vt_id, vt in self.get_vt_iterator(details=False):
+            if vt_id in drivers:
+                continue
             param_chain = ""
             vt_params = vt.get('vt_params')
             if vt_params:


### PR DESCRIPTION
**What**:
Don't expose notus driver VTs to clients
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The notus drivers VTs are not exposed to the clients and are considered backend entities. Therefore are not sent in the get_vts command response.
<!-- Why are these changes necessary? -->

**How**:
Check with get_vts if the VT is present in the response.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
