### PR TITLE
Extend su privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Validate port list to be sent to openvas. [#411](https://github.com/greenbone/ospd-openvas/pull/411)
 - Validate credentials to be sent to openvas. [#416](https://github.com/greenbone/ospd-openvas/pull/416)
+- New Credentials for SSH to get su privileges. [#419](https://github.com/greenbone/ospd-openvas/pull/419)
 
 ### Changed
 ### Removed

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -600,6 +600,8 @@ class PreferenceHandler:
             if service == 'ssh':
                 # For ssh check the Port
                 port = cred_params.get('port', '22')
+                priv_username = cred_params.get('priv_username', '')
+                priv_password = cred_params.get('priv_password', '')
                 if not port:
                     port = '22'
                     warning = (
@@ -660,6 +662,20 @@ class PreferenceHandler:
                     + ':1:'
                     + 'entry:SSH login '
                     + 'name:|||{0}'.format(username)
+                )
+                cred_prefs_list.append(
+                    OID_SSH_AUTH
+                    + ':7:'
+                    + 'entry:SSH privilege login name:|||{0}'.format(
+                        priv_username
+                    )
+                )
+                cred_prefs_list.append(
+                    OID_SSH_AUTH
+                    + ':8:'
+                    + 'password:SSH privilege password:|||{0}'.format(
+                        priv_password
+                    )
                 )
             # Check servic smb
             elif service == 'smb':

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -127,6 +127,8 @@ class PreferenceHandlerTestCase(TestCase):
             'auth_port_ssh|||22',
             '1.3.6.1.4.1.25623.1.0.103591:1:entry:SSH login name:|||username',
             '1.3.6.1.4.1.25623.1.0.103591:3:password:SSH password (unsafe!):|||pass',
+            '1.3.6.1.4.1.25623.1.0.103591:7:entry:SSH privilege login name:|||',
+            '1.3.6.1.4.1.25623.1.0.103591:8:password:SSH privilege password:|||',
         ]
         cred_dict = {
             'ssh': {
@@ -152,6 +154,8 @@ class PreferenceHandlerTestCase(TestCase):
             '1.3.6.1.4.1.25623.1.0.103591:1:entry:SSH login name:|||username',
             '1.3.6.1.4.1.25623.1.0.103591:2:password:SSH key passphrase:|||pass',
             '1.3.6.1.4.1.25623.1.0.103591:4:file:SSH private key:|||',
+            '1.3.6.1.4.1.25623.1.0.103591:7:entry:SSH privilege login name:|||',
+            '1.3.6.1.4.1.25623.1.0.103591:8:password:SSH privilege password:|||',
             '1.3.6.1.4.1.25623.1.0.90023:1:entry:SMB login:|||username',
             '1.3.6.1.4.1.25623.1.0.90023:2:password]:SMB password :|||pass',
             '1.3.6.1.4.1.25623.1.0.105076:1:password:SNMP Community:some comunity',
@@ -168,6 +172,8 @@ class PreferenceHandlerTestCase(TestCase):
                 'username': 'username',
                 'password': 'pass',
                 'private': 'some key',
+                'priv_username': 'su_user',
+                'priv_password': 'su_pass',
             },
             'smb': {'type': 'up', 'username': 'username', 'password': 'pass'},
             'esxi': {
@@ -190,10 +196,14 @@ class PreferenceHandlerTestCase(TestCase):
         ret = p.build_credentials_as_prefs(cred_dict)
 
         self.assertEqual(len(ret), len(cred_out))
-        self.assertIn('auth_port_ssh|||22', cred_out)
+        self.assertIn('auth_port_ssh|||22', ret)
         self.assertIn(
             '1.3.6.1.4.1.25623.1.0.90023:1:entry:SMB login:|||username',
-            cred_out,
+            ret,
+        )
+        self.assertIn(
+            '1.3.6.1.4.1.25623.1.0.103591:8:password:SSH privilege password:|||su_pass',
+            ret,
         )
 
     def test_build_alive_test_opt_empty(self):
@@ -316,6 +326,8 @@ class PreferenceHandlerTestCase(TestCase):
                 'port': '22',
                 'username': 'username',
                 'password': 'pass',
+                'priv_username': "privuser",
+                'priv_password': "privpass",
             },
             'smb': {'type': 'up', 'username': 'username', 'password': 'pass'},
             'esxi': {


### PR DESCRIPTION
**What**:
Extend OSP API to handle new priv_username and priv_password credential.
Extend the validation of the credential types to handle the new credential type.
Make the SSH credentials available for VTs as a redis KB entry, similar to SSH credentials already in use.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
New feature to support su privileges on the target system when logging in via SSH.
<!-- Why are these changes necessary? -->

**How**:
Tested via unittests if the new entries are prepared for redis.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
