### PR TITLE
Fix: using empty dict as scanner-params instead of returning 404

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -598,7 +598,7 @@ class StartScan(BaseCommand):
 
         scanner_params = xml.find('scanner_params')
         if scanner_params is None:
-            raise OspdCommandError('No scanner_params element', 'start_scan')
+            scanner_params = {}
 
         # params are the parameters we got from the <scanner_params> XML.
         params = self._daemon.preprocess_scan_params(scanner_params)


### PR DESCRIPTION
Although it is possible to send empty scanner_params OSPD did enforce an empty
element. To make it easier to use OSPD it should just use an empty dict
when scanner_params got omitted.
