### PR TITLE
Refactor: change topic from scanner/results to scanner/scan/info

### DIFF
--- a/ospd_openvas/messages/result.py
+++ b/ospd_openvas/messages/result.py
@@ -29,7 +29,7 @@ class ResultType(Enum):
 
 class ResultMessage(Message):
     message_type: MessageType = MessageType.RESULT
-    topic = "scanner/results"
+    topic = "scanner/scan/info"
 
     def __init__(
         self,

--- a/tests/messages/test_result.py
+++ b/tests/messages/test_result.py
@@ -40,7 +40,7 @@ class ResultMessageTestCase(TestCase):
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.RESULT)
-        self.assertEqual(message.topic, 'scanner/results')
+        self.assertEqual(message.topic, 'scanner/scan/info')
 
         self.assertEqual(message.scan_id, 'scan_1')
         self.assertEqual(message.host_ip, '1.1.1.1')

--- a/tests/messaging/test_mqtt.py
+++ b/tests/messaging/test_mqtt.py
@@ -52,7 +52,7 @@ class MQTTPublisherTestCase(TestCase):
         publisher.publish(message)
 
         client.publish.assert_called_with(
-            'scanner/results',
+            'scanner/scan/info',
             '{"message_id": "63026767-029d-417e-9148-77f4da49f49a", '
             '"message_type": "result.scan", '
             '"group_id": "866350e8-1492-497e-b12b-c079287d51dd", '
@@ -88,7 +88,7 @@ class MQTTSubscriberTestCase(TestCase):
 
         subscriber.subscribe(message, callback)
 
-        client.subscribe.assert_called_with('scanner/results', qos=1)
+        client.subscribe.assert_called_with('scanner/scan/info', qos=1)
 
 
 class MQTTDaemonTestCase(TestCase):


### PR DESCRIPTION
To make it easier to find notus results adjust the topic
to scanner/scan/info. This makes it easier to sport notus messages in a
different scan management environment than ospd.
