### PR TITLE
Refactor adjust group_id as defined in eulabeia

### DIFF
--- a/ospd_openvas/messages/message.py
+++ b/ospd_openvas/messages/message.py
@@ -33,18 +33,18 @@ class Message:
     topic: str = None
     message_type: MessageType = None
     message_id: UUID = None
-    group_id: UUID = None
+    group_id: str = None
     created: datetime = None
 
     def __init__(
         self,
         *,
         message_id: Optional[UUID] = None,
-        group_id: Optional[UUID] = None,
+        group_id: Optional[str] = None,
         created: Optional[datetime] = None,
     ):
         self.message_id = message_id if message_id else uuid4()
-        self.group_id = group_id if group_id else uuid4()
+        self.group_id = group_id if group_id else str(uuid4())
         self.created = created if created else datetime.utcnow()
 
     @classmethod
@@ -57,7 +57,7 @@ class Message:
             )
         return {
             'message_id': UUID(data.get("message_id")),
-            'group_id': UUID(data.get("group_id")),
+            'group_id': data.get("group_id"),
             'created': datetime.fromtimestamp(
                 float(data.get("created")), timezone.utc
             ),

--- a/tests/messages/test_message.py
+++ b/tests/messages/test_message.py
@@ -28,13 +28,13 @@ class MessageTestCase(TestCase):
         message = Message()
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
     def test_serialize(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID('63026767-029d-417e-9148-77f4da49f49a')
-        group_id = UUID('866350e8-1492-497e-b12b-c079287d51dd')
+        group_id = '866350e8-1492-497e-b12b-c079287d51dd'
         message = Message(
             message_id=message_id, group_id=group_id, created=created
         )
@@ -64,7 +64,7 @@ class MessageTestCase(TestCase):
             message.message_id, UUID('63026767-029d-417e-9148-77f4da49f49a')
         )
         self.assertEqual(
-            message.group_id, UUID('866350e8-1492-497e-b12b-c079287d51dd')
+            message.group_id, '866350e8-1492-497e-b12b-c079287d51dd'
         )
         self.assertEqual(
             message.created,
@@ -101,7 +101,7 @@ class MessageTestCase(TestCase):
     def test_to_str(self):
         created = datetime.fromtimestamp(1628512774)
         message_id = UUID('63026767-029d-417e-9148-77f4da49f49a')
-        group_id = UUID('866350e8-1492-497e-b12b-c079287d51dd')
+        group_id = '866350e8-1492-497e-b12b-c079287d51dd'
         message = Message(
             message_id=message_id, group_id=group_id, created=created
         )
@@ -129,7 +129,7 @@ class MessageTestCase(TestCase):
             message.message_id, UUID('63026767-029d-417e-9148-77f4da49f49a')
         )
         self.assertEqual(
-            message.group_id, UUID('866350e8-1492-497e-b12b-c079287d51dd')
+            message.group_id, '866350e8-1492-497e-b12b-c079287d51dd'
         )
         self.assertEqual(
             message.created,

--- a/tests/messages/test_result.py
+++ b/tests/messages/test_result.py
@@ -36,7 +36,7 @@ class ResultMessageTestCase(TestCase):
         )
 
         self.assertIsInstance(message.message_id, UUID)
-        self.assertIsInstance(message.group_id, UUID)
+        self.assertIsInstance(message.group_id, str)
         self.assertIsInstance(message.created, datetime)
 
         self.assertEqual(message.message_type, MessageType.RESULT)
@@ -108,7 +108,7 @@ class ResultMessageTestCase(TestCase):
             message.message_id, UUID('63026767-029d-417e-9148-77f4da49f49a')
         )
         self.assertEqual(
-            message.group_id, UUID('866350e8-1492-497e-b12b-c079287d51dd')
+            message.group_id, '866350e8-1492-497e-b12b-c079287d51dd'
         )
         self.assertEqual(
             message.created,


### PR DESCRIPTION
To prevent failures if ospd will be integrated into eulabeia the
parsing of group_id to uuid is getting dropped according to:

https://github.com/greenbone/eulabeia/blob/main/docs/messaging.md
