### PR TITLE
Set required version of psutil in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         'ospd>=21.10.0.dev1',
         'redis>=3.0.1',
-        'psutil',
+        'psutil>=5.7.2,<6.0.0',
         'packaging',
     ],
     entry_points={'console_scripts': ['ospd-openvas=ospd_openvas.daemon:main']},


### PR DESCRIPTION
**What**:

Set requirement for Python psutil module to be >=5.7.2,<6.0.0 in setup.py.

**Why**:

Following the docs to build GVM 21.04 on Ubuntu 20.04, installing ospd-openvas reports this requirement as an error.

**How**:

On Ubuntu 20.04 I manually made this change via sed, then re-ran the relevant "python3 -m pip install" command.