### PR TITLE
Fix timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 ### Changed
+- Set Log Timestamp to UTC. [#412](https://github.com/greenbone/ospd-openvas/pull/412)
+
 ### Removed
 ### Fixed
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -469,6 +469,8 @@ class OSPDopenvas(OSPDaemon):
 
         self.scan_only_params = dict()
 
+        logging.Formatter.converter = time.gmtime
+
     def init(self, server: BaseServer) -> None:
 
         self.scan_collection.init()


### PR DESCRIPTION
**What**:
The logger now uses UTC for timestamps.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Other tools used UTC and ospd-openvas used local time.

<!-- Why are these changes necessary? -->

**How**:
Adding one line in which the timezone of the logger is set to UTC. Simply running ospd-openvas showed that this change works.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
