### PR TITLE
Updated Description field of the ospd-openvas.service file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Improve logging for unsatisfied vts dependencies. [#336](https://github.com/greenbone/ospd-openvas/pull/336)
 - Do not use busy wait when waiting for the openvas scan process to finish. [#360](https://github.com/greenbone/ospd-openvas/pull/360)
+- The description field of the systemd ospd-openvas.service file was updated. [#372](https://github.com/greenbone/ospd-openvas/pull/372)
 
 ### Fixed
 - Fix nvticache name when for stable version from sources. [#317](https://github.com/greenbone/ospd-openvas/pull/317)

--- a/config/ospd-openvas.service
+++ b/config/ospd-openvas.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=OSPd based OpenVAS scanner (ospd-openvas)
+Description=OpenVAS Wrapper of the Greenbone Vulnerability Management (ospd-openvas)
 Documentation=man:ospd-openvas(8) man:openvas(8)
 After=network.target networking.service redis-server@openvas.service
 Wants=redis-server@openvas.service


### PR DESCRIPTION
We should have a reference to GVM in the description so i took the description from here:

https://github.com/greenbone/ospd-openvas/blob/b1ad2d8e00a3f2dd48a4628712ccc747ae8485ec/docs/ospd-openvas.8#L3

Better suggestions (also for the ospd-openvas.8) welcome.