### PR TITLE
Fix timeout preference handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix timeout preference handling. [#486](https://github.com/greenbone/ospd-openvas/pull/486)
 
 [Unreleased]: https://github.com/greenbone/ospd-openvas/compare/v21.4.2...HEAD
 
@@ -58,24 +59,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 [Unreleased]: https://github.com/greenbone/ospd-openvas/compare/v21.4.2...HEAD
 
-
-## [21.4.2] - 2021-08-04
-### Changed
-- Use better defaults for for ospd-openvas settings [#454](https://github.com/greenbone/ospd-openvas/pull/454)
-- Improved error logging while trying to acquire a lock file [#458](https://github.com/greenbone/ospd-openvas/pull/458)
-- Stopping and interrupting scans. [#465](https://github.com/greenbone/ospd-openvas/pull/465)
-
-## [Unreleased]
+## [20.8.2] ()
 ### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-
-[Unreleased]: https://github.com/greenbone/ospd-openvas/compare/v21.4.2...HEAD
-
-
-## [21.4.2] - 2021-08-04### Added
 - Check for scanner error messages before leaving. [#395](https://github.com/greenbone/ospd-openvas/pull/395)
 
 ### Fixed
@@ -87,8 +72,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove globalscanid. [#326](https://github.com/greenbone/ospd-openvas/pull/326)
 
 [20.8.2]: https://github.com/greenbone/ospd-openvas/compare/v20.08.1...ospd-openvas-20.08
-
-[21.4.2]: https://github.com/greenbone/ospd-openvas/compare/v21.4.1...v21.4.2
 
 ## (20.8.1) - 2021-02-01
 

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -235,7 +235,7 @@ class PreferenceHandler:
                 param_type = self._get_vt_param_type(vt, vt_param_id)
                 param_name = self._get_vt_param_name(vt, vt_param_id)
 
-                if not param_type or not param_name:
+                if vt_param_id > '0' and (not param_type or not param_name):
                     logger.debug(
                         'Missing type or name for VT parameter %s of %s. '
                         'This VT parameter will not be set.',
@@ -263,11 +263,14 @@ class PreferenceHandler:
                 if type_aux == 'checkbox':
                     vt_param_value = _from_bool_to_str(int(vt_param_value))
 
-                vts_params[
-                    "{0}:{1}:{2}:{3}".format(
-                        vtid, vt_param_id, param_type, param_name
-                    )
-                ] = str(vt_param_value)
+                if vt_param_id == '0':
+                    vts_params["timeout.{0}".format(vtid)] = str(vt_param_value)
+                else:
+                    vts_params[
+                        "{0}:{1}:{2}:{3}".format(
+                            vtid, vt_param_id, param_type, param_name
+                        )
+                    ] = str(vt_param_value)
 
         return vts_list, vts_params
 


### PR DESCRIPTION
SC-352

**What**:
Scripts timeouts are special preferences and in the openvas side are
treated in a especial way too.

The timeout preference is in the 13th position in the script metadata in redis,
and not with other preferences.
Also, the timeout is stored in globals with format `timeout.<SCRIPT-OID>|||<value>`,
while other script preferences have the form `oid:name:id:type|||value`.

The user is allowed to send a custom timeout, even when the script has no default one
set in the description block (use default 320sec). When the user send a custom timeout
the preference is not found and ospd-openvas logs an error message.

With this patch, the preference with ID:0 (timeout) is always handled and sent to openvas.

This issue does not affect gvmd/gsad client, because it sends the timeout as scanner preferece
Also, fix the changelog.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Because the custom timeout set by the user is not working for gvm-cli and other client than gvmd
<!-- Why are these changes necessary? -->

**How**:
Set the timeout to 1 second for a plugin you know it runs long. Run the scan. Check for the nvt timeout in the logs. It always finishes without timeout, although it should time out in 1 second.
With the patch, it must timeout in one second
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
