### PR TITLE
Change: Don't use a pip cache within the container build

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -28,6 +28,8 @@ FROM greenbone/openvas-scanner:${VERSION}
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+ENV PIP_NO_CACHE_DIR off
+
 COPY --from=tools /usr/local/src/bin/ospd-scans /usr/local/bin/
 COPY ./config/ospd-openvas.conf /etc/gvm/ospd-openvas.conf
 COPY .docker/entrypoint.sh /usr/local/bin/entrypoint


### PR DESCRIPTION
**What**:

Don't use a pip cache within the container build

**Why**:

Shrink the container image size by not storing the pip cache in an image
layer.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
