### PR TITLE
Fix: Stop and clean finished/running openvas process before resumming a scan

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1090,6 +1090,15 @@ class OSPDopenvas(OSPDaemon):
             dryrun.exec_dry_run_scan(scan_id, self.nvti, OSPD_PARAMS)
             return
 
+        kbdb, err = self.main_db.check_consistency(scan_id)
+        if err < 0:
+            logger.debug(
+                "An old scan with the same scanID was found in the kb. "
+                "Waiting for the kb clean up to finish."
+            )
+            self.stop_scan_cleanup(kbdb, scan_id, kbdb.get_scan_process_id())
+            self.main_db.release_database(kbdb)
+
         do_not_launch = False
         kbdb = self.main_db.get_new_kb_database()
         scan_prefs = PreferenceHandler(

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1171,7 +1171,7 @@ class OSPDopenvas(OSPDaemon):
         while kbdb.get_status(scan_id) == 'new':
             res = openvas_process.poll()
             if res and res < 0:
-                self.stop_scan_cleanup(kbdb, scan_id, openvas_process)
+                self.stop_scan_cleanup(kbdb, scan_id, openvas_process.pid)
                 logger.error(
                     'It was not possible run the task %s, since openvas ended '
                     'unexpectedly with errors during launching.',
@@ -1198,7 +1198,7 @@ class OSPDopenvas(OSPDaemon):
             if scan_stopped:
                 logger.debug('%s: Scan stopped by the client', scan_id)
 
-                self.stop_scan_cleanup(kbdb, scan_id, openvas_process)
+                self.stop_scan_cleanup(kbdb, scan_id, openvas_process.pid)
 
                 # clean main_db, but wait for scanner to finish.
                 while not kbdb.target_is_finished(scan_id):

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -648,6 +648,25 @@ class MainDB(BaseDB):
 
         return None
 
+    def check_consistency(self, scan_id) -> Tuple[Optional[KbDB], int]:
+        """Check if the current scan id already exists in a kb.
+
+        Return a tuple with the kb or none, and an error code, being 0 if
+        the db is clean, -1 on old finished scan, -2 on still running scan.
+        """
+        err = 0
+
+        kb = self.find_kb_database_by_scan_id(scan_id)
+        current_status = None
+        if kb:
+            current_status = kb.get_status(scan_id)
+        if current_status == "finished":
+            err = -1
+        elif current_status == "stop_all" or current_status == "ready":
+            err = -2
+
+        return (kb, err)
+
     def release_database(self, database: BaseDB):
         self.release_database_by_index(database.index)
         database.flush()


### PR DESCRIPTION
**What**:
Fix: Stop and clean finished/running openvas process before resumming a scan

Jira: SC-624
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
If Ospd-Openvas crashes during a scan, probably the scan will continue
running in background, leaving the kb in redis occupied.
After ospd-openvas is initialized, the task can be resumed.
In this case, the scan id of the task will be the same one as before,
and there will be two kbs for the old and the new tasks with the same scanid.

This patch ensure that there is no kb in redis in used with the same scan id,
and also it will stop the scan in case it is still running.
<!-- Why are these changes necessary? -->

**How**:
- Run a scan and kill ospd-openvas with SIGKILL (-9) signal: `killall -9 ospd-openvas`
- Start ospd-openvas 
- Check with top/htop/ps, that openvas runs in background, it is an orphan process with ppid = 1 (system).
- Check in gvmd that the task is stopped or interrupted
- Check in redis that there is a main kb in use and the scan id. If you started the test with a clean setup, it should be the kb 2
- Resume the task. It will use the same scan id. Compare it whit the one checked in redis.

- Without the patch: the old openvas process still run and a new kbs are taken with the same scan id for the resume task
- With the patch, the old openvas process are stopped and its kb is released before resuming the scan.


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
