### PR TITLE
Add: notus advisories in get_vts

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -432,9 +432,9 @@ class OSPDopenvas(OSPDaemon):
     ):
         """Initializes the ospd-openvas daemon's internal data."""
         self.main_db = MainDB()
-        notus_dir = kwargs.get( 'notus_feed_dir')
+        notus_dir = kwargs.get('notus_feed_dir')
         notus = Notus(notus_dir) if notus_dir else None
-        
+
         self.nvti = NVTICache(
             self.main_db,
             notus,

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -23,8 +23,6 @@
 
 import logging
 
-from ospd.parser import CliParser
-from ospd_openvas.notus import Notus
 import time
 import copy
 
@@ -37,6 +35,7 @@ from lxml.etree import tostring, SubElement, Element
 
 import psutil
 
+from ospd.parser import CliParser
 from ospd.ospd import OSPDaemon
 from ospd.scan import ScanProgress, ScanStatus
 from ospd.server import BaseServer
@@ -47,6 +46,7 @@ from ospd.resultlist import ResultList
 from ospd_openvas import __version__
 from ospd_openvas.errors import OspdOpenvasError
 
+from ospd_openvas.notus import Notus
 from ospd_openvas.dryrun import DryRun
 from ospd_openvas.nvticache import NVTICache
 from ospd_openvas.db import MainDB, BaseDB
@@ -432,13 +432,12 @@ class OSPDopenvas(OSPDaemon):
     ):
         """Initializes the ospd-openvas daemon's internal data."""
         self.main_db = MainDB()
