### PR TITLE
Add: automatically connect to mqtt broker as soon as one is available

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -27,7 +27,6 @@ import copy
 
 from typing import Callable, Optional, Dict, List, Tuple, Iterator, Any
 from datetime import datetime
-from socket import gaierror
 
 from pathlib import Path
 from os import geteuid, environ
@@ -527,24 +526,14 @@ class OSPDopenvas(OSPDaemon):
         notus_handler = NotusResultHandler(self.report_results)
 
         if self._mqtt_broker_address:
-            try:
-                client = MQTTClient(
-                    self._mqtt_broker_address, self._mqtt_broker_port, "ospd"
-                )
-                daemon = MQTTDaemon(client)
-                subscriber = MQTTSubscriber(client)
+            client = MQTTClient(
+                self._mqtt_broker_address, self._mqtt_broker_port, "ospd"
+            )
+            daemon = MQTTDaemon(client)
+            subscriber = MQTTSubscriber(client)
 
-                subscriber.subscribe(
-                    ResultMessage, notus_handler.result_handler
-                )
-                daemon.run()
-            except (ConnectionRefusedError, gaierror, ValueError) as e:
-                logger.error(
-                    "Could not connect to MQTT broker at %s, error was: %s."
-                    " Unable to get results from Notus.",
-                    self._mqtt_broker_address,
-                    e,
-                )
+            subscriber.subscribe(ResultMessage, notus_handler.result_handler)
+            daemon.run()
         else:
             logger.info(
                 "MQTT Broker Adress empty. MQTT disabled. Unable to get Notus"

--- a/ospd_openvas/messaging/mqtt.py
+++ b/ospd_openvas/messaging/mqtt.py
@@ -175,7 +175,10 @@ class MQTTDaemon:
                     e,
                 )
                 return
-            except (ConnectionRefusedError, timeout) as e:
+            # ConnectionRefusedError - when mqtt declines connection
+            # timeout - when address is not reachable
+            # OSError - in container when address cannot be assigned
+            except (ConnectionRefusedError, timeout, OSError) as e:
                 logger.warning(
                     "Could not connect to MQTT broker, error was: %s."
                     " Trying again in 10s.",

--- a/tests/messaging/test_mqtt.py
+++ b/tests/messaging/test_mqtt.py
@@ -98,13 +98,13 @@ class MQTTDaemonTestCase(TestCase):
         # pylint: disable=unused-variable
         daemon = MQTTDaemon(client)
 
-        client.connect.assert_called_with()
-
     def test_run(self):
         client = mock.MagicMock()
 
         daemon = MQTTDaemon(client)
 
         daemon.run()
+
+        client.connect.assert_called_with()
 
         client.loop_start.assert_called_with()


### PR DESCRIPTION
**What**:
In case ospd-openvas was started without a broker running, the connection fails and ospd-openvas prints that notus is unavailable. This patch solves this issue by trying to connect to the broker every 10 seconds in case the last try failed.
SC-651

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Start ospd-openvas without a broker running. See that ospd-openvas connects to the broker within 10 seconds. Start a scan with notus in order to confirm that notus results are delivered.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
