### PR TITLE
Fix: missing category of notus advisories

### DIFF
--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -122,6 +122,7 @@ class Notus:
         result["refs"] = refs
         result["family"] = path.stem
         result["name"] = advisory.get("title", "")
+        result["category"] = "3"
         return result
 
     def get_filenames_and_oids(self):


### PR DESCRIPTION
**What**:
Add category for notus advisories
SC-479

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
gvmd got error due to missing category

<!-- Why are these changes necessary? -->

**How**:
Tested with the get vt command that the notus advisories contains the category now:
`gvm-cli --log DEBUG --timeout 3600 --protocol OSP socket --socketpath /home/ck2104/greenbone/install/var/run/ospd/ospd-openvas.sock -X "<get_vts/>" | xmlstarlet fo > all_vts.xml`
xmlstarlet is for formatting the output, to be able to read the data properly I saved them in a file.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] PR merge commit message adjusted
