### PR TITLE
Fix: Stop and resume scan

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -328,6 +328,7 @@ class DeleteScan(BaseCommand):
 
         if not self._daemon.scan_exists(scan_id):
             text = f"Failed to find scan '{scan_id}'"
+            logger.debug(text)
             return simple_response_str('delete_scan', 404, text)
 
         self._daemon.check_scan_process(scan_id)

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -591,7 +591,9 @@ class ScanCollection:
             return False
 
         scans_table = self.scans_table
-        del scans_table[scan_id]
-        self.scans_table = scans_table
-
+        try:
+            del scans_table[scan_id]
+            self.scans_table = scans_table
+        except KeyError:
+            return False
         return True


### PR DESCRIPTION
**What**:
Fix stop and resume task

Jira: AP-1893
Jira: SC-233
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When a scan is started, stopped when it is still 0% progress and quickly resumed, the task ended as interrupted, or not in a blocking situation with "requested" status.

<!-- Why are these changes necessary? -->

**How**:
1a) Start a vulnerability scan against a single host target
2a) As soon as the scan task has the status "0%", stop the scan task
3a) Once the scan task has the status "Stopped at 0%", resume the scan task
4a) If the scan task has the status "Stopped at 0%" or "Interrupted at 0%" subsequently, resume the scan task again

With the patch, it is possible to do this and the scan is stopped successfully and it is possible to resume it with out issues.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
