### PR TITLE
test_create_paren_dirs_fail should not rely on the actual access rights

### DIFF
--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -21,7 +21,7 @@ import shutil
 import tempfile
 import fcntl
 
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 from unittest.mock import patch, MagicMock
 from ospd_openvas.lock import LockFile
@@ -36,7 +36,7 @@ class LockFileTestCase(unittest.TestCase):
         shutil.rmtree(str(self.temp_dir))
 
     def test_acquire_lock(self):
-        lock_file_path = self.temp_dir / 'test.lock'
+        lock_file_path = self.temp_dir / "test.lock"
 
         lock_file = LockFile(lock_file_path)
         lock_file._acquire_lock()
@@ -45,9 +45,9 @@ class LockFileTestCase(unittest.TestCase):
         self.assertTrue(lock_file_path.exists())
         lock_file._release_lock()
 
-    @patch('ospd_openvas.lock.logger')
+    @patch("ospd_openvas.lock.logger")
     def test_already_locked(self, mock_logger):
-        lock_file_path = self.temp_dir / 'test.lock'
+        lock_file_path = self.temp_dir / "test.lock"
 
         lock_file_aux = LockFile(lock_file_path)
         lock_file_aux._acquire_lock()
@@ -61,7 +61,7 @@ class LockFileTestCase(unittest.TestCase):
         lock_file_aux._release_lock()
 
     def test_create_parent_dirs(self):
-        lock_file_path = self.temp_dir / 'foo' / 'bar' / 'test.lock'
+        lock_file_path = self.temp_dir / "foo" / "bar" / "test.lock"
 
         lock_file = LockFile(lock_file_path)
         lock_file._acquire_lock()
@@ -74,9 +74,13 @@ class LockFileTestCase(unittest.TestCase):
 
         lock_file._release_lock()
 
-    @patch('ospd_openvas.lock.logger')
+    @patch("ospd_openvas.lock.logger")
     def test_create_paren_dirs_fail(self, mock_logger):
-        lock_file_path = Path('/root/lock/file/test.lock')
+        lock_file_path = MagicMock(spec=Path).return_value
+        parent = MagicMock(spec=PosixPath)
+        lock_file_path.parent = parent
+        parent.mkdir.side_effect = PermissionError
+
         lock_file = LockFile(lock_file_path)
 
         lock_file._acquire_lock()
@@ -85,7 +89,7 @@ class LockFileTestCase(unittest.TestCase):
         assert_called_once(mock_logger.error)
 
     def test_context_manager(self):
-        lock_file_path = self.temp_dir / 'test.lock'
+        lock_file_path = self.temp_dir / "test.lock"
 
         lock_file = LockFile(lock_file_path)
 


### PR DESCRIPTION
When you're building a debian package within container.io definition
than you tyically do that as root with access to /root/.

Therefore it is more reliable to work with a mock than relying on
actual access rights on a os while testing.

This commit got cherry-picked from master.
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
