### PR TITLE
add log message to determine None cases

### DIFF
--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -544,7 +544,8 @@ class KbDB(BaseKbDB):
 
         if status is None:
             logger.info(
-                "%s: Target set as finished because redis returned None as scanner status.",
+                "%s: Target set as finished because redis returned None as "
+                "scanner status.",
                 scan_id,
             )
 

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -543,7 +543,9 @@ class KbDB(BaseKbDB):
         status = self._get_single_item('internal/{}'.format(scan_id))
 
         if status is None:
-            logger.info("Target set as finished, but the status is None.")
+            logger.info(
+                "%s: Target set as finished, but the status is None.", scan_id
+            )
 
         return status == 'finished' or status is None
 

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -542,6 +542,9 @@ class KbDB(BaseKbDB):
 
         status = self._get_single_item('internal/{}'.format(scan_id))
 
+        if status is None:
+            logger.info("Target set as finished, but the status is None.")
+
         return status == 'finished' or status is None
 
     def stop_scan(self, openvas_scan_id: str):

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -544,7 +544,8 @@ class KbDB(BaseKbDB):
 
         if status is None:
             logger.info(
-                "%s: Target set as finished, but the status is None.", scan_id
+                "%s: Target set as finished because redis returned None as scanner status.",
+                scan_id,
             )
 
         return status == 'finished' or status is None


### PR DESCRIPTION
**What**:
Added aditional log message to determine if openvas is finished because its status is finished or None

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The impact of the statement that the status is None is currently unknown. This statement could possibly cause some of the interrupted scan issues.

<!-- Why are these changes necessary? -->

**How**:
The log is generated as an info message.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
