### PR TITLE
Fix various typos.

### DIFF
--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -723,7 +723,7 @@ class PreferenceHandler:
                     and not privacy_algorithm == "des"
                 ):
                     self.errors.append(
-                        "Unknows privacy algorithm used: "
+                        "Unknown privacy algorithm used: "
                         + privacy_algorithm
                         + ". Use 'aes', 'des' or '' (none)."
                     )
@@ -731,7 +731,7 @@ class PreferenceHandler:
 
                 if not auth_algorithm:
                     self.errors.append(
-                        "Missing authentification algorithm for SNMP."
+                        "Missing authentication algorithm for SNMP."
                         + " Use 'md5' or 'sha1'."
                     )
                     continue
@@ -739,7 +739,7 @@ class PreferenceHandler:
                     not auth_algorithm == "md5" and not auth_algorithm == "sha1"
                 ):
                     self.errors.append(
-                        "Unknown authentification algorithm: "
+                        "Unknown authentication algorithm: "
                         + auth_algorithm
                         + ". Use 'md5' or 'sha1'."
                     )

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -564,7 +564,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         self.assertFalse(r)
         self.assertIn(
-            "Unknows privacy algorithm used: "
+            "Unknown privacy algorithm used: "
             + "das"
             + ". Use 'aes', 'des' or '' (none).",
             e,
@@ -593,7 +593,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         self.assertFalse(r)
         self.assertIn(
-            "Missing authentification algorithm for SNMP."
+            "Missing authentication algorithm for SNMP."
             + " Use 'md5' or 'sha1'.",
             e,
         )
@@ -622,7 +622,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         self.assertFalse(r)
         self.assertIn(
-            "Unknown authentification algorithm: "
+            "Unknown authentication algorithm: "
             + "sha2"
             + ". Use 'md5' or 'sha1'.",
             e,


### PR DESCRIPTION
Found via codespell:

```
./ospd_openvas/preferencehandler.py:726: Unknows ==> Unknowns
./ospd_openvas/preferencehandler.py:734: authentification ==> authentication
./ospd_openvas/preferencehandler.py:742: authentification ==> authentication
./tests/test_preferencehandler.py:567: Unknows ==> Unknowns
./tests/test_preferencehandler.py:596: authentification ==> authentication
./tests/test_preferencehandler.py:625: authentification ==> authentication
```

Those only exists in the master branch so targeting that branch directly.