### PR TITLE
Fix: Improve handling of unknown scan ids

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -850,7 +850,12 @@ class OSPDopenvas(OSPDaemon):
             with following fields: result_type, host_ip, host_name, port, oid,
             value, uri (optional)
 
+        Returns:
+            True if the results have been reported
         """
+        if not self.scan_collection.id_exists(scan_id):
+            logger.warning("Unknown scan_id %s", scan_id)
+            return False
 
         vthelper = VtHelper(self.nvti)
 


### PR DESCRIPTION
**What**:

Don't print a traceback if a scan_id is not available. Instead safely
handle this case and log a warning.

The case where notus-scanner issues scan results without having started the scan by ospd-openvas should never happen in the wild but I've just tested notus-scanner with the `notus-scan-start` tool.

`root@f5f919a97dfb:/notus# notus-scan-start -b mqtt-broker --host-ip 1.1.1.1 --host-name foo.bar --os-release "Mageia 2" --packages libsss_autofs-1.8.5-1.mga2.x86_64`

**Why**:

Avoid tracebacks
```
ospd-openvas_1   | Exception in thread Thread-493:                                                                                                                                                                                          
ospd-openvas_1   | Traceback (most recent call last):                                                                                                                                                                                       
ospd-openvas_1   |   File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner                                                                                                                                                  
ospd-openvas_1   |     self.run()                                                                                                                                                                                                           
ospd-openvas_1   |   File "/usr/lib/python3.9/threading.py", line 1266, in run                                                                                                                                                              
ospd-openvas_1   |     self.function(*self.args, **self.kwargs)                                                                                                                                                                             
ospd-openvas_1   |   File "/usr/local/lib/python3.9/dist-packages/ospd_openvas/notus.py", line 166, in _report_results                                                                                                                      
ospd-openvas_1   |     if not self._report_func(results, scan_id):                                                                                                                                                                          
ospd-openvas_1   |   File "/usr/local/lib/python3.9/dist-packages/ospd_openvas/daemon.py", line 981, in report_results                                                                                                                      
ospd-openvas_1   |     self.scan_collection.add_result_list(scan_id, res_list)                                                                                                                                                              
ospd-openvas_1   |   File "/usr/local/lib/python3.9/dist-packages/ospd/scan.py", line 127, in add_result_list                                                                                                                               
ospd-openvas_1   |     results = self.scans_table[scan_id]['results']                                    
ospd-openvas_1   | KeyError: 'fd6ce175-d0ae-422c-9a88-d2b2c491bf10
```
**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] PR merge commit message adjusted
