### PR TITLE
Fix pylint warnings. Remove u prefix for strings, no longer necessary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove source_iface preferences. [#418](https://github.com/greenbone/ospd-openvas/pull/418)
 
 ### Fixed
+- Fix pylint warnings. Remove u prefix for strings, no longer necessary. [#495](https://github.com/greenbone/ospd-openvas/pull/495)
 
 [21.10]: https://github.com/greenbone/ospd-openvas/compare/ospd-openvas-21.04...master
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -350,7 +350,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        custom = {'a': u"\u0006"}
+        custom = {'a': "\u0006"}
         w.get_custom_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', custom=custom
         )
@@ -381,7 +381,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        sever = {'severity_base_vector': u"\u0006"}
+        sever = {'severity_base_vector': "\u0006"}
         w.get_severities_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', severities=sever
         )
@@ -417,7 +417,7 @@ class TestOspdOpenvas(TestCase):
             '1': {
                 'id': '1',
                 'type': 'entry',
-                'default': u'\u0006',
+                'default': '\u0006',
                 'name': 'dns-fuzz.timelimit',
                 'description': 'Description',
             }
@@ -471,7 +471,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.error = Mock()
 
-        dep = [u"\u0006"]
+        dep = ["\u0006"]
         w.get_dependencies_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', vt_dependencies=dep
         )
@@ -494,7 +494,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        ctime = u'\u0006'
+        ctime = '\u0006'
         w.get_creation_time_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', vt_creation_time=ctime
         )
@@ -517,7 +517,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        mtime = u'\u0006'
+        mtime = '\u0006'
         w.get_modification_time_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', mtime
         )
@@ -539,7 +539,7 @@ class TestOspdOpenvas(TestCase):
     def test_get_summary_xml_failed(self):
         w = DummyDaemon()
 
-        summary = u'\u0006'
+        summary = '\u0006'
         logging.Logger.warning = Mock()
         w.get_summary_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', summary)
 
@@ -559,7 +559,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        impact = u'\u0006'
+        impact = '\u0006'
         w.get_impact_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', impact)
 
         assert_called_once(logging.Logger.warning)
@@ -580,7 +580,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        insight = u'\u0006'
+        insight = '\u0006'
         w.get_insight_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', insight)
 
         assert_called_once(logging.Logger.warning)
@@ -611,7 +611,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        solution = u'\u0006'
+        solution = '\u0006'
         w.get_solution_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', solution)
 
         assert_called_once(logging.Logger.warning)
@@ -633,7 +633,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        detection = u'\u0006'
+        detection = '\u0006'
         w.get_detection_vt_as_xml_str('1.3.6.1.4.1.25623.1.0.100061', detection)
 
         assert_called_once(logging.Logger.warning)
@@ -654,7 +654,7 @@ class TestOspdOpenvas(TestCase):
         w = DummyDaemon()
         logging.Logger.warning = Mock()
 
-        affected = u"\u0006" + "affected"
+        affected = "\u0006" + "affected"
         w.get_affected_vt_as_xml_str(
             '1.3.6.1.4.1.25623.1.0.100061', affected=affected
         )


### PR DESCRIPTION
**What**:
Fix pylint warnings. Remove u prefix for strings.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
No longer necessary. Unicode is default since python <= 3.0
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
