### PR TITLE
Refactor: add possibility to test scan-configs

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -13,6 +13,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/login-action@v2
+        with:
+          username: greenbonebot
+          password: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          registry: ghcr.io
       - uses: docker/setup-buildx-action@v1
       - run: make
         working-directory: smoketest

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ build
 .vscode
 .coverage
 .venv
-smoketest/run
+smoketest/bin
 smoketest/build.log
+
+smoketest/.scan-config

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ smoketest/bin
 smoketest/build.log
 
 smoketest/.scan-config
+smoketest/.nasl

--- a/smoketest/Dockerfile
+++ b/smoketest/Dockerfile
@@ -1,3 +1,9 @@
+FROM ghcr.io/greenbone/data-objects:community-staging AS data_objects
+RUN mv `ls -d /var/lib/gvm/data-objects/gvmd/*/*configs | sort -r | head -n 1` /policies
+
+FROM ghcr.io/greenbone/vulnerability-tests:community-staging AS nasl
+# use latest version
+RUN mv `ls -d /var/lib/openvas/* | sort -r | head -n 1`/vt-data/nasl /nasl
 
 FROM greenbone/openvas-scanner:unstable
 
@@ -16,6 +22,8 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     python3-redis \
     python3-gnupg \
     python3-paho-mqtt \
+    make \
+    openssh-server \
     curl &&\
 	apt-get remove --purge --auto-remove -y &&\
 	rm -rf /var/lib/apt/lists/*
@@ -54,12 +62,21 @@ RUN chown mosquitto:mosquitto /var/log/mosquitto
 RUN chmod 774 /var/log/mosquitto
 
 WORKDIR /usr/local/src/ospd-openvas/smoketest
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 /usr/local/go/bin/go build -o /usr/local/bin/ospd-openvas-smoketests cmd/test/main.go
+RUN GO="/usr/local/go/bin/go" make build-cmds
+RUN mv bin/* /usr/local/bin/
 RUN mv /usr/local/src/ospd-openvas/smoketest/run-tests.sh /usr/local/bin/run
-
+COPY --from=nasl --chmod=7777 /nasl /usr/local/src/nasl
+COPY --from=data_objects --chmod=7777 /policies /usr/local/src/policies
+RUN ospd-policy-feed -s /usr/local/src/nasl -t /var/lib/openvas/plugins -p /usr/local/src/policies
 RUN rm -rf /usr/local/go
 RUN rm -rf /usr/local/src/ospd-openvas
-RUN apt-get remove --purge --auto-remove -y curl python3-pip python3-packaging
-
+#RUN rm -rf /usr/local/src/nasl
+RUN apt-get remove --purge --auto-remove -y curl python3-pip python3-packaging make
+RUN chown -R gvm:redis /var/lib/openvas/plugins/
+RUN mkdir /run/sshd
+# make gvm capable of running sshd
+RUN chown -R gvm:redis /etc/ssh
+RUN echo 'gvm:test' | chpasswd
+RUN sed -i 's/#PidFile/Pidfile/' /etc/ssh/sshd_config
 USER gvm
 CMD /usr/local/bin/run

--- a/smoketest/Makefile
+++ b/smoketest/Makefile
@@ -1,12 +1,28 @@
 .PHONY: build run
 
+MAKEFILE_PATH := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+
 ALTERNATIVE_HOSTS := smoketest.localdomain smoke.localdomain and.localdomain mirrors.localdomain
 
 ADD_HOST := $(addprefix --add-host ,$(addsuffix :127.0.0.1, ${ALTERNATIVE_HOSTS}))
 
 RUN_PARAM := run --rm --privileged ${ADD_HOST}
 
+DATA_OBJECTS := ghcr.io/greenbone/data-objects:community-staging
+NASL := ghcr.io/greenbone/vulnerability-tests:community-staging
+
+ifndef GO
+	GO := go
+endif
+GO_BUILD := CGO_ENABLED=0 GOOS=linux GOARCH=amd64 ${GO} build -o
+
 all: build run
+
+build-cmds:
+	- mkdir bin || true
+	 ${GO_BUILD} bin/ospd-openvas-smoketests cmd/test/main.go
+	 ${GO_BUILD} bin/ospd-policy-feed cmd/feed-preparer/main.go
+	 ${GO_BUILD} bin/ospd-scans cmd/scans/main.go
 
 build:
 	cd .. && DOCKER_BUILDKIT=1 docker build -t greenbone/ospd-openvas-smoketests -f smoketest/Dockerfile . 2>build.log && rm build.log || (cat build.log && false)
@@ -15,4 +31,16 @@ run:
 	docker ${RUN_PARAM} greenbone/ospd-openvas-smoketests
 
 interactive:
-	docker ${RUN_PARAM} -it greenbone/ospd-openvas-smoketests bash
+	docker ${RUN_PARAM} --name ospd-st-ia -it greenbone/ospd-openvas-smoketests bash
+
+update-nasl-image:
+	- docker pull ${NASL} || ( printf "are you logged in ghr.io within docker and an access token `read:packages`?\n" && false )
+
+fetch-nasl: update-nasl-image
+	- docker run -it -v ${MAKEFILE_PATH}:/mnt --rm ${NASL} sh -c 'cp -rv `ls -d /var/lib/openvas/* | sort -r | head -n 1`/vt-data/nasl /mnt/.nasl && chmod -R 777 /mnt/.nasl'
+
+update-data-objects-image:
+	- docker pull ${DATA_OBJECTS} || ( printf "are you logged in ghr.io within docker and an access token `read:packages`?\n" && false )
+
+fetch-scan-configs: update-data-objects-image
+	- docker run -it -v ${MAKEFILE_PATH}:/mnt --rm ${DATA_OBJECTS} sh -c 'install -D -v -m 777 `find /var/lib/gvm/data-objects/gvmd/*/*configs -type d | sort -r | head -n 1`/* -t /mnt/.scan-config'

--- a/smoketest/README.md
+++ b/smoketest/README.md
@@ -3,9 +3,20 @@
 Contains a small subset of functionality tests for ospd-openvas within a controlled environment.
 
 To build and run the tests a Makefile is provided:
+- make build-cmds - creates the go binaries within bin/
+- make fetch-nasl - fetches the newest community feed into `.nasl/`
+- make fetch-scan-configs - fetches the newest scan-configs/policies into `.scan-configs/`
 - make build - builds the image `greenbone/ospd-openvas-smoketests`
 - make run - runs the image `greenbone/ospd-openvas-smoketests`
 - make - builds and run the image `greenbone/ospd-openvas-smoketests`
+
+Unfortunately the community images are not deployed into docker hub yet. 
+
+You have to login within ghcr.io:
+
+```
+echo <your_github_token> | docker login ghcr.io -u <your_github_handle> --password-stdin
+```
 
 To verify your local environment you need to have `go` installed:
 
@@ -14,3 +25,14 @@ OSPD_SOCKET=$PATH_TO_YOUR_OSPD_SOCKET go run cmd/test/main.go
 ```
 
 Be aware that you need to have the nasl files within `./data/plugins` within your feed dir and the notus advisories `./data/notus/advisories` installed in your notus advisory dir.
