### PR TITLE
Fix: hash calculation

### DIFF
--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -188,6 +188,7 @@ class VtHelper:
                 # treat oids for dependency lookup as a dict
                 oids = dict(vt_collection)
 
+        vt_selection.sort()
         for vt_id in vt_selection:
             vt = self.get_single_vt(vt_id, oids)
             yield (vt_id, vt)


### PR DESCRIPTION
Due to yielding of notus as well as nvt oids the hash calculation failed due to incorrect order. To fix this the resulting list needs to be order by oids in lexicographical order.

To verify it run:
```
gvmd --rebuild
```

There should be no: Rebuilding all NVTs because of a hash value mismatch.