### PR TITLE
Fix: ospd-feed-preparer to copy recursively for script-dependencies

### DIFF
--- a/smoketest/feed/preparer.go
+++ b/smoketest/feed/preparer.go
@@ -151,7 +151,7 @@ func (p *preparer) copyPlugin(n *nasl.Plugin) error {
 	}
 	for _, sdp := range n.ScriptDependencies {
 		if sd := p.naslCache.ByPath(sdp); sd != nil {
-			if err := cp(sd); err != nil {
+			if err := p.copyPlugin(sd); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
With this patch the feed-preparer does copy dependencies of a
script-dependency instead of just copying the first dependency.
