### PR TITLE
Fix: race condition within daemon and notus

### DIFF
--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -36,10 +36,9 @@ from tests.helper import assert_called_once
 from ospd_openvas.daemon import (
     OSPD_PARAMS,
     OpenVasVtsFilter,
-    hashsum_verificator,
 )
 from ospd_openvas.openvas import Openvas
-from ospd_openvas.notus import Notus
+from ospd_openvas.notus import Notus, hashsum_verificator
 
 OSPD_PARAMS_OUT = {
     'auto_enable_dependencies': {

--- a/tests/test_notus.py
+++ b/tests/test_notus.py
@@ -50,7 +50,8 @@ class NotusTestCase(TestCase):
         redis_mock = mock.MagicMock()
         redis_mock.scan_iter.return_value = ["internal/notus/advisories/12"]
         redis_mock.lindex.return_value = '{"file_name": "/tmp/something" }'
-        notus = Notus(path_mock, Cache(redis_mock), lambda _: True)
+        notus = Notus(path_mock, Cache(redis_mock))
+        notus._verifier = lambda _: True  # pylint: disable=protected-access
         oids = [x for x in notus.get_filenames_and_oids()]
         self.assertEqual(len(oids), 1)
 
@@ -69,13 +70,15 @@ class NotusTestCase(TestCase):
             ] 
         }'''
         redis_mock = mock.MagicMock()
-        load_into_redis = Notus(path_mock, Cache(redis_mock), lambda _: True)
+        load_into_redis = Notus(path_mock, Cache(redis_mock))
+        # pylint: disable=protected-access
+        load_into_redis._verifier = lambda _: True
         load_into_redis.reload_cache()
         self.assertEqual(redis_mock.lpush.call_count, 1)
         redis_mock.reset_mock()
-        do_not_load_into_redis = Notus(
-            path_mock, Cache(redis_mock), lambda _: False
-        )
+        do_not_load_into_redis = Notus(path_mock, Cache(redis_mock))
+        # pylint: disable=protected-access
+        do_not_load_into_redis._verifier = lambda _: False
         do_not_load_into_redis.reload_cache()
         self.assertEqual(redis_mock.lpush.call_count, 0)
 
@@ -102,7 +105,8 @@ class NotusTestCase(TestCase):
             ] 
         }'''
         cache_fake = CacheFake()
-        notus = Notus(path_mock, cache_fake, lambda _: True)
+        notus = Notus(path_mock, cache_fake)
+        notus._verifier = lambda _: True  # pylint: disable=protected-access
         notus.reload_cache()
         nm = notus.get_nvt_metadata("12")
         assert nm


### PR DESCRIPTION
While creating a hash sum verification it can happen that a lock exist
within daemon which is not yet resolved while already doing a hashsum
verification in a different process.

This results in a non functioning OSPD since it stuck on loading; to
prevent a scenario like this notus will create the verification only
when needed and not eagerly while creating the first instance.
