### PR TITLE
Fix: mqtt network loop

### DIFF
--- a/ospd_openvas/messaging/mqtt.py
+++ b/ospd_openvas/messaging/mqtt.py
@@ -140,7 +140,6 @@ class MQTTDaemon:
         self._client = client
         self._client.on_disconnect = self.on_disconnect
         self._client.on_connect = self.on_connect
-        self._client._userdata = "foo"
 
         self._client.connect()
 


### PR DESCRIPTION
**What**:
Move the initialization of the MQTT connection
SC-491

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When ospd-openvas was started in the background the MQTT stuff did not work properly. The reason was that the MQTT network loop was started within the main process, which exits after the initialization of the deamon. The MQTT network loop exits at this point too because it is a child of the main process.
Moving the initialization of the MQTT stuff fixes this issue.

<!-- Why are these changes necessary? -->

**How**:
1. Start ospd-openvas in background
2. Start a scan with a target supported by notus:
```xml
<start_scan scan_id='97079ee9-8917-49da-aa4f-4ef95f757ac1'>
    <vt_selection>
        <vt_single id='1.3.6.1.4.1.25623.1.0.50282'>
        </vt_single>
    </vt_selection>
    <targets>
        <target>
            <hosts>localhost</hosts>
            <ports>80,8080,443,22</ports>
            <credentials>
                <credential service="ssh" type="up" port="22">
                    <username>username</username>
                    <password>password</password>
                </credential>
            </credentials>
        </target>
    </targets>
    <scanner_params>
    </scanner_params>
</start_scan>
```
3. Check if notus results appear:
```xml
<get_scans scan_id='97079ee9-8917-49da-aa4f-4ef95f757ac1' details='1' progress='1'/>
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
