### PR TITLE
Fix: Use the agreed default directory for notus advisories

### DIFF
--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -186,7 +186,7 @@ class NotusResultHandler:
             timer.start()
 
 
-DEFAULT_NOTUS_FEED_DIR = "/var/lib/openvas/plugins/notus/advisories"
+DEFAULT_NOTUS_FEED_DIR = "/var/lib/notus/advisories"
 
 
 class NotusParser(CliParser):


### PR DESCRIPTION
**What**:

Fix: Use the agreed default directory for notus advisories

**Why**:

The directory should be /var/lib/notus/advisories by default. See https://github.com/greenbone/notus-scanner/pull/229

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
