### PR TITLE
Add: possibility to handle redis tcp connections configured in openvas

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -34,4 +34,4 @@ RUN python3 -m pip install /ospd-openvas/*
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
-CMD ["ospd-openvas", "--config", "/etc/gvm/ospd-openvas.conf", "-f", "-m", "666"]
+CMD ["ospd-openvas", "--disable-notus-hashsum-verification", "--config", "/etc/gvm/ospd-openvas.conf", "-f", "-m", "666"]


### PR DESCRIPTION
Since https://github.com/greenbone/gvm-libs/pull/669 openvas can be
configured with tcp:// this commit enables the same behaviour within
ospd-openvas.