### PR TITLE
Refactor: remove on_disonnect on favor of destructor

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -521,6 +521,11 @@ class OSPDopenvas(OSPDaemon):
 
         self._mqtt_broker_address = mqtt_broker_address
         self._mqtt_broker_port = mqtt_broker_port
+        self._mqtt_daemon = None
+
+    def __del__(self):
+        if self._mqtt_daemon:
+            self._mqtt_daemon.stop()
 
     def init(self, server: BaseServer) -> None:
 
@@ -531,13 +536,14 @@ class OSPDopenvas(OSPDaemon):
                 client = MQTTClient(
                     self._mqtt_broker_address, self._mqtt_broker_port, "ospd"
                 )
-                daemon = MQTTDaemon(client)
+                self._mqtt_daemon = MQTTDaemon(client)
                 subscriber = MQTTSubscriber(client)
 
                 subscriber.subscribe(
                     ResultMessage, notus_handler.result_handler
                 )
-                daemon.run()
+                self._mqtt_daemon.run()
+
             except (ConnectionRefusedError, gaierror, ValueError) as e:
                 logger.error(
                     "Could not connect to MQTT broker at %s, error was: %s."

--- a/ospd_openvas/messaging/mqtt.py
+++ b/ospd_openvas/messaging/mqtt.py
@@ -138,22 +138,11 @@ class MQTTDaemon:
         client: MQTTClient,
     ):
         self._client = client
-        self._client.on_disconnect = self.on_disconnect
-        self._client.on_connect = self.on_connect
-
-        self._client.connect()
-
-    @staticmethod
-    def on_connect(_client, _userdata, _flags, rc, _properties):
-        if rc == 0:
-            logger.info("Connected to broker successfully")
-        else:
-            logger.error('Failed to connect to broker. Reason code %s', rc)
-
-    @staticmethod
-    def on_disconnect(client, _userdata, rc, _properties):
-        logger.info("Disconnected from broker. Reason code %s", rc)
-        client.loop_stop()
 
     def run(self):
+        self._client.connect()
         self._client.loop_start()
+
+    def stop(self):
+        self._client.disconnect()
+        self._client.loop_stop()

--- a/tests/messaging/test_mqtt.py
+++ b/tests/messaging/test_mqtt.py
@@ -97,8 +97,16 @@ class MQTTDaemonTestCase(TestCase):
 
         # pylint: disable=unused-variable
         daemon = MQTTDaemon(client)
+        daemon.run()
 
         client.connect.assert_called_with()
+
+    def test_stop(self):
+        client = mock.MagicMock()
+        daemon = MQTTDaemon(client)
+        daemon.stop()
+        client.disconnect.assert_called_with()
+        client.loop_stop.assert_called_with()
 
     def test_run(self):
         client = mock.MagicMock()


### PR DESCRIPTION
In paho version 1.5.1 (used in debian) _do_on_disconnect can raise an
exception due to incorrect usage. Since we cannot change the behaviour
of the packaged version we switch from using on_disonnect to a
destructor approach.

jira: SC-599 SC-606
