### PR TITLE
Refactor: clean up smoketest/Dockerfile

### DIFF
--- a/smoketest/Dockerfile
+++ b/smoketest/Dockerfile
@@ -5,6 +5,11 @@ FROM ghcr.io/greenbone/vulnerability-tests:community-staging AS nasl
 # use latest version
 RUN mv `ls -d /var/lib/openvas/* | sort -r | head -n 1`/vt-data/nasl /nasl
 
+FROM golang AS binaries
+COPY --chmod=7777 smoketest /usr/local/src
+WORKDIR /usr/local/src
+RUN make build-cmds
+
 FROM greenbone/openvas-scanner:unstable
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
@@ -22,18 +27,9 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     python3-redis \
     python3-gnupg \
     python3-paho-mqtt \
-    make \
-    openssh-server \
-    curl &&\
+    openssh-server &&\
 	apt-get remove --purge --auto-remove -y &&\
 	rm -rf /var/lib/apt/lists/*
-# due to old version in buster
-RUN curl -L https://golang.org/dl/go1.17.2.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
-    rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf /tmp/go.tar.gz &&\
-    rm /tmp/go.tar.gz
-
-
 COPY --chmod=7777 . /usr/local/src/ospd-openvas
 COPY smoketest/redis.conf /etc/redis/redis.conf
 RUN rm -rf /var/lib/openvas/plugins/*
@@ -62,17 +58,12 @@ RUN mkdir -p /var/log/mosquitto/
 RUN chown mosquitto:mosquitto /var/log/mosquitto
 RUN chmod 774 /var/log/mosquitto
 
-WORKDIR /usr/local/src/ospd-openvas/smoketest
-RUN GO="/usr/local/go/bin/go" make build-cmds
-RUN mv bin/* /usr/local/bin/
+COPY --from=binaries /usr/local/src/bin/* /usr/local/bin/
 RUN mv /usr/local/src/ospd-openvas/smoketest/run-tests.sh /usr/local/bin/run
 COPY --from=nasl --chmod=7777 /nasl /usr/local/src/nasl
 COPY --from=data_objects --chmod=7777 /policies /usr/local/src/policies
-RUN ospd-policy-feed -s /usr/local/src/nasl -t /var/lib/openvas/plugins -p /usr/local/src/policies
-RUN rm -rf /usr/local/go
 RUN rm -rf /usr/local/src/ospd-openvas
-#RUN rm -rf /usr/local/src/nasl
-RUN apt-get remove --purge --auto-remove -y curl python3-pip python3-packaging make
+RUN apt-get remove --purge --auto-remove -y python3-pip python3-packaging
 RUN chown -R gvm:redis /var/lib/openvas/plugins/
 RUN mkdir /run/sshd
 # make gvm capable of running sshd


### PR DESCRIPTION
Creating go binaries in a second step instead of using curl to get the
latest go version so that we can benefit from githubs image layer.

Removed the preparation call of the feed since the full-and-fast policy
contains almost all nvts.
