### PR TITLE
Refactor instead of setting filter to family load oids

### DIFF
--- a/smoketest/feed/preparer.go
+++ b/smoketest/feed/preparer.go
@@ -168,7 +168,7 @@ func (p *preparer) Run() error {
 		return err
 	}
 	for _, policy := range policies {
-		s := policy.AsVTSelection()
+		s := policy.AsVTSelection(p.naslCache)
 		p.wg.Add(1)
 		go func(s []scan.VTSingle) {
 			defer p.wg.Done()
@@ -196,9 +196,6 @@ func (p *preparer) Run() error {
 				go func(filter string) {
 					defer p.wg.Done()
 					var fam string
-					if len(filter) > familyPrefixLen {
-						fam = strings.ToLower(filter[familyPrefixLen : len(filter)-1])
-					}
 					for _, j := range p.naslCache.ByFamily(fam) {
 						if err := p.copyPlugin(j); err != nil {
 							fmt.Fprintf(os.Stderr, "Unable to copy %s: %s\n", j.OID, err)

--- a/smoketest/usecases/policy/init.go
+++ b/smoketest/usecases/policy/init.go
@@ -14,7 +14,7 @@ func discoveryAuthenticated(cache *policies.Cache, username, password string) uc
 		Run: func(proto string, address string) uc.Response {
 			pol := "Discovery"
 			sc := cache.ByName(pol)
-			selection := sc.AsVTSelection()
+			selection := sc.AsVTSelection(nil)
 			if len(selection.Single) == 0 && len(selection.Group) == 0 {
 				return uc.Response{
 					Success:     false,


### PR DESCRIPTION
When loading a policy with all families ospd-scans should load all nvts
with a registered family instead of a filter.

In addition scans/main.go got extended to be capable of running multiple
policies and print the progress.