### PR TITLE
Fix: within python 3.9 and higher notus results are missing

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -521,11 +521,6 @@ class OSPDopenvas(OSPDaemon):
 
         self._mqtt_broker_address = mqtt_broker_address
         self._mqtt_broker_port = mqtt_broker_port
-        self._mqtt_daemon = None
-
-    def __del__(self):
-        if self._mqtt_daemon:
-            self._mqtt_daemon.stop()
 
     def init(self, server: BaseServer) -> None:
 
@@ -536,14 +531,13 @@ class OSPDopenvas(OSPDaemon):
                 client = MQTTClient(
                     self._mqtt_broker_address, self._mqtt_broker_port, "ospd"
                 )
-                self._mqtt_daemon = MQTTDaemon(client)
+                daemon = MQTTDaemon(client)
                 subscriber = MQTTSubscriber(client)
 
                 subscriber.subscribe(
                     ResultMessage, notus_handler.result_handler
                 )
-                self._mqtt_daemon.run()
-
+                daemon.run()
             except (ConnectionRefusedError, gaierror, ValueError) as e:
                 logger.error(
                     "Could not connect to MQTT broker at %s, error was: %s."

--- a/ospd_openvas/messaging/mqtt.py
+++ b/ospd_openvas/messaging/mqtt.py
@@ -139,10 +139,7 @@ class MQTTDaemon:
     ):
         self._client = client
 
-    def run(self):
         self._client.connect()
-        self._client.loop_start()
 
-    def stop(self):
-        self._client.disconnect()
-        self._client.loop_stop()
+    def run(self):
+        self._client.loop_start()

--- a/tests/messaging/test_mqtt.py
+++ b/tests/messaging/test_mqtt.py
@@ -97,16 +97,8 @@ class MQTTDaemonTestCase(TestCase):
 
         # pylint: disable=unused-variable
         daemon = MQTTDaemon(client)
-        daemon.run()
 
         client.connect.assert_called_with()
-
-    def test_stop(self):
-        client = mock.MagicMock()
-        daemon = MQTTDaemon(client)
-        daemon.stop()
-        client.disconnect.assert_called_with()
-        client.loop_stop.assert_called_with()
 
     def test_run(self):
         client = mock.MagicMock()


### PR DESCRIPTION
With python 3.9 and paho the notus results were not consumed this fixed
it by partially reverting cb6dacd61bb39f681f5d21ca0651dde815daca4e
