### PR TITLE
Fix: warning on ERRMSG

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1176,31 +1176,24 @@ class OSPDopenvas(OSPDaemon):
             ruri = res["uri"] if "uri" in res else ""
 
             if (
-                roid
-                and not host_is_dead
+                not host_is_dead
                 and not host_deny
                 and not start_end_msg
                 and not host_count
             ):
+                if not roid and res["result_type"] != 'ERRMSG':
+                    logger.warning('Missing VT oid for a result')
                 vt_aux = vthelper.get_single_vt(roid)
+                if not vt_aux:
+                    logger.warning('Invalid VT oid %s for a result', roid)
+                else:
+                    if vt_aux.get('qod_type'):
+                        qod_t = vt_aux.get('qod_type')
+                        rqod = self.nvti.QOD_TYPES[qod_t]
+                    elif vt_aux.get('qod'):
+                        rqod = vt_aux.get('qod')
 
-            if (
-                not vt_aux
-                and not host_is_dead
-                and not host_deny
-                and not start_end_msg
-                and not host_count
-            ):
-                logger.warning('Invalid VT oid %s for a result', roid)
-
-            if vt_aux:
-                if vt_aux.get('qod_type'):
-                    qod_t = vt_aux.get('qod_type')
-                    rqod = self.nvti.QOD_TYPES[qod_t]
-                elif vt_aux.get('qod'):
-                    rqod = vt_aux.get('qod')
-
-                rname = vt_aux.get('name')
+                    rname = vt_aux.get('name')
 
             if res["result_type"] == 'ERRMSG':
                 res_list.add_scan_error_to_list(


### PR DESCRIPTION
**What**:
When ospd-openvas received an ERRMSG result, it often printed a warning that the OID is invalid, because some error messages do not contain an OID.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Start a scan with LSC enabled, but do not start notus. After a timeout (60s) openvas sends an ERRMSG as a result, that the LSC failed. In the old version ospd-openvas prints a warning that the OID of the result is not valid. After this patch this warning is only printed, if the result actually contained an OID.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
