### PR TITLE
Don't crash with non-ascii chars in openvas.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 ### Deprecated
 ### Removed
+
 ### Fixed
+- Don't crash with non-ascii chars in openvas.conf. [#391](https://github.com/greenbone/ospd-openvas/pull/381)
 
 [Unreleased]: https://github.com/greenbone/ospd-openvas/compare/v20.8.1...HEAD
 

--- a/ospd_openvas/openvas.py
+++ b/ospd_openvas/openvas.py
@@ -98,7 +98,7 @@ class Openvas:
         try:
             result = subprocess.check_output(['openvas', '-s'])
             result = result.decode('ascii')
-        except (subprocess.SubprocessError, OSError) as e:
+        except (subprocess.SubprocessError, OSError, UnicodeDecodeError) as e:
             logger.warning('Could not gather openvas settings. Reason %s', e)
             return param_list
 

--- a/tests/test_openvas.py
+++ b/tests/test_openvas.py
@@ -183,6 +183,19 @@ class OpenvasCommandTestCase(TestCase):
 
         self.assertFalse(settings)  # settings dict is empty
 
+        mock_check_output.reset_mock()
+
+        # from https://gehrcke.de/2015/12/how-to-raise-unicodedecodeerror-in-python-3/
+        mock_check_output.side_effect = UnicodeDecodeError(
+            'funnycodec', b'\x00\x00', 1, 2, 'This is just a fake reason!'
+        )
+
+        settings = Openvas.get_settings()
+
+        mock_check_output.assert_called_with(['openvas', '-s'])
+
+        self.assertFalse(settings)  # settings dict is empty
+
     @patch('ospd_openvas.openvas.subprocess.Popen')
     def test_start_scan(self, mock_popen: MagicMock):
         proc = Openvas.start_scan('scan_1')


### PR DESCRIPTION
**What**:
And let ospd-openvas exit gracefully.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
If there is a non-ascii char in the openvas.conf (like in the plugins directory path) ospd-openvas crashes
Close #376 
<!-- Why are these changes necessary? -->

**How**:

Add non-ascii char in the config_file option path and start ospd-openvas. Whit this patch opsd-openvas does not crashes and log messages. 
```
$ cat ~/install/etc/openvas/openvas.conf
### Basic config
config_file = /home/jjnicolaß/install/etc/openvas/openvas.conf
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
