### PR TITLE
Add: log info for VT update

### DIFF
--- a/ospd_openvas/openvas.py
+++ b/ospd_openvas/openvas.py
@@ -123,7 +123,7 @@ class Openvas:
         return param_list
 
     @staticmethod
-    def load_vts_into_redis():
+    def load_vts_into_redis() -> bool:
         """Loads all VTs into the redis database"""
         logger.debug('Loading VTs into Redis DB...')
 
@@ -132,8 +132,10 @@ class Openvas:
                 ['openvas', '--update-vt-info'], stdout=subprocess.DEVNULL
             )
             logger.debug('Finished loading VTs into Redis DB')
+            return True
         except (subprocess.SubprocessError, OSError) as err:
             logger.error('OpenVAS Scanner failed to load VTs. %s', err)
+            return False
 
     @staticmethod
     def start_scan(


### PR DESCRIPTION
**What**:
Adding logging to get information about VT updates on info level.
SC-507

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When a VT update was ongoing it only was logged on debugging level. This lead to confusion why scans were not started. Scans do not start during a VT update. Now info log message indicates the VT update ans also prints the old and new feed version.

<!-- Why are these changes necessary? -->

**How**:
Start ospd-openvas and see the logs. They should look like:

```
OSPD[20692] 2022-03-21 09:46:03,120: INFO: (ospd_openvas.daemon) Loading VTs. Scans will be [requested|queued] until VTs are loaded. This may take a few minutes, please wait...
OSPD[20692] 2022-03-21 09:46:52,850: INFO: (ospd_openvas.daemon) Finished loading VTs. The VT cache has been updated from version 0 to 202001010002.
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
