### PR TITLE
Change: add multiprocessing.Lock before writin in ospd/scan

### DIFF
--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -49,8 +49,13 @@ class VtHelper:
         vt_params = custom.pop('vt_params')
         vt_refs = custom.pop('refs')
         name = custom.pop('name')
-        vt_creation_time = custom.pop('creation_date')
-        vt_modification_time = custom.pop('last_modification')
+        vt_creation_time = custom.pop('creation_date', None)
+        vt_modification_time = custom.pop('last_modification', None)
+        if not vt_creation_time or not vt_modification_time:
+            logger.warning(
+                "Unable to get modification_time or creation_time for %s", vt_id
+            )
+            return None
 
         if oids:
             vt_dependencies = list()


### PR DESCRIPTION
When writing into a shared dict we should Lock to prevent data
inconsistency while getting results.

How to test:
start a full and fast scan.