### PR TITLE
Change: before starting ospd-openvas cleanup data-pickle-files

### DIFF
--- a/ospd/main.py
+++ b/ospd/main.py
@@ -149,6 +149,9 @@ def main(
     signal.signal(
         signal.SIGINT, partial(exit_cleanup, args.pid_file, server, daemon)
     )
+    signal.signal(
+        signal.SIGQUIT, partial(exit_cleanup, args.pid_file, server, daemon)
+    )
     if not daemon.check():
         return 1
 


### PR DESCRIPTION
In some circumstances it can happen that the data-pickle files are not
properly removed; for this cases they should be cleaned up before
ospd-openvas starts.
