### PR TITLE
Fix: notus advisories

### DIFF
--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -119,16 +119,18 @@ class Notus:
             cvss = severity.get("cvss_v2", None)
         result["severity_vector"] = cvss
         result["filename"] = path.name
-        bid = advisory.get("bid", [])
-        cve = advisory.get("cve", [])
-        xref = advisory.get("xrefs", [])
+        cves = advisory.get("cves", None)
+        xrefs = advisory.get("xrefs", None)
+        advisory_xref = advisory.get("advisory_xref", "")
         refs = {}
-        if bid:
-            refs['bid'] = bid
-        if cve:
-            refs['cve'] = cve
-        if xref:
-            refs['xref'] = xref
+        refs['url'] = [advisory_xref]
+        advisory_id = advisory.get("advisory_id", None)
+        if cves:
+            refs['cve'] = cves
+        if xrefs:
+            refs['url'] = refs['url'] + xrefs
+        if advisory_id:
+            refs['advisory_id'] = [advisory_id]
 
         result["refs"] = refs
         result["family"] = meta_data.get("family", path.stem)


### PR DESCRIPTION
**What**:
Adjust parsing of notus-advisories
SC-648

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When requesting information of a VT which is handled by notus, some information within the advisory were missing

<!-- Why are these changes necessary? -->

**How**:
Start ospd-openvas and wait until it is initialized. Run the gvm-cli to request a specific VT:
```
gvm-cli --log DEBUG --timeout 3600 --protocol OSP socket --socketpath /path/to/ospd-openvas.sock -X '<get_vts vt_id="1.3.6.1.4.1.25623.1.1.2.2021.2553"/>' --pretty
```
The `<refs>` part including the cves and urls were missing and should be included now.

Before:
```xml
<vt id="1.3.6.1.4.1.25623.1.1.2.2021.2553">
    <name>Huawei EulerOS: Security Advisory for httpd (EulerOS-SA-2021-2553)</name>
    <creation_time>1632812890</creation_time>
    <modification_time>1632812890</modification_time>
    <summary>The remote host is missing an update for the Huawei EulerOS 'httpd' package(s) announced via the EulerOS SA-2021-2553 advisory.</summary>
    <affected>'httpd' package(s) on Huawei EulerOS V2.0SP9(x86_64).</affected>
    <insight>Apache HTTP Server versions 2.4.0 to 2.4.46 [...]</insight>
    <solution type="VendorFix">Please install the updated package(s).</solution>
    <detection qod_type="package">Checks if a vulnerable package version is present on the target host.</detection>
    <severities>
    <severity type="cvss_base_v3">
        <value>CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</value>
        <date>1632812890</date>
    </severity>
    </severities>
    <custom>
    <modification_time>1632812890</modification_time>
    <filename>euleros.notus</filename>
    <family>Huawei EulerOS Local Security Checks</family>
    <category>3</category>
    </custom>
</vt>
```

After:
```xml
<vt id="1.3.6.1.4.1.25623.1.1.2.2021.2553">
    <name>Huawei EulerOS: Security Advisory for httpd (EulerOS-SA-2021-2553)</name>
    <refs>
        <ref id="https://developer.huaweicloud.com/ict/en/site-euleros/euleros/security-advisories/EulerOS-SA-2021-2553" type="url"/>
        <ref id="CVE-2020-35452" type="cve"/>
        <ref id="CVE-2021-26690" type="cve"/>
        <ref id="CVE-2021-26691" type="cve"/>
        <ref id="CVE-2021-30641" type="cve"/>
        <ref id="EulerOS-SA-2021-2553" type="advisory_id"/>
    </refs>
    <creation_time>1632812890</creation_time>
    <modification_time>1632812890</modification_time>
    <summary>The remote host is missing an update for the Huawei EulerOS 'httpd' package(s) announced via the EulerOS-SA-2021-2553 advisory.</summary>
    <affected>'httpd' package(s) on Huawei EulerOS V2.0SP9(x86_64).</affected>
    <insight>Apache HTTP Server versions 2.4.0 to 2.4.46 [...]</insight>
    <solution type="VendorFix">Please install the updated package(s).</solution>
    <detection qod_type="package">Checks if a vulnerable package version is present on the target host.</detection>
    <severities>
    <severity type="cvss_base_v3">
        <value>CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</value>
        <date>1632812890</date>
    </severity>
    </severities>
    <custom>
    <modification_time>1632812890</modification_time>
    <filename>euleros.notus</filename>
    <family>Huawei EulerOS Local Security Checks</family>
    <category>3</category>
    </custom>
</vt>
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
