### PR TITLE
Fix: do not load oids in openvas when handled by notus

### DIFF
--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -177,7 +177,7 @@ class NotusResultHandler:
             timer.start()
 
 
-DEFAULT_NOTUS_FEED_DIR = "/var/lib/openvas/notus/advisories"
+DEFAULT_NOTUS_FEED_DIR = "/var/lib/openvas/plugins/notus/advisories"
 
 
 class NotusParser(CliParser):

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -72,6 +72,22 @@ class PreferenceHandlerTestCase(TestCase):
 
         self.assertFalse(ret[1])
 
+    def test_not_append_notus_oids(self):
+        dummy = DummyDaemon()
+
+        vts = {
+            '1.3.6.1.4.1.25623.1.0.100061': {'1': 'new value'},
+            'vt_groups': ['family=debian', 'family=general'],
+        }
+
+        p_handler = PreferenceHandler(
+            '1234-1234', None, dummy.scan_collection, dummy.nvti, lambda _: True
+        )
+        re = p_handler._process_vts(vts)  # pylint: disable = protected-access
+
+        self.assertEqual(re[0], [])
+        self.assertEqual(re[1], {})
+
     def test_process_vts(self):
         dummy = DummyDaemon()
 


### PR DESCRIPTION
Given a scan configuration that contains a the Notus VT then openvas is
printing a warning:

`The NVT with oid ... was not found in the nvticache.`

Since those oids are handled by notus and not by openvas they are
filtered out within the preferencehandler.
