### PR TITLE
SC 607 Fix: missing reload on update_vts

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -682,6 +682,10 @@ class OSPDopenvas(OSPDaemon):
             " loaded. This may take a few minutes, please wait..."
         )
         old = self.nvti.get_feed_version() or 0
+        # reload notus cache
+        if self.nvti.notus:
+            self.nvti.notus.reload_cache()
+
         if Openvas.load_vts_into_redis():
             new = self.nvti.get_feed_version()
             if new != old:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -39,6 +39,7 @@ from ospd_openvas.daemon import (
     hashsum_verificator,
 )
 from ospd_openvas.openvas import Openvas
+from ospd_openvas.notus import Notus
 
 OSPD_PARAMS_OUT = {
     'auto_enable_dependencies': {
@@ -343,6 +344,12 @@ class TestOspdOpenvas(TestCase):
         w._is_running_as_root = False  # pylint: disable=protected-access
 
         self.assertTrue(w.sudo_available)
+
+    def test_update_vts(self):
+        daemon = DummyDaemon()
+        daemon.nvti.notus = MagicMock(spec=Notus)
+        daemon.update_vts()
+        self.assertEqual(daemon.nvti.notus.reload_cache.call_count, 1)
 
     @patch('ospd_openvas.daemon.Path.exists')
     @patch('ospd_openvas.daemon.Path.open')


### PR DESCRIPTION
Fix: missing reload on update_vts

On check_feed update_vts is triggered however it just updates openvas
vts and not notus; this commit changes that by reloading the notus cache
as well.

Although ospd-openvas should handle the calls reload-cache of notus is
now checking if there is already a reload process called and blocking
until that one is finished to prevent multiple reloads at the same time.

This pr should be merged after https://github.com/greenbone/ospd-openvas/pull/643 .