### PR TITLE
Retry host progress update if it the progress is still below 100 percent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix alive test preferences when a non default method is selected. [#334](https://github.com/greenbone/ospd-openvas/pull/334)
 - Check for empty vts preferences list. [#340](https://github.com/greenbone/ospd-openvas/pull/340)
 - Fix progress calculation when the host count differs from the target string count. [#343](https://github.com/greenbone/ospd-openvas/pull/343)
-- Retry host progress update if it the progress is still below 100 percent. [#390](https://github.com/greenbone/ospd-openvas/pull/390)
+- Retry host progress update if the progress is still below 100 percent. [#390](https://github.com/greenbone/ospd-openvas/pull/390)
 
 [20.8.1]: https://github.com/greenbone/ospd-openvas/compare/v20.8.0...ospd-openvas-20.08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix alive test preferences when a non default method is selected. [#334](https://github.com/greenbone/ospd-openvas/pull/334)
 - Check for empty vts preferences list. [#340](https://github.com/greenbone/ospd-openvas/pull/340)
 - Fix progress calculation when the host count differs from the target string count. [#343](https://github.com/greenbone/ospd-openvas/pull/343)
+- Retry host progress update if it the progress is still below 100 percent. [#390](https://github.com/greenbone/ospd-openvas/pull/390)
 
 [20.8.1]: https://github.com/greenbone/ospd-openvas/compare/v20.8.0...ospd-openvas-20.08
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1429,7 +1429,9 @@ class OSPDopenvas(OSPDaemon):
                                 scan_id, current_host
                             )
 
-                        if retry == 0:
+                        if (
+                            host_progress > -1 and host_progress < 100
+                        ) and retry == 0:
                             self.add_scan_error(
                                 scan_id,
                                 name='',

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1412,13 +1412,39 @@ class OSPDopenvas(OSPDaemon):
                         while (
                             host_progress > -1 and host_progress < 100
                         ) and retry > 0:
+                            logger.debug(
+                                '%s: Host %s finished but its scan progress is '
+                                'still %d. Retrying the host progress update '
+                                'in 1 second',
+                                scan_id,
+                                current_host,
+                                host_progress,
+                            )
+                            time.sleep(1)
                             self.report_openvas_scan_status(
                                 scan_db, scan_id, current_host
                             )
-                            time.sleep(1)
                             retry -= 1
                             host_progress = self.get_scan_host_progress(
                                 scan_id, current_host
+                            )
+
+                        if retry == 0:
+                            self.add_scan_error(
+                                scan_id,
+                                name='',
+                                host='',
+                                value=(
+                                    'The scan progress of host %s could not be '
+                                    'properly updated.' % current_host
+                                ),
+                            )
+                            logger.error(
+                                '%s: Host %s finished but its scan progress '
+                                'is %d.',
+                                scan_id,
+                                current_host,
+                                host_progress,
                             )
                         # Set HOST_END timestamp
                         self.report_openvas_timestamp_scan_host(

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1401,13 +1401,30 @@ class OSPDopenvas(OSPDaemon):
                     )
 
                     if scan_db.host_is_finished(openvas_scan_id):
-                        self.report_openvas_scan_status(
-                            scan_db, scan_id, current_host
+                        # Check that the host status is updated. As it has
+                        # finished, its stauts should be DEAD or FINISHED.
+                        # Otherwise it is considered an error. It tries 3
+                        # times until considered it an error
+                        retry = 3
+                        host_progress = self.get_scan_host_progress(
+                            scan_id, current_host
                         )
-
+                        while (
+                            host_progress > -1 and host_progress < 100
+                        ) and retry > 0:
+                            self.report_openvas_scan_status(
+                                scan_db, scan_id, current_host
+                            )
+                            time.sleep(1)
+                            retry -= 1
+                            host_progress = self.get_scan_host_progress(
+                                scan_id, current_host
+                            )
+                        # Set HOST_END timestamp
                         self.report_openvas_timestamp_scan_host(
                             scan_db, scan_id, current_host
                         )
+
                         if current_host:
                             self.sort_host_finished(
                                 scan_id, finished_hosts=current_host
@@ -1415,6 +1432,9 @@ class OSPDopenvas(OSPDaemon):
 
                         kbdb.remove_scan_database(scan_db)
                         self.main_db.release_database(scan_db)
+                        logger.debug(
+                            '%s: Release host KB of %s', scan_id, current_host
+                        )
 
             # Scan end. No kb in use for this scan id
             if no_id_found and kbdb.target_is_finished(scan_id):


### PR DESCRIPTION
**What**:
Check the scan progress of host up to three time if it
was considered finishes or dead and the progress is still under 100%
The retries could avoid a race condition in which a finished host still
has the progress udner 100%, which leads to interrupted scans.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The retries could avoid a race condition in which a finished host still
has the progress udner 100%, which leads to interrupted scans.

<!-- Why are these changes necessary? -->

**How**:
This is quite difficult to test since some interrupted scans can be the result of a race condition. 
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
