### PR TITLE
Use /etc/openvas/gnupg for gnupg home as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Greenbone Logo](https://www.greenbone.net/wp-content/uploads/gb_logo_resilience_horizontal.png)
+![Greenbone Logo](https://www.greenbone.net/wp-content/uploads/gb_new-logo_horizontal_rgb_small.png)
 
 # ospd-openvas
 

--- a/README.md
+++ b/README.md
@@ -20,19 +20,17 @@ you can create scan tasks to use OpenVAS and Notus.
 
 Python 3.7 and later is supported.
 
-Beyond the [ospd base library](https://github.com/greenbone/ospd),
 `ospd-openvas` has dependencies on the following Python packages:
 
-- `redis`
-- `psutil`
+- `defusedxml`
+- `depreacted`
+- `lxml`
 - `packaging`
-
-There are no special installation aspects for this module beyond the general
-installation guide for ospd-based scanners.
-
-Please follow the general installation guide for ospd-based scanners:
-
-  <https://github.com/greenbone/ospd-openvas/blob/main/docs/INSTALL-ospd-scanner.md>
+- `paho-mqtt`
+- `paramiko`
+- `psutil`
+- `python-gnupg`
+- `redis`
 
 ### Mandatory configuration
 

--- a/ospd_openvas/gpg_sha_verifier.py
+++ b/ospd_openvas/gpg_sha_verifier.py
@@ -6,14 +6,16 @@ from typing import Callable, Dict, Optional
 from dataclasses import dataclass
 from gnupg import GPG
 
+OPENVAS_GPG_HOME = "/etc/openvas/gnupg"
+
 
 def __default_gpg_home() -> GPG:
     """
-    __defaultGpgHome tries to load the variable 'GPG_HOME' or to guess it
+    __defaultGpgHome tries to load the variable 'GNUPGHOME' or to guess it
     """
-    manual = os.getenv("GPG_HOME")
+    manual = os.getenv("GNUPGHOME")
 
-    home = Path(manual) if manual else Path.home() / ".gnupg"
+    home = Path(manual) if manual else Path(OPENVAS_GPG_HOME)
     return GPG(gnupghome=f"{home.absolute()}")
 
 


### PR DESCRIPTION
**What**:

Use the same directory as openvas-scanner for loading the gnupg keys by
default. Additionally rename the env variable GPG_HOME to GNUPGHOME to
use the same variable as the gnupg project.

SC-477

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
