### PR TITLE
Fix: use ~/.gnupg when /etc/openvas/gnupg is not available

### DIFF
--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -47,7 +47,11 @@ def hashsum_verificator(
     def on_hash_sum_verification_failure(
         _: Optional[Dict[str, str]]
     ) -> Dict[str, str]:
-        raise Exception("GPG verification of notus sha256sums failed")
+        logger.warning(
+            "GPG verification of notus sha256sums failed."
+            " Notus advisories are not loaded."
+        )
+        return {}
 
     sha_sum_file_path = advisories_directory_path / "sha256sums"
     sha_sum_reload_config = ReloadConfiguration(


### PR DESCRIPTION
Instead of just using GOS defaults `/etc/openvas/gnupg` check if the
directory exists and when not use `$HOME/.gnupg` instead.

If both are not available print a warning that the env variable
GNUPGHOME should be set but stick with the failing `$HOME/.gnupg` to
prevent None checking.

Fixes https://github.com/greenbone/ospd-openvas/issues/765

Depends on: https://github.com/greenbone/ospd-openvas/pull/767