### PR TITLE
Uses a new and empty Redis namespace for the Notus cache.

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -456,7 +456,7 @@ class OSPDopenvas(OSPDaemon):
             ndir = Path(notus_dir)
             notus = Notus(
                 ndir,
-                Cache(self.main_db.ctx),
+                Cache(self.main_db),
                 disable_notus_hashsum_verification,
             )
 

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -318,6 +318,8 @@ class OpenvasDB:
 
         if lpush:
             ctx.lpush(name, *set(values))
+            return
+
         ctx.rpush(name, *set(values))
 
     @staticmethod

--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -36,6 +36,8 @@ from ospd_openvas.gpg_sha_verifier import (
 
 logger = logging.getLogger(__name__)
 
+NOTUS_CACHE_NAME = "notuscache"
+
 
 def hashsum_verificator(
     advisories_directory_path: Path, disable: bool

--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -23,8 +23,6 @@ from threading import Timer
 import json
 import logging
 
-from redis import Redis
-
 from ospd.parser import CliParser
 from ospd_openvas.messages.result import ResultMessage
 from ospd_openvas.db import OpenvasDB, BaseDB, MainDB


### PR DESCRIPTION
**What**:
Uses a new and empty Redis namespace for the Notus cache.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It was using the redis namespace 0, which is reserved for openvas to keep a list of in-use kbs.
<!-- Why are these changes necessary? -->

**How**:
$ redis-cli -s <redis-socket>
> info namespaces
> keys *

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
