### PR TITLE
Extend script_xref logging on unexpected data / input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Improve logging for unsatisfied vts dependencies. [#336](https://github.com/greenbone/ospd-openvas/pull/336)
 - Do not use busy wait when waiting for the openvas scan process to finish. [#360](https://github.com/greenbone/ospd-openvas/pull/360)
+- Improve logging for unexpected data in script_xref tags. [#374](https://github.com/greenbone/ospd-openvas/pull/374)
 
 ### Fixed
 - Fix nvticache name when for stable version from sources. [#317](https://github.com/greenbone/ospd-openvas/pull/317)

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -687,11 +687,12 @@ class OSPDopenvas(OSPDaemon):
                     for xref in value.split(', '):
                         try:
                             _type, _id = xref.split(':', 1)
-                        except ValueError:
+                        except ValueError as e:
                             logger.error(
-                                'Not possible to parse xref %s for VT %s',
+                                'Not possible to parse xref "%s" for VT %s: %s',
                                 xref,
                                 vt_id,
+                                e,
                             )
                             continue
                         vt_ref.set('type', _type.lower())


### PR DESCRIPTION
**What**:

Previously to this change we had the following log entry:

```
OSPD[9960] 2021-01-23 10:39:35,939: ERROR: (ospd_openvas.daemon) Not possible to parse xref Protocols and Services Are Running for VT 1.3.6.1.4.1.25623.1.0.150070
```

which had two issues:

1. There was no clear separation between the text of the log message and the text of the malformed xref.
2. The exception info was missing.

After this PR we now have:

```
OSPD[15404] 2021-01-25 09:02:42,784: ERROR: (ospd_openvas.daemon) Not possible to parse xref "Protocols and Services Are Running" for VT 1.3.6.1.4.1.25623.1.0.150070: not enough values to unpack (expected 2, got 1)
```

**Why**:

Better / more consistent logging.

**How**:

Startup `ospd-openvas` against the current feed with a VT that has the following `script_xref`:

```
script_xref(name:"Policy", value:"CIS Controls Version 7: 9.2 Ensure Only Approved Ports, Protocols and Services Are Running");
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