+
+To run the policy tests you also need to have the dependent scripts installed. To prepare that you can run:
+
+```
+go run cmd/feed-preparer/main.go -p .scan-configs -s .nasl -t /var/lib/openvas/plugins
+```
+
+This will parse the given scan configs and copy the necessary plugins from <path_to_existing_feed> to <path_to_new_target>.
+
+On top of that you need to have a local ssh-server running and populate user credentials via `USERNAME` and `PASSWORD`; otherwise the policy test will fail because they're unable to connect to ssh.
+

--- a/smoketest/cmd/feed-preparer/main.go
+++ b/smoketest/cmd/feed-preparer/main.go
@@ -1,0 +1,48 @@
+/*
+This cmd is
+  parsing the scan-configs,
+  looking within a source dir for nvts with either oid or family
+  to copy them to a target dir.
+
+It is mainly used to prevent an unnecessarily large feed within the smoketest image when testing the policies.
+*/
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/greenbone/ospd-openvas/smoketest/feed"
+	"github.com/greenbone/ospd-openvas/smoketest/nasl"
+	"github.com/greenbone/ospd-openvas/smoketest/policies"
+)
+
+func main() {
+	source := flag.String("s", "/var/lib/openvas/plugins", "A path to existing plugins to copy from.")
+	target := flag.String("t", "", "A path to prepare the new plugins layout.")
+	policy := flag.String("p", "", "Path to scan-configs / plugins.")
+	flag.Parse()
+	if *source == "" || *target == "" || *policy == "" {
+		flag.Usage()
+		return
+	}
+	fmt.Print("Initializing caches")
+	naslCache, err := nasl.InitCache(*source)
+	if err != nil {
+		panic(err)
+	}
+	policyCache, err := policies.InitCache(*policy)
+	if err != nil {
+		panic(err)
+	}
+	policies := policyCache.Get()
+	fmt.Printf(" found %d plugins and %d policies\n", len(naslCache.Get()), len(policies))
+	p := feed.NewPreparer(naslCache, policyCache, *source, *target)
+	fmt.Printf("Preparing feed structure %s\n", *target)
+	if err := p.Run(); err != nil {
+		panic(err)
+	}
+	p.Wait()
+
+	fmt.Printf("Prepared feed structure %s\n", *target)
+}

--- a/smoketest/cmd/scans/main.go
+++ b/smoketest/cmd/scans/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/greenbone/ospd-openvas/smoketest/connection"
+	"github.com/greenbone/ospd-openvas/smoketest/policies"
+	"github.com/greenbone/ospd-openvas/smoketest/scan"
+)
+
+var address string
+
+const protocoll = "unix"
+
+func init() {
+	address = os.Getenv("OSPD_SOCKET")
+	if address == "" {
+		address = "/var/run/ospd/ospd.sock"
+	}
+}
+
+var DefaultScannerParams = []scan.ScannerParam{
+	{},
+}
+
+func main() {
+
+	policy := flag.String("policy", "", "policy to use for a scan.")
+	policyPath := flag.String("policy-path", "/usr/local/src/policies", "path to policies.")
+	host := flag.String("host", "", "host to scan")
+	oids := flag.String("oid", "", "oid of a plugin to execute")
+	username := flag.String("user", "", "user of host (when using credentials)")
+	password := flag.String("password", "", "password of user (when using credentials)")
+	scan_id := flag.String("id", "", "id of a scan")
+	cmd := flag.String("cmd", "automatic", "get either be start,get,automatic. On automatic the cmd will be selected based on other parameter.")
+	flag.Parse()
+	var ospdCMD interface{}
+	if flag.Parsed() {
+		if *cmd == "automatic" {
+			if *host == "" && *scan_id != "" {
+				*cmd = "get"
+			} else {
+				*cmd = "start"
+			}
+		}
+		switch *cmd {
+		case "get":
+			ospdCMD = scan.GetScans{
+				ID: *scan_id,
+			}
+		case "start":
+			alive := scan.AliveTestMethods{
+				ConsiderAlive: 1,
+			}
+			target := scan.Target{
+				Hosts:            *host,
+				Ports:            "22,80,443,8080",
+				AliveTestMethods: alive,
+			}
+			if *username != "" {
+				credential := scan.Credential{
+					Type:     "up",
+					Service:  "ssh",
+					Username: *username,
+					Password: *password,
+				}
+				target.Credentials = scan.Credentials{
+					Credentials: []scan.Credential{credential},
+				}
+			}
+			var selection scan.VTSelection
+
+			policyCache, err := policies.InitCache(*policyPath)
+			if err != nil {
+				panic(err)
+			}
+			selection = policyCache.ByName(*policy).AsVTSelection()
+			if *oids != "" {
+				selection.Single = append(selection.Single, scan.VTSingle{
+					ID: *oids,
+				})
+			}
+
+			ospdCMD = scan.Start{
+				Targets:       scan.Targets{Targets: []scan.Target{target}},
+				VTSelection:   []scan.VTSelection{selection},
+				ScannerParams: DefaultScannerParams,
+			}
+
+		}
+	}
+	connection.Debug = true
+	b, err := connection.SendRaw(protocoll, address, ospdCMD)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s\n", b)
+}

--- a/smoketest/connection/cmd.go
+++ b/smoketest/connection/cmd.go
@@ -9,37 +9,44 @@ import (
 	"reflect"
 )
 
