### PR TITLE
Fix syncing notus files from feed

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -27,8 +27,9 @@ RUN addgroup --gid 1001 --system ospd-openvas && \
 
 RUN mkdir -p /run/ospd && \
     mkdir -p /var/lib/openvas && \
+    mkdir -p /var/lib/notus && \
     chown -R ospd-openvas.ospd-openvas \
-    /run/ospd /var/lib/openvas /etc/openvas /var/log/gvm && \
+    /run/ospd /var/lib/openvas /var/lib/notus /etc/openvas /var/log/gvm && \
     chmod 755 /etc/openvas /var/log/gvm && \
     chmod 644 /etc/openvas/openvas_log.conf && \
     chmod 755 /usr/local/bin/entrypoint


### PR DESCRIPTION
**What**:

Fix syncing notus files from feed

**Why**:

Ensure the docker container has write permissions to /var/lib/notus to
allow to run greenbone-nvt-sync without issues.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
