### PR TITLE
Fix various typos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add dedicated port list for alive detection (Boreas only) as scanner preference if supplied via OSP. [#327](https://github.com/greenbone/ospd-openvas/pull/327)
-- Add methods for adding VTs to the redis cache.[#337](https://github.com/greenbone/ospd-openvas/pull/337)
-- Add support for supplying alive test methods via seperate elements. [#331](https://github.com/greenbone/ospd-openvas/pull/331)
+- Add methods for adding VTs to the redis cache. [#337](https://github.com/greenbone/ospd-openvas/pull/337)
+- Add support for supplying alive test methods via separate elements. [#331](https://github.com/greenbone/ospd-openvas/pull/331)
 - Add support CVSSv3 and accept new tags for severity vector, origin, date. [#346](https://github.com/greenbone/ospd-openvas/pull/346)
 
 ### Changed

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -317,9 +317,9 @@ class PreferenceHandler:
         alive_test = None
 
         if target_options:
-            # Alive test speciefied as bit field.
+            # Alive test specified as bit field.
             alive_test = target_options.get('alive_test')
-            # Alive test speciefied as individual methods.
+            # Alive test specified as individual methods.
             alive_test_methods = target_options.get('alive_test_methods')
             # alive_test takes precedence over alive_test_methods
             if alive_test is None and alive_test_methods:
@@ -446,9 +446,9 @@ class PreferenceHandler:
 
         if target_options:
             alive_test_ports = target_options.get('alive_test_ports')
-            # Alive test was speciefied as bit field.
+            # Alive test was specified as bit field.
             alive_test = target_options.get('alive_test')
-            # Alive test was speciefied as individual methods.
+            # Alive test was specified as individual methods.
             alive_test_methods = target_options.get('alive_test_methods')
             # <alive_test> takes precedence over <alive_test_methods>
             if alive_test is None and alive_test_methods:

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -205,7 +205,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         self.assertEqual(ret, {})
 
-        # alive test was supplied via seperate xml element
+        # alive test was supplied via separate xml element
         w = DummyDaemon()
         target_options_dict = {'alive_test_methods': '1', 'icmp': '0'}
         p = PreferenceHandler('1234-1234', None, w.scan_collection, None)


### PR DESCRIPTION
From codespell:

```
./CHANGELOG.md:12: seperate ==> separate
./ospd_openvas/preferencehandler.py:320: speciefied ==> specified
./ospd_openvas/preferencehandler.py:322: speciefied ==> specified
./ospd_openvas/preferencehandler.py:449: speciefied ==> specified
./ospd_openvas/preferencehandler.py:451: speciefied ==> specified
./tests/test_preferencehandler.py:208: seperate ==> separate
```

Seems these typos doesn't exist in the ospd-openvas-20.08 branch so i have created the PR against master.