-const debug = false
+var Debug = false
+
+// SendCommand sends given cmd to OSP (protocol, address) and returns the response
+func SendRaw(protocol, address string, cmd interface{}) ([]byte, error) {
+	c, err := net.Dial(protocol, address)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	b, err := xml.Marshal(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if Debug {
+		fmt.Printf("request: %s\n", b)
+	}
+	n, err := c.Write(b)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(b) {
+		return nil, fmt.Errorf("%d bytes were not send", len(b)-n)
+	}
+	return io.ReadAll(c)
+}
 
 // SendCommand sends given cmd to OSP (protocol, address) and unmarshal the result into v
 func SendCommand(protcol, address string, cmd, v interface{}) error {
 	if reflect.ValueOf(v).Kind() != reflect.Ptr {
 		return errors.New("non-pointer passed to Unmarshal")
 	}
-	c, err := net.Dial(protcol, address)
+	incoming, err := SendRaw(protcol, address, cmd)
 	if err != nil {
 		return err
 	}
-	defer c.Close()
-	b, err := xml.Marshal(cmd)
-	if err != nil {
-		return err
-	}
-	n, err := c.Write(b)
-	if err != nil {
-		return err
-	}
-	if n != len(b) {
-		return fmt.Errorf("%d bytes were not send", len(b)-n)
-	}
-	incoming, err := io.ReadAll(c)
-	if debug {
+	if Debug {
 		fmt.Printf("response: %s\n", incoming)
 	}
-	if err != nil {
-		return err
-	}
-
 	if v == nil {
 		return nil
 	}

--- a/smoketest/data/plugins/slowtest.nasl
+++ b/smoketest/data/plugins/slowtest.nasl
@@ -1,0 +1,46 @@
+if(description)
+{
+  script_oid("0.0.0.0.0.0.0.0.0.2");
+  script_version("2019-11-10T15:30:28+0000");
+  script_name("test");
+  script_category(ACT_SCANNER);
+  script_family("my test family");  
+  script_tag(name:"some", value:"tag");
+  script_tag(name:"last_modification", value:"2019-11-10 15:30:28 +0000 (Tue, 10 Nov 2020)");
+  script_tag(name:"creation_date", value:"2015-03-27 12:00:00 +0100 (Fri, 27 Mar 2015)");
+  script_tag(name:"cvss_base", value:"0.0");
+  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
+  script_tag(name:"qod_type", value:"remote_app");
+  script_tag(name:"qod", value:"0");
+
+  script_version("2021-08-19T02:25:52+0000");
+  script_cve_id("CVE-0000-0000", "CVE-0000-0001");
+  script_tag(name:"severity_vector", value:"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+  script_tag(name:"severity_origin", value:"NVD");
+  script_tag(name:"severity_date", value:"2020-08-07 19:36:00 +0000 (Fri, 07 Aug 2020)");
+  script_xref(name:"Example", value:"GB-Test-1");
+  script_xref(name:"URL", value:"https://www.greenbone.net");
+
+
+  script_add_preference(name:"example", type:"entry", value:"a default string value");
+
+  script_tag(name:"vuldetect", value:"Describes what this plugin is doing to detect a vulnerability.");
+
+  script_tag(name:"summary", value:"A short description of the problem");
+  script_tag(name:"insight", value:"Some detailed insights of the problem");
+  script_tag(name:"impact", value:"Some detailed about what is impacted");
+
+  script_tag(name:"affected", value:"Affected programs, operation system, ...");
+
+  script_tag(name:"solution", value:"Solution description");
+  script_tag(name:"solution_type", value:"Type of solution (e.g. mitigation, vendor fix)");
+  script_tag(name:"solution_method", value:"how to solve it (e.g. debian apt upgrade)");
+  script_tag(name:"qod_type", value:"package");
+  exit(0);
+}
+
+log_message(data: "before sleep");
+sleep(60);
+log_message(data: "after sleep");
+
+exit(0);

--- a/smoketest/feed/preparer.go
+++ b/smoketest/feed/preparer.go
@@ -1,0 +1,154 @@
+package feed
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/greenbone/ospd-openvas/smoketest/file"
+	"github.com/greenbone/ospd-openvas/smoketest/nasl"
+	"github.com/greenbone/ospd-openvas/smoketest/policies"
+	"github.com/greenbone/ospd-openvas/smoketest/scan"
+)
+
+const familyPrefixLen int = len("family = \"")
+
+func copyFile(source, target, fpath string) (int64, error) {
+	npath := strings.Replace(fpath, source, target, 1)
+	bdir := filepath.Dir(npath)
+	if _, err := os.Stat(bdir); errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(bdir, 0740); err != nil {
+			return 0, err
+		}
+	}
+	fin, err := file.Retry(fpath, os.Open)
+	if err != nil {
+		return 0, err
+	}
+	fout, err := file.Retry(npath, os.Create)
+	if err != nil {
+		fin.Close()
+		return 0, err
+	}
+	blen, err := io.Copy(fout, fin)
+	fin.Close()
+	fout.Close()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to copy %s into %s: %s\n", fpath, npath, err)
+		if err := os.Remove(npath); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to remove %s: %s\n", npath, err)
+		}
+	}
+	return blen, err
+
+}
+
+type preparer struct {
+	wg          sync.WaitGroup
+	naslCache   *nasl.Cache
+	policyCache *policies.Cache
+	feedsource  string
+	feedtarget  string
+}
+
+func NewPreparer(naslCache *nasl.Cache, policyCache *policies.Cache, source, target string) *preparer {
+	return &preparer{
+		naslCache:   naslCache,
+		policyCache: policyCache,
+		feedsource:  source,
+		feedtarget:  target,
+	}
+}
+
+func (p *preparer) feedInfo() error {
+	fip := filepath.Join(p.feedtarget, "plugin_feed_info.inc")
+	if _, err := os.Stat(p.feedtarget); errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(p.feedtarget, 0740); err != nil {
+			return err
+		}
+	}
+	if _, err := os.Stat(fip); errors.Is(err, os.ErrNotExist) {
+		fout, err := os.Create(fip)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(fout, "PLUGIN_SET = \"%d\"\n", time.Now().UnixMilli())
+		fmt.Fprintf(fout, "PLUGIN_FEED = \"%s\"\n", "Policy Plugins Only")
+		fmt.Fprintf(fout, "FEED_VENDOR = \"%s\"\n", "Greenbone Networks GmbH")
+		fmt.Fprintf(fout, "FEED_HOME = \"%s\"\n", "N/A")
+		fmt.Fprintf(fout, "FEED_NAME = \"%s\"\n", "PPO")
+		fout.Close()
+
+	}
+	return nil
+}
+
+func (p *preparer) copyPlugin(n *nasl.Plugin) error {
+
+	if _, err := copyFile(p.feedsource, p.feedtarget, n.Path); err != nil {
+		return err
+	}
+	for _, inc := range n.Plugins {
+
+		if _, err := copyFile(p.feedsource, p.feedtarget, inc); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+func (p *preparer) Run() error {
+	policies := p.policyCache.Get()
+	if err := p.feedInfo(); err != nil {
+		return err
+	}
+	for _, policy := range policies {
+		s := policy.AsVTSelection()
+		p.wg.Add(1)
+		go func(s []scan.VTSingle) {
+			defer p.wg.Done()
+			for _, i := range s {
+				p.wg.Add(1)
+				go func(oid string) {
+					defer p.wg.Done()
+					if n := p.naslCache.ByOID(oid); n != nil {
+						if err := p.copyPlugin(n); err != nil {
+							fmt.Fprintf(os.Stderr, "Unable to copy %s: %s\n", n.OID, err)
+						}
+					} else {
+						fmt.Fprintf(os.Stderr, "%s not found\n", oid)
+					}
+
+				}(i.ID)
+			}
+
+		}(s.Single)
+		p.wg.Add(1)
+		go func(g []scan.VTGroup) {
+			defer p.wg.Done()
+			for _, i := range g {
+				p.wg.Add(1)
+				go func(filter string) {
+					defer p.wg.Done()
+					fam := strings.ToLower(filter[familyPrefixLen : len(filter)-1])
+					for _, j := range p.naslCache.ByFamily(fam) {
+						if err := p.copyPlugin(j); err != nil {
+							fmt.Fprintf(os.Stderr, "Unable to copy %s: %s\n", j.OID, err)
+						}
+					}
+				}(i.Filter)
+			}
+		}(s.Group)
+	}
+	return nil
+}
+
+func (p *preparer) Wait() {
+	p.wg.Wait()
+}

--- a/smoketest/file/walker.go
+++ b/smoketest/file/walker.go
@@ -1,0 +1,64 @@
+package file
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Walker struct {
+	Suffix  string
+	Handler func(*os.File) error
+	wg      sync.WaitGroup
+}
+
+func (fw *Walker) Wait() {
+	fw.wg.Wait()
+}
+
+func Retry(path string, fo func(string) (*os.File, error)) (*os.File, error) {
+
+open:
+	f, err := fo(path)
+	if pe, ok := err.(*fs.PathError); ok {
+		if pe.Err.Error() == "too many open files" {
+			// wait for a bit and retry
+			time.Sleep(1 * time.Second)
+			goto open
+		}
+	}
+	return f, err
+}
+
+func (fw *Walker) Walk(p string, i os.FileInfo, e error) error {
+	if e != nil {
+		if pe, ok := e.(*fs.PathError); i.IsDir() && ok {
+			if pe.Err.Error() == "too many open files" {
+				// wait for a bit and retry
+				time.Sleep(1 * time.Second)
+				return filepath.Walk(p, fw.Walk)
+			}
+		}
+		panic(e)
+	}
+	if !i.IsDir() && strings.HasSuffix(p, fw.Suffix) {
+		fw.wg.Add(1)
+		go func(path string) {
+			defer fw.wg.Done()
+
+			f, err := Retry(path, os.Open)
+			if err != nil {
+				panic(err)
+			}
+			if err := fw.Handler(f); err != nil {
+				panic(err)
+			}
+			f.Close()
+		}(p)
+
+	}
+	return nil
+}

--- a/smoketest/go.mod
+++ b/smoketest/go.mod
@@ -1,3 +1,3 @@
 module github.com/greenbone/ospd-openvas/smoketest
 
-go 1.16
+go 1.18

--- a/smoketest/nasl/cache.go
+++ b/smoketest/nasl/cache.go
@@ -14,6 +14,7 @@ type Cache struct {
 	plugins  []Plugin
 	byOID    map[string]*Plugin
 	byFamily map[string][]*Plugin
+	byPath   map[string]*Plugin
 }
 
 func NewCache() *Cache {
@@ -21,6 +22,7 @@ func NewCache() *Cache {
 		plugins:  make([]Plugin, 0),
 		byOID:    make(map[string]*Plugin),
 		byFamily: make(map[string][]*Plugin),
+		byPath:   make(map[string]*Plugin),
 	}
 }
 
@@ -32,6 +34,7 @@ func (c *Cache) Append(p Plugin) {
 	// have to track of the original
 	ptr := &c.plugins[len(c.plugins)-1]
 	c.byOID[p.OID] = ptr
+	c.byPath[p.Path] = ptr
 	fam := strings.ToLower(p.Family)
 	if f, ok := c.byFamily[fam]; ok {
 		c.byFamily[fam] = append(f, ptr)
@@ -52,6 +55,15 @@ func (c *Cache) ByOID(oid string) *Plugin {
 	c.RLock()
 	defer c.RUnlock()
 	if r, ok := c.byOID[oid]; ok {
+		return r
+	}
+	return nil
+}
+
+func (c *Cache) ByPath(path string) *Plugin {
+	c.RLock()
+	defer c.RUnlock()
+	if r, ok := c.byPath[path]; ok {
 		return r
 	}
 	return nil

--- a/smoketest/nasl/cache.go
+++ b/smoketest/nasl/cache.go
@@ -1,0 +1,101 @@
+package nasl
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/greenbone/ospd-openvas/smoketest/file"
+)
+
+type Cache struct {
+	sync.RWMutex
+	plugins  []Plugin
+	byOID    map[string]*Plugin
+	byFamily map[string][]*Plugin
+}
+
+func NewCache() *Cache {
+	return &Cache{
+		plugins:  make([]Plugin, 0),
+		byOID:    make(map[string]*Plugin),
+		byFamily: make(map[string][]*Plugin),
+	}
+}
+
+func (c *Cache) Append(p Plugin) {
+	c.Lock()
+	c.plugins = append(c.plugins, p)
+	// point to the copy of c.plugins instead of given instance
+	// to make it a bit easier for the garbage collector to not
+	// have to track of the original
+	ptr := &c.plugins[len(c.plugins)-1]
+	c.byOID[p.OID] = ptr
+	fam := strings.ToLower(p.Family)
+	if f, ok := c.byFamily[fam]; ok {
+		c.byFamily[fam] = append(f, ptr)
+	} else {
+		c.byFamily[fam] = []*Plugin{ptr}
+	}
+	// not using defer to speed things up
+	c.Unlock()
+}
+
+func (c *Cache) Get() []Plugin {
+	c.RLock()
+	defer c.RUnlock()
+	return c.plugins
+}
+
+func (c *Cache) ByOID(oid string) *Plugin {
+	c.RLock()
+	defer c.RUnlock()
+	if r, ok := c.byOID[oid]; ok {
+		return r
+	}
+	return nil
+}
+
+func (c *Cache) ByFamily(family string) []*Plugin {
+	c.RLock()
+	defer c.RUnlock()
+	if r, ok := c.byFamily[family]; ok {
+		return r
+	}
+	return []*Plugin{}
+}
+
+type CacheFileWalkerHandler struct {
+	cache  *Cache
+	source string
+}
+
+func (fwh *CacheFileWalkerHandler) fh(f *os.File) error {
+	p := Parse(fwh.source, f.Name(), f)
+	f.Close()
+	fwh.cache.Append(p)
+	return nil
+}
+
+func NewCacheFileWalker(source string, c *Cache) *file.Walker {
+	fwh := &CacheFileWalkerHandler{
+		source: source,
+		cache:  c,
+	}
+	return &file.Walker{
+		Handler: fwh.fh,
+		Suffix:  ".nasl",
+	}
+}
+
+func InitCache(source string) (cache *Cache, err error) {
+	cache = NewCache()
+	fw := NewCacheFileWalker(source, cache)
+	err = filepath.Walk(source, fw.Walk)
+	if err != nil {
+		return
+	}
+	fw.Wait()
+	return
+}

--- a/smoketest/nasl/parser.go
+++ b/smoketest/nasl/parser.go
@@ -1,0 +1,284 @@
+package nasl
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type Plugin struct {
+	Path    string
+	OID     string
+	Family  string
+	Plugins []string
+}
+
+type Token int
+
+const (
+	UNKNOWN Token = iota
+	EOF
+	WS      //  \t\n
+	QT      // "'
+	LP      // (
+	RP      // )
+	LB      // [
+	RB      // ]
+	CLB     // {
+	CRB     // }
+	C       // ,
+	SC      // ;
+	DP      // :
+	KEYWORD //keyword are non special character
+)
+
+var eof = rune(0)
+
+func isWhitespace(ch rune) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n'
+}
+
+func isKeywordComp(ch rune) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '-' || ch == '_'
+}
+
+type Scanner struct {
+	r *bufio.Reader
+}
+
+func NewScanner(r io.Reader) *Scanner {
+	return &Scanner{r: bufio.NewReader(r)}
+}
+
+func (s *Scanner) read() rune {
+	ch, _, err := s.r.ReadRune()
+	if err != nil {
+		return eof
+	}
+	return ch
+}
+
+func (s *Scanner) unread() { _ = s.r.UnreadRune() }
+
+func (s *Scanner) skip(result Token, verify func(rune) bool) (Token, string) {
+	var buf bytes.Buffer
+	buf.WriteRune(s.read())
+	for {
+		if ch := s.read(); ch == eof {
+			break
+		} else if !verify(ch) {
+			s.unread()
+			break
+		} else {
+			buf.WriteRune(ch)
+		}
+	}
+	return result, buf.String()
+}
+
+func (s *Scanner) skipWS() (Token, string) {
+	return s.skip(WS, isWhitespace)
+}
+
+func (s *Scanner) skipNonSpecial() (Token, string) {
+	return s.skip(KEYWORD, isKeywordComp)
+}
+
+func (s *Scanner) Scan() (Token, string) {
+	ch := s.read()
+	if isWhitespace(ch) {
+		s.unread()
+		return s.skip(WS, isWhitespace)
+	}
+	if isKeywordComp(ch) {
+		s.unread()
+		return s.skip(KEYWORD, isKeywordComp)
+	}
+	switch ch {
+	case eof:
+		return EOF, ""
+	case '\'':
+		return QT, string(ch)
+	case '"':
+		return QT, string(ch)
+	case '(':
+		return LP, string(ch)
+	case ')':
+		return RP, string(ch)
+	case '[':
+		return LB, string(ch)
+	case ']':
+		return RB, string(ch)
+	case '{':
+		return CLB, string(ch)
+	case '}':
+		return CRB, string(ch)
+	case ',':
+		return C, string(ch)
+	case ';':
+		return SC, string(ch)
+	case ':':
+		return DP, string(ch)
+
+	default:
+		return UNKNOWN, string(ch)
+	}
+
+}
+
+func skipWS(scanner *Scanner) (t Token, s string) {
+	for {
+		t, s = scanner.Scan()
+		if t != WS {
+			return
+		}
+	}
+}
+
+type PluginCache struct {
+	sync.RWMutex
+	plugins []string
+}
+
+func (pc *PluginCache) Append(s ...string) {
+	pc.Lock()
+	pc.plugins = append(pc.plugins, s...)
+	pc.Unlock()
+}
+
+func (pc *PluginCache) Get() []string {
+	pc.RLock()
+	result := pc.plugins
+	pc.RUnlock()
+	return result
+}
+
+func StringArgument(scanner *Scanner) (string, bool) {
+	var buf bytes.Buffer
+	t, i := skipWS(scanner)
+	if t == QT {
+
+		for {
+			t, i = scanner.Scan()
+			if t == EOF {
+				break
+			}
+
+			if t == QT {
+				return buf.String(), true
+			}
+
+			buf.WriteString(i)
+		}
+	}
+	return "", false
+}
+
+func singleAnonStringArgumentFunction(scanner *Scanner) (string, bool) {
+	t, _ := skipWS(scanner)
+	if t == LP {
+		if arg, ok := StringArgument(scanner); ok {
+			t, _ = skipWS(scanner)
+			if t == RP {
+				t, _ = skipWS(scanner)
+				if t == SC {
+					return arg, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+func multipleAnonStringArgumentFunction(scanner *Scanner) ([]string, bool) {
+	result := make([]string, 0)
+	t, _ := skipWS(scanner)
+	if t == LP {
+		for {
+			if arg, ok := StringArgument(scanner); ok {
+				t, _ = skipWS(scanner)
+				if t == RP {
+					t, _ = skipWS(scanner)
+					if t == SC {
+						result = append(result, arg)
+						return result, true
+					}
+				}
+				if t == C {
+					result = append(result, arg)
+					continue
+				}
+				if t != C || t == EOF {
+					break
+				}
+			} else {
+				break
+			}
+		}
+	}
+	return result, false
+}
+
+func Parse(source, path string, input io.Reader) Plugin {
+	// We currently assume that each nasl script has a
+	// if (description) { }
+	// block so that we don't have to care about && ||
+	// As of 2022-06-03 there are no cases where script_oid or script_family contain anything but a string
+	// to make things easier we just asssume that so tat we don't have to do a loopup for a variable
+	oid := ""
+	family := ""
+	plugins := make([]string, 0)
+	scanner := NewScanner(input)
+	appendPluginPath := func(arg string) {
+
+		ip := filepath.Join(source, arg)
+		plugins = append(plugins, ip)
+	}
+	for {
+		t, i := scanner.Scan()
+		if t == EOF {
+			break
+		}
+		if t == KEYWORD {
+			switch i {
+			case "script_oid":
+				if arg, ok := singleAnonStringArgumentFunction(scanner); ok {
+					// TODO check if already parsed via cache and return
+					oid = arg
+				}
+			case "script_family":
+				if arg, ok := singleAnonStringArgumentFunction(scanner); ok {
+					family = arg
+				}
+			case "script_dependencies":
+				// TODO on nasl we actually need to parse them again
+				if args, ok := multipleAnonStringArgumentFunction(scanner); ok {
+					for _, i := range args {
+						// there are some instances that call script_dependencies("a.nasl, b.nasl");
+						// instead of script_dependencies("a.nasl", "b.nasl");
+						split := strings.Split(i, ",")
+						for _, j := range split {
+							appendPluginPath(strings.Trim(j, " "))
+						}
+					}
+				}
+			case "include":
+				if arg, ok := singleAnonStringArgumentFunction(scanner); ok {
+					appendPluginPath(arg)
+				}
+			}
+
+		}
+
+	}
+	return Plugin{
+		Path:    path,
+		OID:     oid,
+		Family:  family,
+		Plugins: plugins,
+	}
+
+}

--- a/smoketest/policies/cache.go
+++ b/smoketest/policies/cache.go
@@ -1,0 +1,84 @@
+package policies
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/greenbone/ospd-openvas/smoketest/file"
+)
+
+type Cache struct {
+	cache map[string]ScanConfig
+	sync.RWMutex
+}
+
+func (c *Cache) Append(s ScanConfig) {
+	c.Lock()
+	c.cache[s.Name] = s
+	c.Unlock()
+}
+
+func (c *Cache) Get() []ScanConfig {
+	c.RLock()
+	defer c.RUnlock()
+	i := 0
+	r := make([]ScanConfig, len(c.cache))
+	for _, v := range c.cache {
+		r[i] = v
+		i++
+	}
+	return r
+}
+
+func (c *Cache) ByName(name string) ScanConfig {
+	c.RLock()
+	defer c.RUnlock()
+	if s, ok := c.cache[name]; ok {
+		return s
+	}
+	return ScanConfig{}
+}
+
+func NewCache() *Cache {
+	return &Cache{
+		cache: make(map[string]ScanConfig),
+	}
+}
+
+type FileWalkerHandler struct {
+	cache *Cache
+}
+
+func (fw *FileWalkerHandler) fh(f *os.File) error {
+	d := xml.NewDecoder(f)
+	var sp ScanConfig
+	if err := d.Decode(&sp); err != nil {
+		return err
+	}
+	f.Close()
+	fw.cache.Append(sp)
+	return nil
+}
+
+func NewFileWalker(cache *Cache) *file.Walker {
+	h := &FileWalkerHandler{
+		cache: cache,
+	}
+	return &file.Walker{
+		Handler: h.fh,
+		Suffix:  ".xml",
+	}
+}
+
+func InitCache(source string) (cache *Cache, err error) {
+	cache = NewCache()
+	fw := NewFileWalker(cache)
+	err = filepath.Walk(source, fw.Walk)
+	if err != nil {
+		return
+	}
+	fw.Wait()
+	return
+}

--- a/smoketest/policies/init.go
+++ b/smoketest/policies/init.go
@@ -1,0 +1,59 @@
+package policies
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/greenbone/ospd-openvas/smoketest/scan"
+)
+
+type NVTSelector struct {
+	Include int    `xml:"include"`
+	Type    int    `xml:"type"` // 0 = Disabled, 1 = Family, 2 = NVT
+	Filter  string `xml:"family_or_nvt"`
+}
+
+type NVTSelectors struct {
+	XMLName   xml.Name      `xml:"nvt_selectors"`
+	Selectors []NVTSelector `xml:"nvt_selector"`
+}
+
+func (s NVTSelector) AsScanSelector() (group *scan.VTGroup, single *scan.VTSingle) {
+	if s.Type == 1 {
+		group = &scan.VTGroup{
+			Filter: fmt.Sprintf("family = \"%s\"", s.Filter),
+		}
+	}
+	if s.Type == 2 {
+		single = &scan.VTSingle{
+			ID: s.Filter,
+		}
+	}
+	return
+}
+
+type ScanConfig struct {
+	XMLName   xml.Name `xml:"config"`
+	ID        string   `xml:"id,attr"`
+	Name      string   `xml:"name"`
+	Comment   string   `xml:"comment"`
+	Type      int      `xml:"type"`       // no function since we just are a ospd scanner
+	Usage     string   `xml:"usage_type"` // no function, we don't differntiate between policy and scan
+	Selectors NVTSelectors
+}
+
+func (c ScanConfig) AsVTSelection() scan.VTSelection {
+	selection := scan.VTSelection{
+		Single: make([]scan.VTSingle, 0),
+		Group:  make([]scan.VTGroup, 0),
+	}
+	for _, sel := range c.Selectors.Selectors {
+		if g, s := sel.AsScanSelector(); s != nil {
+			selection.Single = append(selection.Single, *s)
+		} else if g != nil {
+			selection.Group = append(selection.Group, *g)
+		}
+
+	}
+	return selection
+}

--- a/smoketest/run-tests.sh
+++ b/smoketest/run-tests.sh
@@ -4,6 +4,7 @@
 shutdown() {
   kill $(cat /var/run/ospd/ospd.pid) || true
   kill $(cat /tmp/mosquitto.pid) || true
+  kill $(grep -o "Pidfile.*" /etc/ssh/sshd_config | awk '{printf $2}') || true
   redis-cli -s /var/run/redis/redis.sock SHUTDOWN
 }
 
@@ -12,6 +13,7 @@ trap shutdown EXIT
 set -e
 mosquitto -c /etc/mosquitto.conf &
 redis-server /etc/redis/redis.conf
+/usr/sbin/sshd
 ospd-openvas --disable-notus-hashsum-verification True \
   -u /var/run/ospd/ospd.sock \
   -l /var/log/gvm/ospd.log

--- a/smoketest/scan/init.go
+++ b/smoketest/scan/init.go
@@ -9,6 +9,14 @@ type ScannerParam struct {
 	TableDrivenLSC string `xml:"table_driven_lsc,omitempty"`
 }
 
+var DefaultScannerParams = []ScannerParam{
+	{},
+}
+
+var DisableNotus = []ScannerParam{
+	{TableDrivenLSC: "0"},
+}
+
 type VTValue struct {
 	ID    string `xml:"id,attr,omitempty"`
 	Value string `xml:",chardata"`
@@ -32,8 +40,13 @@ type Credential struct {
 	Type     string `xml:"type,attr,omitempty"`
 	Service  string `xml:"service,attr,omitempty"`
 	Port     string `xml:"port,attr,omitempty"`
-	Username string `xml:"username,attr,omitempty"`
-	Password string `xml:"password,attr,omitempty"`
+	Username string `xml:"username,omitempty"`
+	Password string `xml:"password,omitempty"`
+}
+
+type Credentials struct {
+	XMLName     xml.Name     `xml:"credentials"`
+	Credentials []Credential `xml:"credential"`
 }
 
 type AliveTestMethods struct {
@@ -44,11 +57,15 @@ type AliveTestMethods struct {
 	ConsiderAlive int `xml:"consider_alive,omitempty"`
 }
 
+var ConsiderAlive AliveTestMethods = AliveTestMethods{
+	ConsiderAlive: 1,
+}
+
 type Target struct {
 	XMLName            xml.Name         `xml:"target"`
 	Hosts              string           `xml:"hosts,omitempty"`
 	Ports              string           `xml:"ports,omitempty"`
-	Credentials        Credential       `xml:"credentials,omitempty"`
+	Credentials        Credentials      `xml:"credentials,omitempty"`
 	ExcludedHosts      string           `xml:"excluded_hosts,omitempty"`
 	FinishedHosts      string           `xml:"finished_hosts,omitempty"`
 	AliveTestPorts     string           `xml:"alive_test_ports,omitempty"`

--- a/smoketest/usecases/policy/init.go
+++ b/smoketest/usecases/policy/init.go
@@ -1,0 +1,72 @@
+package policy
+
+import (
+	"fmt"
+
+	"github.com/greenbone/ospd-openvas/smoketest/policies"
+	"github.com/greenbone/ospd-openvas/smoketest/scan"
+	uc "github.com/greenbone/ospd-openvas/smoketest/usecases"
+)
+
+func discoveryAuthenticated(cache *policies.Cache, username, password string) uc.Test {
+	return uc.Test{
+		Title: "Discovery - enable authenticated checks",
+		Run: func(proto string, address string) uc.Response {
+			pol := "Discovery"
+			sc := cache.ByName(pol)
+			selection := sc.AsVTSelection()
+			if len(selection.Single) == 0 && len(selection.Group) == 0 {
+				return uc.Response{
+					Success:     false,
+					Description: fmt.Sprintf("Config %s not found\n", pol),
+				}
+			}
+
+			credential := scan.Credential{
+				Type:     "up",
+				Service:  "ssh",
+				Username: username,
+				Password: password,
+			}
+			target := scan.Target{
+				Hosts:            "localhost",
+				Ports:            "22",
+				AliveTestMethods: scan.ConsiderAlive,
+				Credentials:      scan.Credentials{Credentials: []scan.Credential{credential}},
+			}
+
+			ospdCMD := scan.Start{
+				Targets:       scan.Targets{Targets: []scan.Target{target}},
+				VTSelection:   []scan.VTSelection{selection},
+				ScannerParams: scan.DisableNotus,
+			}
+			r := uc.StartScanGetLastStatus(ospdCMD, proto, address)
+			if r.Failure != nil {
+				return *r.Failure
+			}
+			ssh_success_msg := "It was possible to login using the provided SSH credentials. Hence authenticated checks are enabled.\n"
+
+			for _, rs := range r.Resp.Scan.Results.Results {
+				if rs.Value == ssh_success_msg {
+					return uc.Response{
+						Success:     true,
+						Description: "ssh login with given credentials was successful.",
+					}
+				}
+			}
+
+			return uc.Response{
+				Success:     false,
+				Description: "failed to find ssh success message",
+			}
+		},
+	}
+}
+func Create(cache *policies.Cache, username, password string) uc.Tests {
+	return uc.Tests{
+		Title: "Policy/Scan-Config",
+		UseCases: []uc.Test{
+			discoveryAuthenticated(cache, username, password),
+		},
+	}
+}

--- a/smoketest/usecases/scan/init.go
+++ b/smoketest/usecases/scan/init.go
@@ -8,19 +8,11 @@ import (
 	"github.com/greenbone/ospd-openvas/smoketest/usecases"
 )
 
-var DefaultScannerParams = []scan.ScannerParam{
-	{TableDrivenLSC: "0"},
-}
-
-var DefaultAlive = scan.AliveTestMethods{
-	ConsiderAlive: 1,
-}
-
 var DefaultTargets = scan.Targets{Targets: []scan.Target{
 	{
 		Hosts:            "localhost,smoketest.localdomain,smoke.localdomain,and.localdomain,mirrors.localdomain",
 		Ports:            "8080,443",
-		AliveTestMethods: DefaultAlive,
+		AliveTestMethods: scan.ConsiderAlive,
 	},
 },
 }
@@ -31,99 +23,9 @@ var DefaultSelection = []scan.VTSelection{
 	}}},
 }
 var DefaultStart = scan.Start{
-	ScannerParams: DefaultScannerParams,
+	ScannerParams: scan.DisableNotus,
 	Targets:       DefaultTargets,
 	VTSelection:   DefaultSelection,
-}
-
-func ScanStatusFinished(status string) bool {
-	switch status {
-	case "interrupted", "finished", "stopped", "failed":
-		return true
-	default:
-		return false
-	}
-}
-
-type getScanResponseFailure struct {
-	resp    scan.GetScansResponse
-	failure *usecases.Response
-}
-
-func WrongScanStatus(expected, got string) *usecases.Response {
-	return &usecases.Response{
-		Success:     false,
-		Description: fmt.Sprintf("Expected %s but got %s as a Scan.Status", expected, got),
-	}
-
-}
-
-func VerifyGet(get scan.GetScans, proto, address, status string) getScanResponseFailure {
-	var result getScanResponseFailure
-	if err := connection.SendCommand(proto, address, get, &result.resp); err != nil {
-		panic(err)
-	}
-	if result.resp.Code != "200" {
-		result.failure = WrongStatusCodeResponse(result.resp.StatusCodeResponse)
-		return result
-	}
-	if result.resp.Scan.Status != status {
-		result.failure = WrongScanStatus(status, result.resp.Scan.Status)
-	}
-	return result
-}
-
-func VerifyTillNextState(get scan.GetScans, proto, address, status string) getScanResponseFailure {
-	if r := VerifyGet(get, proto, address, status); r.failure != nil {
-		return r
-	}
-	return TillNextState(get, proto, address, status)
-
-}
-
-func TillNextState(get scan.GetScans, proto, address, status string) getScanResponseFailure {
-	var result getScanResponseFailure
-	result.resp.Scan.Status = status
-	for result.resp.Scan.Status == status {
-		result.resp = scan.GetScansResponse{}
-		if err := connection.SendCommand(proto, address, get, &result.resp); err != nil {
-			panic(err)
-		}
-		if result.resp.Code != "200" {
-			result.failure = WrongStatusCodeResponse(result.resp.StatusCodeResponse)
-			break
-		}
-	}
-
-	return result
-}
-
-func StartScanGetLastStatus(start scan.Start, proto, address string) getScanResponseFailure {
-	var result getScanResponseFailure
-	var startR scan.StartResponse
-
-	if err := connection.SendCommand(proto, address, start, &startR); err != nil {
-		panic(err)
-	}
-	if startR.Code != "200" {
-		result.failure = WrongStatusCodeResponse(startR.StatusCodeResponse)
-		return result
-	}
-	get := scan.GetScans{ID: startR.ID}
-
-	for !ScanStatusFinished(result.resp.Scan.Status) {
-		// reset to not contain previous results
-		result.resp = scan.GetScansResponse{}
-		if err := connection.SendCommand(proto, address, get, &result.resp); err != nil {
-			panic(err)
-		}
-		if result.resp.Code != "200" {
-			result.failure = WrongStatusCodeResponse(result.resp.StatusCodeResponse)
-			return result
-		}
-	}
-	return result
-
 }
 
 func transitionQueueToRunning() usecases.Test {
@@ -135,47 +37,47 @@ func transitionQueueToRunning() usecases.Test {
 				panic(err)
 			}
 			if startR.Code != "200" {
-				return *WrongStatusCodeResponse(startR.StatusCodeResponse)
+				return *usecases.WrongStatusCodeResponse(startR.StatusCodeResponse)
 			}
 			get := scan.GetScans{ID: startR.ID}
 
-			if r := VerifyTillNextState(get, proto, address, "queued"); r.failure == nil {
-				if r.resp.Scan.Status != "init" {
-					return *WrongScanStatus("init", r.resp.Scan.Status)
+			if r := usecases.VerifyTillNextState(get, proto, address, "queued"); r.Failure == nil {
+				if r.Resp.Scan.Status != "init" {
+					return *usecases.WrongScanStatus("init", r.Resp.Scan.Status)
 				}
-				r = TillNextState(get, proto, address, "init")
-				if r.failure != nil {
-					return *r.failure
+				r = usecases.TillNextState(get, proto, address, "init")
+				if r.Failure != nil {
+					return *r.Failure
 				}
-				if r.resp.Scan.Status != "running" {
-					return *WrongScanStatus("running", r.resp.Scan.Status)
+				if r.Resp.Scan.Status != "running" {
+					return *usecases.WrongScanStatus("running", r.Resp.Scan.Status)
 				}
 				var stopR scan.StopResponse
 				if err := connection.SendCommand(proto, address, scan.Stop{ID: get.ID}, &stopR); err != nil {
 					panic(err)
 				}
 				if stopR.Code != "200" {
-					return *WrongStatusCodeResponse(r.resp.StatusCodeResponse)
+					return *usecases.WrongStatusCodeResponse(r.Resp.StatusCodeResponse)
 				}
-				r = VerifyGet(get, proto, address, "stopped")
-				if r.failure != nil {
-					return *r.failure
+				r = usecases.VerifyGet(get, proto, address, "stopped")
+				if r.Failure != nil {
+					return *r.Failure
 				}
 
 				var deleteR scan.DeleteResponse
 				connection.SendCommand(proto, address, scan.Delete{ID: get.ID}, &deleteR)
 				if deleteR.Code != "200" {
-					return *WrongStatusCodeResponse(deleteR.StatusCodeResponse)
+					return *usecases.WrongStatusCodeResponse(deleteR.StatusCodeResponse)
 				}
 
 				resume := DefaultStart
 				resume.ID = get.ID
-				r = StartScanGetLastStatus(resume, proto, address)
-				if r.resp.Scan.Status != "finished" {
-					return *WrongScanStatus("finished", r.resp.Scan.Status)
+				r = usecases.StartScanGetLastStatus(resume, proto, address)
+				if r.Resp.Scan.Status != "finished" {
+					return *usecases.WrongScanStatus("finished", r.Resp.Scan.Status)
 				}
 			} else {
-				return *r.failure
+				return *r.Failure
 			}
 
 			return usecases.Response{
@@ -187,26 +89,19 @@ func transitionQueueToRunning() usecases.Test {
 	}
 }
 
-func WrongStatusCodeResponse(response scan.StatusCodeResponse) *usecases.Response {
-	return &usecases.Response{
-		Success:     false,
-		Description: fmt.Sprintf("Wrong status code(%s): %s", response.Code, response.Text),
-	}
-}
-
 func startScan() usecases.Test {
 	return usecases.Test{
 		Title: "start",
 		Run: func(proto, address string) usecases.Response {
 
-			r := StartScanGetLastStatus(DefaultStart, proto, address)
-			if r.resp.Scan.Status != "finished" {
-				return *WrongScanStatus("finished", r.resp.Scan.Status)
+			r := usecases.StartScanGetLastStatus(DefaultStart, proto, address)
+			if r.Resp.Scan.Status != "finished" {
+				return *usecases.WrongScanStatus("finished", r.Resp.Scan.Status)
 			}
 			return usecases.Response{
-				Success: r.resp.Scan.Status == "finished",
+				Success: r.Resp.Scan.Status == "finished",
 				Description: fmt.Sprintf("Espected status of %s to be finished but was %s",
-					r.resp.Scan.ID, r.resp.Scan.Status),
+					r.Resp.Scan.ID, r.Resp.Scan.Status),
 			}
 
 		},


### PR DESCRIPTION
To be able to test scan-configs smoketest are extended to parse nasl
files for oid, family and includes.

In extension it is also parsing scan-configs.

For feed preparation there is a new cmd `feed-preparer` which parses
scan-configs and nasl files to lookup the needed files for the
given policies and copies them into a target folder.

The actual test case in `policy/init.go` does start the policy
`Discovery` and verify if authenticated is enabled afterwards.