### PR TITLE
[ospd-openvas.service] Drop Group= directive

### DIFF
--- a/config/ospd-openvas.service
+++ b/config/ospd-openvas.service
@@ -8,7 +8,6 @@ ConditionKernelCommandLine=!recovery
 [Service]
 Type=forking
 User=gvm
-Group=gvm
 RuntimeDirectory=ospd
 RuntimeDirectoryMode=2775
 PIDFile=/run/ospd/ospd-openvas.pid


### PR DESCRIPTION
Specifying the Group is typically never required, as systemd's default
behavior to use the user's primary group is what you want anyways. And
to make the service file more readable, unnecessary directives should
be removed. So this removes the Group= directive.