### PR TITLE
Check for scanner error messages before leaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Added
+- Check for scanner error messages before leaving. [#395](https://github.com/greenbone/ospd-openvas/pull/395)
+
 ### Changed
 ### Deprecated
 ### Removed
 
 ### Fixed
-- Don't crash with non-ascii chars in openvas.conf. [#391](https://github.com/greenbone/ospd-openvas/pull/381)
+- Don't crash with non-ascii chars in openvas.conf. [#381](https://github.com/greenbone/ospd-openvas/pull/381)
 
 [Unreleased]: https://github.com/greenbone/ospd-openvas/compare/v20.8.1...HEAD
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1350,6 +1350,10 @@ class OSPDopenvas(OSPDaemon):
                     host='',
                     value='Task was unexpectedly stopped or killed.',
                 )
+
+                # check for scanner error messages before leaving.
+                self.report_openvas_results(kbdb, scan_id, "")
+
                 kbdb.stop_scan(openvas_scan_id)
                 for scan_db in kbdb.get_scan_databases():
                     self.main_db.release_database(scan_db)


### PR DESCRIPTION
**What**:
Check for scanner error messages before leaving
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When the scanner ends unexpectedly, can leave a message for the client. This patch checks for messages one last time before finishing the scan.
<!-- Why are these changes necessary? -->

**How**:
Create a task and set an invalid iface as source interface. Run the task. The scan will end as interrupted and you will see an error message about the invalid iface in the error tab of the report.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
