### PR TITLE
Change: Allow openvas access raw sockets within container

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /ospd-openvas
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
     gosu \
+    libcap2-bin \
     python3 \
     python3-pip && \
     apt-get remove --purge --auto-remove -y && \
@@ -30,6 +31,8 @@ RUN chgrp -R ospd-openvas /etc/openvas/ && \
 
 COPY dist/* /ospd-openvas
 
+# allow openvas to access raw sockets and all kind of network related tasks
+RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/sbin/openvas
 RUN python3 -m pip install /ospd-openvas/*
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]


### PR DESCRIPTION
**What**:

Allow openvas access raw sockets within container

**Why**:

For the boreas alive detection it is required to access the raw socket. For capturing packages (for example used for detecting log4j) the NET_ADMIN capabilities are required.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
