### PR TITLE
Fix: set to cvss2 when cvss3 is either not present or NULL

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -44,7 +44,7 @@ from ospd.resultlist import ResultList
 from ospd_openvas import __version__
 from ospd_openvas.errors import OspdOpenvasError
 
-from ospd_openvas.notus import Notus, NotusParser, NotusResultHandler
+from ospd_openvas.notus import Cache, Notus, NotusParser, NotusResultHandler
 from ospd_openvas.dryrun import DryRun
 from ospd_openvas.messages.result import ResultMessage
 from ospd_openvas.nvticache import NVTICache
@@ -486,7 +486,8 @@ class OSPDopenvas(OSPDaemon):
             verifier = hashsum_verificator(
                 ndir, disable_notus_hashsum_verification
             )
-            notus = Notus(ndir, self.main_db.ctx, verifier)
+
+            notus = Notus(ndir, Cache(self.main_db.ctx), verifier)
 
         self.nvti = NVTICache(
             self.main_db,

--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -65,12 +65,11 @@ class Notus:
     def __init__(
         self,
         path: Path,
-        redis: Redis,
+        cache: Cache,
         verifier: Callable[[Path], bool],
     ):
         self.path = path
-        self.cache = Cache(redis)
-
+        self.cache = cache
         self._verifier = verifier
 
     def reload_cache(self):
@@ -115,10 +114,10 @@ class Notus:
         )
         result['qod_type'] = meta_data.get('qod_type', 'package')
         severity = advisory.get('severity', {})
-        result["severity_vector"] = severity.get(
-            "cvss_v3", severity.get("cvss_v2", "")
-        )
-
+        cvss = severity.get("cvss_v3", None)
+        if not cvss:
+            cvss = severity.get("cvss_v2", None)
+        result["severity_vector"] = cvss
         result["filename"] = path.name
         bid = advisory.get("bid", [])
         cve = advisory.get("cve", [])


### PR DESCRIPTION
To fix a bug when cvss3 is intentionally set to NULL instead of omitted
Notus double checks if the value is NULL and if so tries to fallback to
cvss2.