+        notus_dir = kwargs.get( 'notus_feed_dir')
+        notus = Notus(notus_dir) if notus_dir else None
+        
         self.nvti = NVTICache(
             self.main_db,
-            Notus(
-                kwargs.get(
-                    'notus_feed_dir', '/var/lib/openvas/notus/advisories'
-                )
-            ),
+            notus,
         )
 
         super().__init__(

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -433,7 +433,7 @@ class OSPDopenvas(OSPDaemon):
         """Initializes the ospd-openvas daemon's internal data."""
         self.main_db = MainDB()
         notus_dir = kwargs.get('notus_feed_dir')
-        notus = Notus(notus_dir) if notus_dir else None
+        notus = Notus(notus_dir, self.main_db.ctx) if notus_dir else None
 
         self.nvti = NVTICache(
             self.main_db,

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -22,6 +22,9 @@
 """ Setup for the OSP OpenVAS Server. """
 
 import logging
+
+from ospd.parser import CliParser
+from ospd_openvas.notus import Notus
 import time
 import copy
 
@@ -429,7 +432,7 @@ class OSPDopenvas(OSPDaemon):
     ):
         """Initializes the ospd-openvas daemon's internal data."""
         self.main_db = MainDB()
-        self.nvti = NVTICache(self.main_db)
+        self.nvti = NVTICache(self.main_db, Notus(kwargs['notus_feed_dir']))
 
         super().__init__(
             customvtfilter=OpenVasVtsFilter(self.nvti),
@@ -1365,9 +1368,20 @@ class OSPDopenvas(OSPDaemon):
         self.main_db.release_database(kbdb)
 
 
+class NotusParser(CliParser):
+    def __init__(self):
+        super().__init__('OSPD - openvas')
+        self.parser.add_argument(
+            '--notus-feed-dir',
+            default="/var/lib/openvas/notus/advisories",
+            help='Directory where notus feed is placed. Default: %(default)s',
+        )
+
+
 def main():
     """OSP openvas main function."""
-    daemon_main('OSPD - openvas', OSPDopenvas)
+
+    daemon_main('OSPD - openvas', OSPDopenvas, NotusParser())
 
 
 if __name__ == '__main__':

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -432,7 +432,14 @@ class OSPDopenvas(OSPDaemon):
     ):
         """Initializes the ospd-openvas daemon's internal data."""
         self.main_db = MainDB()
-        self.nvti = NVTICache(self.main_db, Notus(kwargs['notus_feed_dir']))
+        self.nvti = NVTICache(
+            self.main_db,
+            Notus(
+                kwargs.get(
+                    'notus_feed_dir', '/var/lib/openvas/notus/advisories'
+                )
+            ),
+        )
 
         super().__init__(
             customvtfilter=OpenVasVtsFilter(self.nvti),

--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2014-2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from typing import Dict, Optional
+import json
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class Notus:
+    # caches the oids as well as the filepath to load the meta_data
+    # probably better in redis
+    cache: Dict[str, str]
+    path: Path
+
+    def __init__(self, path: str):
+        self.path = Path(path)
+        self.cache = {}
+
+    def reload_cache(self):
+        new_cache = {}
+        for f in self.path.glob('*.notus'):
+            filename = f.as_posix()
+            data = json.loads(f.read_bytes())
+            advisories = data.get("advisories", [])
+            for advisory in advisories:
+                new_cache[advisory["oid"]] = filename
+        self.cache = new_cache
+
+    def get_filenames_and_oids(self):
+        if not self.cache:
+            self.reload_cache()
+        for k, v in self.cache.items():
+            yield (Path(v).name, k)
+
+    def find_advisory(self, path: Path, oid: str):
+        advisories = json.loads(path.read_bytes())
+        for advisory in advisories.get("advisories", []):
+            if advisory.get("oid") == oid:
+                return advisory
+
+    def get_nvt_metadata(self, oid: str) -> Optional[Dict[str, str]]:
+        if not self.cache:
+            self.reload_cache()
+        pstr = self.cache.get(oid)
+        if not pstr:
+            return None
+        path = Path(pstr)
+        advisory = self.find_advisory(path, oid)
+        if not advisory:
+            return None
+        result = {}
+        result["vt_params"] = []
+        result["creation_time"] = str(advisory.get("creation_date", 0))
+        result["last_modification"] = str(advisory.get("last_modification", 0))
+        result["modification_time"] = str(advisory.get("last_modification", 0))
+        result["summary"] = advisory.get("summary")
+        result["impact"] = advisory.get("impact")
+        result["affected"] = advisory.get("affected")
+        result["insight"] = advisory.get("insight")
+        # vuldetect and solution need to be clarrified
+        # result['solution'] = None
+        # result['vuldetect'] = None
+        severity = {
+            "CVSS:3": result.get("severity", {}).get("cvss_v3"),
+            "CVSS:2": result.get("severity", {}).get("cvss_v2"),
+            "severity_date": result.get("severity", {}).get("date"),
+            "severity_origin": result.get("severity", {}).get("origin"),
+        }
+        result["severity_vector"] = severity
+
+        result["filename"] = path.name
+        result["required_keys"] = ""
+        result["mandatory_keys"] = ""
+        result["excluded_keys"] = ""
+        result["required_udp_ports"] = ""
+        result["required_ports"] = ""
+        result["dependencies"] = ""
+        result["tag"] = ""
+        refs = {
+            "bid": advisory.get("bid", []),
+            "cve": advisory.get("cve", []),
+            "xref": advisory.get("xrefs", []),
+        }
+        result["refs"] = refs
+        result["category"] = advisory.get("category", "")
+        result["family"] = path.stem
+        result["name"] = advisory.get("title", "")
+        return result

--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -46,7 +46,7 @@ class Cache:
 
     def get_keys(self) -> Iterator[str]:
         for key in self.db.scan_iter(f"{self.__prefix}*"):
-            yield str(key).split('/')[-1]
+            yield str(key).rsplit('/', maxsplit=1)[-1]
 
 
 class Notus:

--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -81,9 +81,10 @@ class Notus:
         result["insight"] = advisory.get("insight")
         result['solution'] = "Please install the updated package(s)."
         result['solution_type'] = "VendorFix"
-        result[
-            'vuldetect'
-        ] = 'Checks if a vulnerable package version is present on the target host.'
+        result['vuldetect'] = (
+            'Checks if a vulnerable package version is present on the target'
+            ' host.'
+        )
         result['qod_type'] = 'package'
         severity = advisory.get('severity', {})
         result["severity_vector"] = severity.get(

--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -48,8 +48,8 @@ class Notus:
     def get_filenames_and_oids(self):
         if not self.cache:
             self.reload_cache()
-        for k, v in self.cache.items():
-            yield (Path(v).name, k)
+        for key, value in self.cache.items():
+            yield (Path(value).name, key)
 
     def find_advisory(self, path: Path, oid: str):
         advisories = json.loads(path.read_bytes())

--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -17,91 +17,106 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Iterator, Optional
 import json
 import logging
 
 
+from redis import Redis
+
 logger = logging.getLogger(__name__)
+
+
+class Cache:
+    def __init__(self, db: Redis, prefix: str = "internal/notus/advisories"):
+        self.db = db
+        self.__prefix = prefix
+
+    def store_advisory(self, oid: str, value: Dict[str, str]):
+        return self.db.lpush(f"{self.__prefix}/{oid}", json.dumps(value))
+
+    def exists(self, oid: str) -> bool:
+        return self.db.exists(f"{self.__prefix}/{oid}") == 1
+
+    def get_advisory(self, oid: str) -> Optional[Dict[str, str]]:
+        result = self.db.lindex(f"{self.__prefix}/{oid}", 0)
+        if result:
+            return json.loads(result)
+        return None
+
+    def get_keys(self) -> Iterator[str]:
+        for key in self.db.scan_iter(f"{self.__prefix}*"):
+            yield str(key).split('/')[-1]
 
 
 class Notus:
     # caches the oids as well as the filepath to load the meta_data
     # probably better in redis
-    cache: Dict[str, str]
+    cache: Cache
+    loaded: bool = False
     path: Path
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, redis: Redis):
         self.path = Path(path)
-        self.cache = {}
+        self.cache = Cache(redis)
 
     def reload_cache(self):
-        new_cache = {}
         for f in self.path.glob('*.notus'):
-            filename = f.as_posix()
             data = json.loads(f.read_bytes())
             advisories = data.get("advisories", [])
             for advisory in advisories:
-                new_cache[advisory["oid"]] = filename
-        self.cache = new_cache
+                res = self.__to_ospd(f, advisory)
+                self.cache.store_advisory(advisory["oid"], res)
+        self.loaded = True
 
-    def get_filenames_and_oids(self):
-        if not self.cache:
-            self.reload_cache()
-        for key, value in self.cache.items():
-            yield (Path(value).name, key)
-
-    def find_advisory(self, path: Path, oid: str):
-        advisories = json.loads(path.read_bytes())
-        for advisory in advisories.get("advisories", []):
-            if advisory.get("oid") == oid:
-                return advisory
-
-    def get_nvt_metadata(self, oid: str) -> Optional[Dict[str, str]]:
-        if not self.cache:
-            self.reload_cache()
-        pstr = self.cache.get(oid)
-        if not pstr:
-            return None
-        path = Path(pstr)
-        advisory = self.find_advisory(path, oid)
-        if not advisory:
-            return None
+    def __to_ospd(self, path: Path, advisory: Dict[str, Any]):
         result = {}
         result["vt_params"] = []
-        result["creation_time"] = str(advisory.get("creation_date", 0))
+        result["creation_date"] = str(advisory.get("creation_date", 0))
         result["last_modification"] = str(advisory.get("last_modification", 0))
         result["modification_time"] = str(advisory.get("last_modification", 0))
         result["summary"] = advisory.get("summary")
         result["impact"] = advisory.get("impact")
         result["affected"] = advisory.get("affected")
         result["insight"] = advisory.get("insight")
-        # vuldetect and solution need to be clarrified
-        # result['solution'] = None
-        # result['vuldetect'] = None
-        severity = {
-            "CVSS:3": result.get("severity", {}).get("cvss_v3"),
-            "CVSS:2": result.get("severity", {}).get("cvss_v2"),
-            "severity_date": result.get("severity", {}).get("date"),
-            "severity_origin": result.get("severity", {}).get("origin"),
-        }
-        result["severity_vector"] = severity
+        result['solution'] = "Please install the updated package(s)."
+        result['solution_type'] = "VendorFix"
+        result[
+            'vuldetect'
+        ] = 'Checks if a vulnerable package version is present on the target host.'
+        result['qod_type'] = 'package'
+        severity = advisory.get('severity', {})
+        result["severity_vector"] = severity.get(
+            "cvss_v3", severity.get("cvss_v2", "")
+        )
 
         result["filename"] = path.name
-        result["required_keys"] = ""
-        result["mandatory_keys"] = ""
-        result["excluded_keys"] = ""
-        result["required_udp_ports"] = ""
-        result["required_ports"] = ""
-        result["dependencies"] = ""
-        result["tag"] = ""
-        refs = {
-            "bid": advisory.get("bid", []),
-            "cve": advisory.get("cve", []),
-            "xref": advisory.get("xrefs", []),
-        }
+        bid = advisory.get("bid", [])
+        cve = advisory.get("cve", [])
+        xref = advisory.get("xrefs", [])
+        refs = {}
+        if bid:
+            refs['bid'] = bid
+        if cve:
+            refs['cve'] = cve
+        if xref:
+            refs['xref'] = xref
+
         result["refs"] = refs
-        result["category"] = advisory.get("category", "")
         result["family"] = path.stem
         result["name"] = advisory.get("title", "")
         return result
+
+    def get_filenames_and_oids(self):
+        if not self.loaded:
+            self.reload_cache()
+        for key in self.cache.get_keys():
+            adv = self.cache.get_advisory(key)
+            if adv:
+                yield (adv.get("filename", ""), key)
+
+    def exists(self, oid: str) -> bool:
+        return self.cache.exists(oid)
+
+    def get_nvt_metadata(self, oid: str) -> Optional[Dict[str, str]]:
+        return self.cache.get_advisory(oid)

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -58,7 +58,7 @@ class NVTICache(BaseDB):
     }
 
     def __init__(  # pylint: disable=super-init-not-called
-        self, main_db: MainDB, notus: Optional[Notus]
+        self, main_db: MainDB, notus: Optional[Notus] = None
     ):
         self._ctx = None
         self.index = None

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -89,8 +89,7 @@ class NVTICache(BaseDB):
         """Get the list of NVT file names and OIDs.
 
         Returns:
-            A i. Each single list contains the filename
-            as first element and the oid as second one.
+            An iterable of tuples of file name and oid.
         """
         if self.notus:
             for f, oid in self.notus.get_filenames_and_oids():

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -97,7 +97,7 @@ class NVTICache(BaseDB):
                 yield (f, oid)
         if self.ctx:
             for f, oid in OpenvasDB.get_filenames_and_oids(self.ctx):
-                if not self.notus or not self.notus.cache.get(oid):
+                if not self.notus or not self.notus.exists(oid):
                     yield (f, oid)
 
     def get_nvt_params(self, oid: str) -> Optional[Dict[str, str]]:

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -247,7 +247,6 @@ class NVTICache(BaseDB):
         if n:
             return n.get("family")
 
-
         return OpenvasDB.get_single_item(
             self.ctx,
             f"nvt:{oid}",

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -20,6 +20,7 @@
 """ Provide functions to handle NVT Info Cache. """
 
 import logging
+from ospd_openvas.notus import Notus
 
 from typing import List, Dict, Optional, Iterator, Tuple
 from pathlib import Path
@@ -57,11 +58,12 @@ class NVTICache(BaseDB):
     }
 
     def __init__(  # pylint: disable=super-init-not-called
-        self, main_db: MainDB
+        self, main_db: MainDB, notus: Notus
     ):
         self._ctx = None
         self.index = None
         self._main_db = main_db
+        self.notus = notus
 
     @property
     def ctx(self) -> Optional[RedisCtx]:
@@ -80,6 +82,7 @@ class NVTICache(BaseDB):
             # no nvti cache db available yet
             return None
 
+        # no feed version for notus otherwise tha would be a contract change
         return OpenvasDB.get_single_item(self.ctx, NVTI_CACHE_NAME)
 
     def get_oids(self) -> Iterator[Tuple[str, str]]:
@@ -89,7 +92,12 @@ class NVTICache(BaseDB):
             A i. Each single list contains the filename
             as first element and the oid as second one.
         """
-        return OpenvasDB.get_filenames_and_oids(self.ctx)
+        for f, oid in self.notus.get_filenames_and_oids():
+            yield (f, oid)
+        if self.ctx:
+            for f, oid in OpenvasDB.get_filenames_and_oids(self.ctx):
+                if not self.notus.cache.get(oid):
+                    yield (f, oid)
 
     def get_nvt_params(self, oid: str) -> Optional[Dict[str, str]]:
         """Get NVT's preferences.
@@ -227,7 +235,7 @@ class NVTICache(BaseDB):
 
         return refs
 
-    def get_nvt_family(self, oid: str) -> str:
+    def get_nvt_family(self, oid: str) -> Optional[str]:
         """Get NVT family
         Arguments:
             oid: OID of VT from which to get the VT family.
@@ -235,6 +243,11 @@ class NVTICache(BaseDB):
         Returns:
             A str with the VT family.
         """
+        n = self.notus.get_nvt_metadata(oid)
+        if n:
+            return n.get("family")
+
+
         return OpenvasDB.get_single_item(
             self.ctx,
             f"nvt:{oid}",
@@ -252,6 +265,7 @@ class NVTICache(BaseDB):
             A list with the VT preferences.
         """
         key = f'oid:{oid}:prefs'
+        # notus doesn't seem to have preferences, ignoring
         return OpenvasDB.get_list_item(self.ctx, key)
 
     def get_nvt_tags(self, oid: str) -> Optional[Dict[str, str]]:
@@ -280,6 +294,7 @@ class NVTICache(BaseDB):
         return OpenvasDB.get_key_count(self.ctx, "nvt:*")
 
     def force_reload(self):
+        self.notus.reload_cache()
         self._main_db.release_database(self)
 
     def add_vt_to_cache(self, vt_id: str, vt: List[str]):

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -34,12 +34,14 @@ class VtHelper:
         self.nvti = nvticache
 
     def get_single_vt(self, vt_id: str, oids=None) -> Optional[Dict[str, Any]]:
+        nr = None
         if self.nvti.notus:
             nr = self.nvti.notus.get_nvt_metadata(vt_id)
-            if nr:
-                return nr
 
-        custom = self.nvti.get_nvt_metadata(vt_id)
+        if nr:
+            custom = nr
+        else:
+            custom = self.nvti.get_nvt_metadata(vt_id)
 
         if not custom:
             return None
@@ -101,6 +103,7 @@ class VtHelper:
             qod_v = custom.pop('qod')
 
         severity = dict()
+
         if 'severity_vector' in custom:
             severity_vector = custom.pop('severity_vector')
         else:

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -21,9 +21,8 @@
 
 from hashlib import sha256
 import logging
-from typing import Optional, Dict, List, Tuple, Iterator
+from typing import Any, Optional, Dict, List, Tuple, Iterator
 
-from typing import Any
 from ospd.cvss import CVSS
 from ospd_openvas.nvticache import NVTICache
 

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -21,7 +21,6 @@
 
 from hashlib import sha256
 import logging
-from ospd_openvas.notus import Notus
 from typing import Optional, Dict, List, Tuple, Iterator
 
 from typing import Any
@@ -36,9 +35,10 @@ class VtHelper:
         self.nvti = nvticache
 
     def get_single_vt(self, vt_id: str, oids=None) -> Optional[Dict[str, Any]]:
-        nr = self.nvti.notus.get_nvt_metadata(vt_id)
-        if nr:
-            return nr
+        if self.nvti.notus:
+            nr = self.nvti.notus.get_nvt_metadata(vt_id)
+            if nr:
+                return nr
 
         custom = self.nvti.get_nvt_metadata(vt_id)
 

--- a/smoketest/Dockerfile
+++ b/smoketest/Dockerfile
@@ -26,12 +26,13 @@ RUN curl -L https://golang.org/dl/go1.17.2.linux-amd64.tar.gz -o /tmp/go.tar.gz 
     tar -C /usr/local -xzf /tmp/go.tar.gz &&\
     rm /tmp/go.tar.gz
 RUN useradd -rm -d /home/gvm -s /bin/bash -g root -g redis -G sudo -u 1000 gvm
-RUN  echo 'gvm:test' | chpasswd
+RUN echo 'gvm:test' | chpasswd
 RUN echo "gvm ALL = NOPASSWD: /usr/sbin/openvas" > /etc/sudoers.d/allow_openvas
 RUN echo "gvm ALL = NOPASSWD: /usr/bin/redis-server" > /etc/sudoers.d/allow_redis-server
-COPY redis.conf /etc/redis/redis.conf
-COPY --chmod=7777 . /usr/local/src/it
-RUN mv /usr/local/src/it/data/plugins/* /var/lib/openvas/plugins
+COPY smoketest/redis.conf /etc/redis/redis.conf
+COPY --chmod=7777 . /usr/local/src/ospd-openvas
+RUN cp -r /usr/local/src/ospd-openvas/smoketest/data/plugins/* /var/lib/openvas/plugins
+RUN cp -r /usr/local/src/ospd-openvas/smoketest/data/notus /var/lib/openvas/notus
 RUN mkdir /run/redis
 RUN chown redis:redis /run/redis
 RUN mkdir -p /home/gvm/
@@ -42,7 +43,6 @@ RUN touch /etc/openvas/openvas_log.conf
 RUN chown gvm:sudo /etc/openvas/openvas_log.conf
 WORKDIR /usr/local/src
 RUN git clone --single-branch --depth=1 https://github.com/greenbone/ospd.git
-RUN git clone --single-branch --depth=1 https://github.com/greenbone/ospd-openvas.git
 WORKDIR /usr/local/src/ospd
 RUN python3 -m pip install .
 WORKDIR /usr/local/src/ospd-openvas
@@ -50,5 +50,5 @@ RUN python3 -m pip install .
 RUN chown gvm:sudo /var/log/gvm
 RUN ln -s /usr/local/go/bin/* /usr/local/bin/
 USER gvm
-WORKDIR /usr/local/src/it
-CMD /usr/local/src/it/run-tests.sh
+WORKDIR /usr/local/src/ospd-openas/smoketest
+CMD /usr/local/src/ospd-openvas/smoketest/run-tests.sh

--- a/smoketest/notus/notus.go
+++ b/smoketest/notus/notus.go
@@ -1,0 +1,29 @@
+package notus
+
+type Severity struct {
+	Origin string `json: "origin"`
+	Date   int64  `json: "date"`
+	CVSSV2 string `json: "cvss_v2"`
+	CVSSV3 string `json: "cvss_v3"`
+}
+
+type Advisory struct {
+	OID              string   `json: "oid"`
+	Title            string   `json: "title"`
+	CreationDate     int64    `json: "creation_date"`
+	LastModification int64    `json: "last_modification"`
+	AdvisoryId       string   `json: "advisory_id"`
+	AdvisoryXref     string   `json: "advisory_xref"`
+	Cves             []string `json: "cves"`
+	Summary          string   `json: "summary"`
+	Insight          string   `json: "insight"`
+	Affected         string   `json: "affected"`
+	Impact           string   `json: "impact"`
+	Xrefs            []string `json: "xrefs"`
+	Severity         Severity `json: "seveerity"`
+}
+
+type Advisories struct {
+	Version    string     `json: "version"`
+	Advisories []Advisory `json: "advisories"`
+}

--- a/smoketest/run-tests.sh
+++ b/smoketest/run-tests.sh
@@ -11,5 +11,5 @@ trap shutdown EXIT
 
 sudo redis-server /etc/redis/redis.conf
 ospd-openvas -u /var/run/ospd/ospd.sock -l /var/log/gvm/ospd.log
-cd /usr/local/src/it
+cd /usr/local/src/ospd-openvas/smoketest
 go test ./...

--- a/tests/dummydaemon.py
+++ b/tests/dummydaemon.py
@@ -160,7 +160,7 @@ class DummyDaemon(OSPDopenvas):
         }
         nvti.get_feed_version.return_value = '123'
 
-        super().__init__(niceness=10, lock_file_dir='/tmp' )
+        super().__init__(niceness=10, lock_file_dir='/tmp')
 
         self.scan_collection.data_manager = FakeDataManager()
 

--- a/tests/dummydaemon.py
+++ b/tests/dummydaemon.py
@@ -94,6 +94,7 @@ class DummyDaemon(OSPDopenvas):
         assert NvtiClass
         nvti = NvtiClass.return_value
         oids = [['mantis_detect.nasl', '1.3.6.1.4.1.25623.1.0.100061']]
+        nvti.notus = None
         nvti.get_oids.return_value = oids
         nvti.get_nvt_params.return_value = {
             '1': {
@@ -159,7 +160,7 @@ class DummyDaemon(OSPDopenvas):
         }
         nvti.get_feed_version.return_value = '123'
 
-        super().__init__(niceness=10, lock_file_dir='/tmp')
+        super().__init__(niceness=10, lock_file_dir='/tmp' )
 
         self.scan_collection.data_manager = FakeDataManager()
 

--- a/tests/test_nvti_cache.py
+++ b/tests/test_nvti_cache.py
@@ -27,7 +27,6 @@ from unittest import TestCase
 from unittest.mock import patch, Mock, PropertyMock
 from pathlib import Path
 
-from ospd_openvas.notus import Notus
 from ospd_openvas.nvticache import NVTICache, NVTI_CACHE_NAME
 
 from tests.helper import assert_called
@@ -75,11 +74,13 @@ class TestNVTICache(TestCase):
         )
 
     def test_get_oids(self, MockOpenvasDB):
-        MockOpenvasDB.get_filenames_and_oids.return_value = [('filename', 'oid')]
+        MockOpenvasDB.get_filenames_and_oids.return_value = [
+            ('filename', 'oid')
+        ]
 
         resp = self.nvti.get_oids()
 
-        self.assertEqual([ x for x in resp ], [('filename', 'oid')])
+        self.assertEqual([x for x in resp], [('filename', 'oid')])
 
     def test_parse_metadata_tag_missing_value(self, MockOpenvasDB):
         logging.Logger.error = Mock()

--- a/tests/test_nvti_cache.py
+++ b/tests/test_nvti_cache.py
@@ -27,6 +27,7 @@ from unittest import TestCase
 from unittest.mock import patch, Mock, PropertyMock
 from pathlib import Path
 
+from ospd_openvas.notus import Notus
 from ospd_openvas.nvticache import NVTICache, NVTI_CACHE_NAME
 
 from tests.helper import assert_called
@@ -37,7 +38,7 @@ class TestNVTICache(TestCase):
     @patch('ospd_openvas.db.MainDB')
     def setUp(self, MockMainDB):  # pylint: disable=arguments-differ
         self.db = MockMainDB()
-        self.nvti = NVTICache(self.db)
+        self.nvti = NVTICache(self.db, None)
         self.nvti._ctx = 'foo'
 
     def test_set_index(self, MockOpenvasDB):
@@ -74,11 +75,11 @@ class TestNVTICache(TestCase):
         )
 
     def test_get_oids(self, MockOpenvasDB):
-        MockOpenvasDB.get_filenames_and_oids.return_value = ['oids']
+        MockOpenvasDB.get_filenames_and_oids.return_value = [('filename', 'oid')]
 
         resp = self.nvti.get_oids()
 
-        self.assertEqual(resp, ['oids'])
+        self.assertEqual([ x for x in resp ], [('filename', 'oid')])
 
     def test_parse_metadata_tag_missing_value(self, MockOpenvasDB):
         logging.Logger.error = Mock()


### PR DESCRIPTION
When calling get_vts ospd-openvas will try to load the notus advisories;
look them up and yielding the response; when it is not in the notus
advisories it will return the information based on redis from openvas as
previously.

With this integration a client e.g. gvmd should get all needed
information for notus results.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
