### PR TITLE
Change: gpg verification failure handling of notus advisories sha256sums

### DIFF
--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -47,7 +47,11 @@ def hashsum_verificator(
     def on_hash_sum_verification_failure(
         _: Optional[Dict[str, str]]
     ) -> Dict[str, str]:
-        raise Exception("GPG verification of notus sha256sums failed")
+        logger.warning(
+            "GPG verification of notus sha256sums failed."
+            " Notus advisories are not loaded."
+        )
+        return {}
 
     sha_sum_file_path = advisories_directory_path / "sha256sums"
     sha_sum_reload_config = ReloadConfiguration(


### PR DESCRIPTION
When gpg verification on sha256sums for notus advisories fails it is
printing a warning instead of crashing ospd-openvas.

This changes the behaviour mentioned in https://github.com/greenbone/ospd-openvas/issues/765
