### PR TITLE
Add: description of table_driven_lsc to OSPD_PARAMS

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -355,6 +355,17 @@ OSPD_PARAMS = {
             + 'list for a dry run scan.'
         ),
     },
+    'table_driven_lsc': {
+        'type': 'boolean',
+        'name': 'table_driven_lsc',
+        'default': 1,
+        'mandatory': 0,
+        'visible_for_client': True,
+        'description': (
+            'If this option is enabled a scanner for table_driven_lsc will '
+            + 'scan package results.'
+        ),
+    },
 }
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -302,6 +302,17 @@ OSPD_PARAMS_OUT = {
             + 'list for a dry run scan.'
         ),
     },
+    'table_driven_lsc': {
+        'type': 'boolean',
+        'name': 'table_driven_lsc',
+        'default': 1,
+        'mandatory': 0,
+        'visible_for_client': True,
+        'description': (
+            'If this option is enabled a scanner for table_driven_lsc will '
+            + 'scan package results.'
+        ),
+    },
 }
 
 


### PR DESCRIPTION
gvmd needs a description of table_driven_lsc when calling

```
<get_scanner_details/>
```

so that it can disable notus on compliance checks.
