### PR TITLE
Fix: ospd-openvas should not crash on missing plugin_feed_info.inc

### DIFF
--- a/ospd/server.py
+++ b/ospd/server.py
@@ -146,8 +146,9 @@ class BaseServer(ABC):
 
     def close(self):
         """Shutdown the server"""
-        self.server.shutdown()
-        self.server.server_close()
+        if self.server:
+            self.server.shutdown()
+            self.server.server_close()
 
     @abstractmethod
     def handle_request(self, request, client_address):

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -598,7 +598,6 @@ class OSPDopenvas(OSPDaemon):
 
     def get_feed_info(self) -> Dict[str, Any]:
         """Parses the current plugin_feed_info.inc file"""
-        feed_info = dict()
 
         plugins_folder = self.scan_only_params.get('plugins_folder')
         if not plugins_folder:
@@ -608,8 +607,9 @@ class OSPDopenvas(OSPDaemon):
         if not feed_info_file.exists():
             self.set_params_from_openvas_settings()
             logger.debug('Plugins feed file %s not found.', feed_info_file)
-            return None
+            return {}
 
+        feed_info = {}
         with feed_info_file.open(encoding='utf-8') as fcontent:
             for line in fcontent:
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -371,7 +371,7 @@ class TestOspdOpenvas(TestCase):
         mock_path_exists.return_value = False
 
         ret = w.get_feed_info()
-        self.assertIsNone(ret)
+        self.assertEqual(ret, {})
 
         self.assertEqual(mock_set_params.call_count, 1)
         self.assertEqual(mock_path_exists.call_count, 1)


### PR DESCRIPTION
This commit fixes the crash when no plugin_feed_info.inc is found.
