### PR TITLE
Fix container image

### DIFF
--- a/.docker/main.Dockerfile
+++ b/.docker/main.Dockerfile
@@ -1,4 +1,6 @@
-FROM debian:stable-slim
+ARG VERSION=unstable
+
+FROM greenbone/openvas-scanner:${VERSION}
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ keywords = [
 
 packages = [
   { include = "ospd_openvas"},
+  { include = "ospd"},
   { include = "docs/ospd-openvas.8", format = "sdist"},
   { include = "config/ospd-openvas.service", format = "sdist"},
   { include = "config/ospd-openvas.conf", format = "sdist"},


### PR DESCRIPTION
**What**:

Fix building the ospd-openvas container image.

**Why**:

The current image can't be started because ospd python package and the openvas scanner executable are not available.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
