### PR TITLE
Fix: fix dead host count (backport #511).

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1095,7 +1095,7 @@ class OSPDopenvas(OSPDaemon):
             # test_alive_host_only in openvas is enable
             elif msg[0] == 'DEADHOST':
                 try:
-                    total_dead = int(msg[5])
+                    total_dead = total_dead + int(msg[5])
                 except TypeError:
                     logger.debug('Error processing dead host count')
 


### PR DESCRIPTION
For large scan with a big amount of dead hosts (higher than 1000), which produces many results like

redis /tmp/redis.sock[2]> lrange internal/results 0 -1
 1) "DEADHOST||| ||| ||| ||| |||1000"
the counter only set 1000 instead of keeping the count.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
