### PR TITLE
Added validation, error handling and some debug messages for credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Validate port list to be sent to openvas. [#411](https://github.com/greenbone/ospd-openvas/pull/411)
+- Validate credentials to be sent to openvas. [#416](https://github.com/greenbone/ospd-openvas/pull/416)
 
 ### Changed
 ### Removed

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1264,10 +1264,27 @@ class OSPDopenvas(OSPDaemon):
 
         # Set credentials
         if not scan_prefs.prepare_credentials_for_openvas():
-            self.add_scan_error(
-                scan_id, name='', host='', value='Malformed credential.'
+            error = (
+                'All authentifications contain errors.'
+                + 'Scan will get interrupted.'
             )
+            self.add_scan_error(
+                scan_id,
+                name='',
+                host='',
+                value=error,
+            )
+            logger.error(error)
             do_not_launch = True
+        for e in scan_prefs.errors:
+            error = 'Malformed credential. ' + e
+            self.add_scan_error(
+                scan_id,
+                name='',
+                host='',
+                value=error,
+            )
+            logger.error(error)
 
         if not scan_prefs.prepare_plugins_for_openvas():
             self.add_scan_error(

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1266,7 +1266,7 @@ class OSPDopenvas(OSPDaemon):
         if not scan_prefs.prepare_credentials_for_openvas():
             error = (
                 'All authentifications contain errors.'
-                + 'Scan will get interrupted.'
+                + 'Starting unauthenticated scan instead.'
             )
             self.add_scan_error(
                 scan_id,
@@ -1275,8 +1275,8 @@ class OSPDopenvas(OSPDaemon):
                 value=error,
             )
             logger.error(error)
-            do_not_launch = True
-        for e in scan_prefs.errors:
+        errors = scan_prefs.get_error_messages()
+        for e in errors:
             error = 'Malformed credential. ' + e
             self.add_scan_error(
                 scan_id,

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -107,6 +107,8 @@ class PreferenceHandler:
 
         self.nvti = nvticache
 
+        self.errors = []
+
     def prepare_scan_id_for_openvas(self):
         """Create the openvas scan id and store it in the redis kb.
         Return the openvas scan_id.
@@ -577,8 +579,7 @@ class PreferenceHandler:
         if prefs_val:
             self.kbdb.add_scan_preferences(self.scan_id, prefs_val)
 
-    @staticmethod
-    def build_credentials_as_prefs(credentials: Dict) -> List[str]:
+    def build_credentials_as_prefs(self, credentials: Dict) -> List[str]:
         """Parse the credential dictionary.
         Arguments:
             credentials: Dictionary with the credentials.
@@ -595,15 +596,24 @@ class PreferenceHandler:
             username = cred_params.get('username', '')
             password = cred_params.get('password', '')
 
+            # Check service ssh
             if service == 'ssh':
+                # For ssh check the Port
                 port = cred_params.get('port', '')
-                cred_prefs_list.append('auth_port_ssh|||' + '{0}'.format(port))
-                cred_prefs_list.append(
-                    OID_SSH_AUTH
-                    + ':1:'
-                    + 'entry:SSH login '
-                    + 'name:|||{0}'.format(username)
-                )
+                if not port:
+                    self.errors.append("Port for SSH is missing.")
+                    continue
+                elif not port.isnumeric():
+                    self.errors.append(
+                        "Port for SSH '" + port + "' is not a valid number."
+                    )
+                    continue
+                elif int(port) > 65535:
+                    self.errors.append(
+                        "Port for SSH is out of range (0-65535): " + port
+                    )
+                    continue
+                # For ssh check the credential type
                 if cred_type == 'up':
                     cred_prefs_list.append(
                         OID_SSH_AUTH
@@ -611,7 +621,7 @@ class PreferenceHandler:
                         + 'password:SSH password '
                         + '(unsafe!):|||{0}'.format(password)
                     )
-                else:
+                elif cred_type == 'usk':
                     private = cred_params.get('private', '')
                     cred_prefs_list.append(
                         OID_SSH_AUTH
@@ -625,7 +635,30 @@ class PreferenceHandler:
                         + 'file:SSH private key:|||'
                         + '{0}'.format(private)
                     )
-            if service == 'smb':
+                elif cred_type:
+                    self.errors.append(
+                        "Unknown Credential Type for SSH: "
+                        + cred_type
+                        + ". Use 'up' for Username + Password"
+                        + " or 'usk' for Username + SSH Key."
+                    )
+                    continue
+                else:
+                    self.errors.append(
+                        "Missing Credential Type for SSH."
+                        + " Use 'up' for Username + Password"
+                        + " or 'usk' for Username + SSH Key."
+                    )
+                    continue
+                cred_prefs_list.append('auth_port_ssh|||' + '{0}'.format(port))
+                cred_prefs_list.append(
+                    OID_SSH_AUTH
+                    + ':1:'
+                    + 'entry:SSH login '
+                    + 'name:|||{0}'.format(username)
+                )
+            # Check servic smb
+            elif service == 'smb':
                 cred_prefs_list.append(
                     OID_SMB_AUTH
                     + ':1:entry'
@@ -637,7 +670,8 @@ class PreferenceHandler:
                     + 'password:SMB password:|||'
                     + '{0}'.format(password)
                 )
-            if service == 'esxi':
+            # Check service esxi
+            elif service == 'esxi':
                 cred_prefs_list.append(
                     OID_ESXI_AUTH
                     + ':1:entry:'
@@ -650,12 +684,46 @@ class PreferenceHandler:
                     + 'password:ESXi login password:|||'
                     + '{0}'.format(password)
                 )
-
-            if service == 'snmp':
+            # Check service snmp
+            elif service == 'snmp':
                 community = cred_params.get('community', '')
                 auth_algorithm = cred_params.get('auth_algorithm', '')
                 privacy_password = cred_params.get('privacy_password', '')
                 privacy_algorithm = cred_params.get('privacy_algorithm', '')
+
+                if not privacy_algorithm:
+                    if privacy_password:
+                        self.errors.append(
+                            "When no privacy algorithm is used, the privacy"
+                            + " password also has to be empty."
+                        )
+                        continue
+                elif (
+                    not privacy_algorithm == "aes"
+                    and not privacy_algorithm == "des"
+                ):
+                    self.errors.append(
+                        "Unknows privacy algorithm used: "
+                        + privacy_algorithm
+                        + ". Use 'aes', 'des' or '' (none)."
+                    )
+                    continue
+
+                if not auth_algorithm:
+                    self.errors.append(
+                        "Missing authentification algorithm for SNMP."
+                        + " Use 'md5' or 'sha1'."
+                    )
+                    continue
+                elif (
+                    not auth_algorithm == "md5" and not auth_algorithm == "sha1"
+                ):
+                    self.errors.append(
+                        "Unknown authentification algorithm: "
+                        + auth_algorithm
+                        + ". Use 'md5' or 'sha1'."
+                    )
+                    continue
 
                 cred_prefs_list.append(
                     OID_SNMP_AUTH
@@ -691,12 +759,19 @@ class PreferenceHandler:
                     + 'radio:SNMPv3 Privacy Algorithm:|||'
                     + '{0}'.format(privacy_algorithm)
                 )
+            elif service:
+                self.errors.append(
+                    "Unknown service type for credential: " + service
+                )
+            else:
+                self.errors.append("Missing service type for credential.")
 
         return cred_prefs_list
 
     def prepare_credentials_for_openvas(self) -> bool:
         """Get the credentials from the scan collection and store them
         in the kb."""
+        logger.debug("Looking for given Credentials...")
         credentials = self.scan_collection.get_credentials(self.scan_id)
         if credentials:
             cred_prefs = self.build_credentials_as_prefs(credentials)
@@ -704,7 +779,9 @@ class PreferenceHandler:
                 self.kbdb.add_credentials_to_scan_preferences(
                     self.scan_id, cred_prefs
                 )
-
+                logger.debug("Credentials added to the kb.")
+        else:
+            logger.debug("No credentials found.")
         if credentials and not cred_prefs:
             return False
 

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -115,6 +115,12 @@ class PreferenceHandler:
         """
         self.kbdb.add_scan_id(self.scan_id)
 
+    def get_error_messages(self) -> List:
+        """Returns the Error List and reset it"""
+        ret = self.errors
+        self.errors = []
+        return ret
+
     @property
     def target_options(self) -> Dict:
         """Return target options from Scan collection"""
@@ -599,18 +605,22 @@ class PreferenceHandler:
             # Check service ssh
             if service == 'ssh':
                 # For ssh check the Port
-                port = cred_params.get('port', '')
+                port = cred_params.get('port', '22')
                 if not port:
-                    self.errors.append("Port for SSH is missing.")
-                    continue
+                    port = '22'
+                    warning = (
+                        "Missing port number for ssh credentials."
+                        + " Using default port 22."
+                    )
+                    logger.warning(warning)
                 elif not port.isnumeric():
                     self.errors.append(
                         "Port for SSH '" + port + "' is not a valid number."
                     )
                     continue
-                elif int(port) > 65535:
+                elif int(port) > 65535 or int(port) < 1:
                     self.errors.append(
-                        "Port for SSH is out of range (0-65535): " + port
+                        "Port for SSH is out of range (1-65535): " + port
                     )
                     continue
                 # For ssh check the credential type

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -140,7 +140,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         ret = p.build_credentials_as_prefs(cred_dict)
 
-        self.assertEqual(ret, cred_out)
+        self.assertCountEqual(ret, cred_out)
 
     def test_build_credentials(self):
         w = DummyDaemon()
@@ -163,14 +163,15 @@ class PreferenceHandlerTestCase(TestCase):
         ]
         cred_dict = {
             'ssh': {
-                'type': 'ssh',
+                'type': 'usk',
                 'port': '22',
                 'username': 'username',
                 'password': 'pass',
+                'private': 'some key',
             },
-            'smb': {'type': 'smb', 'username': 'username', 'password': 'pass'},
+            'smb': {'type': 'up', 'username': 'username', 'password': 'pass'},
             'esxi': {
-                'type': 'esxi',
+                'type': 'up',
                 'username': 'username',
                 'password': 'pass',
             },
@@ -179,9 +180,9 @@ class PreferenceHandlerTestCase(TestCase):
                 'username': 'username',
                 'password': 'pass',
                 'community': 'some comunity',
-                'auth_algorithm': 'some auth algo',
+                'auth_algorithm': 'md5',
                 'privacy_password': 'privacy pass',
-                'privacy_algorithm': 'privacy algo',
+                'privacy_algorithm': 'aes',
             },
         }
 
@@ -311,14 +312,14 @@ class PreferenceHandlerTestCase(TestCase):
 
         creds = {
             'ssh': {
-                'type': 'ssh',
+                'type': 'up',
                 'port': '22',
                 'username': 'username',
                 'password': 'pass',
             },
-            'smb': {'type': 'smb', 'username': 'username', 'password': 'pass'},
+            'smb': {'type': 'up', 'username': 'username', 'password': 'pass'},
             'esxi': {
-                'type': 'esxi',
+                'type': 'up',
                 'username': 'username',
                 'password': 'pass',
             },
@@ -327,9 +328,9 @@ class PreferenceHandlerTestCase(TestCase):
                 'username': 'username',
                 'password': 'pass',
                 'community': 'some comunity',
-                'auth_algorithm': 'some auth algo',
+                'auth_algorithm': 'md5',
                 'privacy_password': 'privacy pass',
-                'privacy_algorithm': 'privacy algo',
+                'privacy_algorithm': 'aes',
             },
         }
 
@@ -337,20 +338,20 @@ class PreferenceHandlerTestCase(TestCase):
 
         p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
         p.scan_id = '456-789'
-        p.kbdb.add_scan_preferences = MagicMock()
+        p.kbdb.add_credentials_to_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
 
         self.assertTrue(r)
-        assert_called_once(p.kbdb.add_scan_preferences)
+        assert_called_once(p.kbdb.add_credentials_to_scan_preferences)
 
     @patch('ospd_openvas.db.KbDB')
-    def test_set_credentials(self, mock_kb):
+    def test_set_bad_service_credentials(self, mock_kb):
         w = DummyDaemon()
 
         # bad cred type shh instead of ssh
         creds = {
             'shh': {
-                'type': 'ssh',
+                'type': 'up',
                 'port': '22',
                 'username': 'username',
                 'password': 'pass',
@@ -365,6 +366,247 @@ class PreferenceHandlerTestCase(TestCase):
         r = p.prepare_credentials_for_openvas()
 
         self.assertFalse(r)
+        self.assertIn("Unknown service type for credential: shh", p.errors)
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_set_bad_ssh_port_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'ssh': {
+                'type': 'up',
+                'port': 'ab',
+                'username': 'username',
+                'password': 'pass',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn("Port for SSH 'ab' is not a valid number.", p.errors)
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_missing_ssh_port_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'ssh': {
+                'type': 'up',
+                'username': 'username',
+                'password': 'pass',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn("Port for SSH is missing.", p.errors)
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_ssh_port_out_of_range_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'ssh': {
+                'type': 'up',
+                'port': '65536',
+                'username': 'username',
+                'password': 'pass',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn("Port for SSH is out of range (0-65535): 65536", p.errors)
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_bad_type_for_ssh_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'ssh': {
+                'type': 'ups',
+                'port': '22',
+                'username': 'username',
+                'password': 'pass',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn(
+            "Unknown Credential Type for SSH: "
+            + "ups"
+            + ". Use 'up' for Username + Password"
+            + " or 'usk' for Username + SSH Key.",
+            p.errors,
+        )
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_missing_type_for_ssh_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'ssh': {
+                'port': '22',
+                'username': 'username',
+                'password': 'pass',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn(
+            "Missing Credential Type for SSH."
+            + " Use 'up' for Username + Password"
+            + " or 'usk' for Username + SSH Key.",
+            p.errors,
+        )
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_snmp_no_priv_alg_but_pw_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'snmp': {
+                'type': 'snmp',
+                'username': 'username',
+                'password': 'pass',
+                'community': 'some comunity',
+                'auth_algorithm': 'sha1',
+                'privacy_password': 'privacy pass',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn(
+            "When no privacy algorithm is used, the privacy"
+            + " password also has to be empty.",
+            p.errors,
+        )
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_snmp_unknown_priv_alg_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'snmp': {
+                'type': 'snmp',
+                'username': 'username',
+                'password': 'pass',
+                'community': 'some comunity',
+                'auth_algorithm': 'sha1',
+                'privacy_password': 'privacy pass',
+                'privacy_algorithm': 'das',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn(
+            "Unknows privacy algorithm used: "
+            + "das"
+            + ". Use 'aes', 'des' or '' (none).",
+            p.errors,
+        )
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_snmp_missing_auth_alg_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'snmp': {
+                'type': 'snmp',
+                'username': 'username',
+                'password': 'pass',
+                'community': 'some comunity',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn(
+            "Missing authentification algorithm for SNMP."
+            + " Use 'md5' or 'sha1'.",
+            p.errors,
+        )
+
+    @patch('ospd_openvas.db.KbDB')
+    def test_snmp_unknown_auth_alg_credentials(self, mock_kb):
+        w = DummyDaemon()
+
+        creds = {
+            'snmp': {
+                'type': 'snmp',
+                'username': 'username',
+                'password': 'pass',
+                'community': 'some comunity',
+                'auth_algorithm': 'sha2',
+            },
+        }
+
+        w.scan_collection.get_credentials = MagicMock(return_value=creds)
+
+        p = PreferenceHandler('1234-1234', mock_kb, w.scan_collection, None)
+        p.scan_id = '456-789'
+        p.kbdb.add_scan_preferences = MagicMock()
+        r = p.prepare_credentials_for_openvas()
+
+        self.assertFalse(r)
+        self.assertIn(
+            "Unknown authentification algorithm: "
+            + "sha2"
+            + ". Use 'md5' or 'sha1'.",
+            p.errors,
+        )
 
     @patch('ospd_openvas.db.KbDB')
     def test_set_credentials_empty(self, mock_kb):

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -364,9 +364,10 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
-        self.assertIn("Unknown service type for credential: shh", p.errors)
+        self.assertIn("Unknown service type for credential: shh", e)
 
     @patch('ospd_openvas.db.KbDB')
     def test_set_bad_ssh_port_credentials(self, mock_kb):
@@ -387,9 +388,10 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
-        self.assertIn("Port for SSH 'ab' is not a valid number.", p.errors)
+        self.assertIn("Port for SSH 'ab' is not a valid number.", e)
 
     @patch('ospd_openvas.db.KbDB')
     def test_missing_ssh_port_credentials(self, mock_kb):
@@ -410,8 +412,7 @@ class PreferenceHandlerTestCase(TestCase):
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
 
-        self.assertFalse(r)
-        self.assertIn("Port for SSH is missing.", p.errors)
+        self.assertTrue(r)
 
     @patch('ospd_openvas.db.KbDB')
     def test_ssh_port_out_of_range_credentials(self, mock_kb):
@@ -432,9 +433,10 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
-        self.assertIn("Port for SSH is out of range (0-65535): 65536", p.errors)
+        self.assertIn("Port for SSH is out of range (1-65535): 65536", e)
 
     @patch('ospd_openvas.db.KbDB')
     def test_bad_type_for_ssh_credentials(self, mock_kb):
@@ -455,6 +457,7 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
         self.assertIn(
@@ -462,7 +465,7 @@ class PreferenceHandlerTestCase(TestCase):
             + "ups"
             + ". Use 'up' for Username + Password"
             + " or 'usk' for Username + SSH Key.",
-            p.errors,
+            e,
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -483,13 +486,14 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
         self.assertIn(
             "Missing Credential Type for SSH."
             + " Use 'up' for Username + Password"
             + " or 'usk' for Username + SSH Key.",
-            p.errors,
+            e,
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -513,12 +517,13 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
         self.assertIn(
             "When no privacy algorithm is used, the privacy"
             + " password also has to be empty.",
-            p.errors,
+            e,
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -543,13 +548,14 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
         self.assertIn(
             "Unknows privacy algorithm used: "
             + "das"
             + ". Use 'aes', 'des' or '' (none).",
-            p.errors,
+            e,
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -571,12 +577,13 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
         self.assertIn(
             "Missing authentification algorithm for SNMP."
             + " Use 'md5' or 'sha1'.",
-            p.errors,
+            e,
         )
 
     @patch('ospd_openvas.db.KbDB')
@@ -599,13 +606,14 @@ class PreferenceHandlerTestCase(TestCase):
         p.scan_id = '456-789'
         p.kbdb.add_scan_preferences = MagicMock()
         r = p.prepare_credentials_for_openvas()
+        e = p.get_error_messages()
 
         self.assertFalse(r)
         self.assertIn(
             "Unknown authentification algorithm: "
             + "sha2"
             + ". Use 'md5' or 'sha1'.",
-            p.errors,
+            e,
         )
 
     @patch('ospd_openvas.db.KbDB')


### PR DESCRIPTION
**What**:
Added validation, error handling and some debug messages for credentials

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Validation was missing on the ospd-openvas side. Also added some error messages to know exactly what was wrong.

<!-- Why are these changes necessary? -->

**How**:
I tested each validation and error messages and also tested some proper scans with gvm-cli and also GSA, to know that we don't get errors when everything should be fine.
Template script for testing with gvm-cli:
```xml
<start_scan scan_id='97079ee9-8917-49da-aa4f-4ef95f757ac1'>
  <vt_selection>
    <vt_single id='1.3.6.1.4.1.25623.1.0.100315'>
      <vt_value id='9'>1</vt_value>
      <vt_value id='6'>1</vt_value>
      <vt_value id='3'>1</vt_value>
    </vt_single>
  </vt_selection>
  <targets>
    <target>
      <hosts>127.0.0.1</hosts>
      <ports>80,8080,443,22</ports>
      <exclude_hosts></exclude_hosts>
      <credentials>
        <credential service="ssh" type="up" port="22">
          <username>user</username>
          <password>pw</password>
        </credential>
      </credentials>
    </target>
  </targets>
  <scanner_params>
  </scanner_params>
</start_scan>
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
