### PR TITLE
Remove special handling for Consider Alive alive test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Changed
 ### Fixed
+
 ### Removed
+
+- Remove some special handling for Consider Alive alive test. [#413](https://github.com/greenbone/ospd-openvas/pull/413)
 
 [21.4.1]: https://github.com/greenbone/ospd-openvas/compare/v21.4.0...ospd-openvas-21.04
 

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -409,12 +409,6 @@ class PreferenceHandler:
                 + 'Mark unrechable Hosts as dead (not scanning)'
             ] = value
 
-            # Also select a method, otherwise Ping Host logs a warning.
-            if alive_test == AliveTest.ALIVE_TEST_CONSIDER_ALIVE:
-                target_opt_prefs_list[
-                    OID_PING_HOST + ':1:checkbox:' + 'Do a TCP ping'
-                ] = 'yes'
-
         return target_opt_prefs_list
 
     def prepare_alive_test_option_for_openvas(self):


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Remove special handling for Consider Alive alive test.

**Why**:

<!-- Why are these changes necessary? -->

When Consider Alive is chosen there was still some other ping method applied in the nasl preferences.
This resulted in a wrong print of the chosen alive method on nasl (host_alive_detection.nasl) side when boreas is used.
Boreas is the default now so this special case is not needed anymore.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Do some simple scan.

```sh
    gvm-cli --protocol OSP socket --socketpath gbinstall/var/run/ospd-openvas.sock -X "\
    <start_scan scan_id='97079ee9-8917-49da-aa4f-4ef95f757ac1'>\
        <vt_selection>\
            <vt_single id='1.3.6.1.4.1.25623.1.0.100315'>\
                <vt_value id='9'>1</vt_value>\
                <vt_value id='6'>1</vt_value>\
                <vt_value id='3'>1</vt_value>\
            </vt_single>\
        </vt_selection>\
        <targets>\
            <target>\
                <alive_test>8</alive_test>\
                <hosts>127.0.0.1</hosts>\
                <ports>80,8080,443,22</ports>\
                <exclude_hosts></exclude_hosts>\
            </target>\
        </targets>\
        <scanner_params>\
        </scanner_params>\
    </start_scan>"
```

Without PR `Host is alive, Methods used: TCP ping via Boreas Host Alive Scanner` is in the results. With applied PR `Host is alive, Methods used:  ping via Boreas Host Alive Scanner` is in the results. This is still not optimal but has to be improved on nasl side and at least does not display wrong information.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
