### PR TITLE
Create required directories and set expected permissions on them

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -22,8 +22,10 @@ RUN addgroup --gid 1001 --system ospd-openvas && \
     adduser --no-create-home --shell /bin/false --disabled-password \
     --uid 1001 --system --group ospd-openvas
 
-RUN chgrp -R ospd-openvas /etc/openvas/ && \
-    chown ospd-openvas /var/log/gvm && \
+RUN mkdir -p /run/ospd && \
+    mkdir -p /var/lib/openvas && \
+    chown -R ospd-openvas.ospd-openvas \
+    /run/ospd /var/lib/openvas /etc/openvas /var/log/gvm && \
     chmod 755 /etc/openvas /var/log/gvm && \
     chmod 644 /etc/openvas/openvas_log.conf && \
     chmod 755 /usr/local/bin/entrypoint


### PR DESCRIPTION
**What**:

ospd-openvas needs to be able to write into /run/ospd for the unix
socket and /var/lib/openvas for the lock file. Therefore it needs to be
ensured that these directories exist and their permissions are fitting.

**Why**:

Allow to run stable docker container.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
