### PR TITLE
Separate notus redis cache from openvas cache

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -1088,7 +1088,7 @@ class OSPDopenvas(OSPDaemon):
         do_not_launch = False
         kbdb = self.main_db.get_new_kb_database()
         scan_prefs = PreferenceHandler(
-            scan_id, kbdb, self.scan_collection, self.nvti
+            scan_id, kbdb, self.scan_collection, self.nvti, self.notus.exists
         )
         kbdb.add_scan_id(scan_id)
         scan_prefs.prepare_target_for_openvas()

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -22,7 +22,7 @@ import logging
 import sys
 import time
 
-from typing import List, NewType, Optional, Iterable, Iterator, Tuple
+from typing import List, NewType, Optional, Iterable, Iterator, Tuple, Callable
 from urllib import parse
 
 import redis
@@ -391,7 +391,7 @@ class OpenvasDB:
 
     @classmethod
     def get_filenames_and_oids(
-        cls, ctx: RedisCtx, pattern: str, parser: Callable[str]
+        cls, ctx: RedisCtx, pattern: str, parser: Callable[[str], str]
     ) -> Iterable[Tuple[str, str]]:
         """Get all items with index 'index', stored under
         a given pattern.

--- a/ospd_openvas/db.py
+++ b/ospd_openvas/db.py
@@ -391,33 +391,29 @@ class OpenvasDB:
 
     @classmethod
     def get_filenames_and_oids(
-        cls, ctx: RedisCtx, pattern: str = 'nvt:*'
+        cls, ctx: RedisCtx, pattern: str, parser: Callable[str]
     ) -> Iterable[Tuple[str, str]]:
         """Get all items with index 'index', stored under
         a given pattern.
 
         Arguments:
             ctx: Redis context to use.
+            pattern: Pattern used for searching the keys
+            parser: Callable method to remove the pattern from the keys.
 
         Return an iterable where each single tuple contains the filename
             as first element and the oid as the second one.
         """
-
-        def parse_oid(item: str, pattern: str):
-            """Returns the OID depending on the key pattern"""
-
-            if pattern == 'nvt:*':
-                return item[4:]
-            return str(item).rsplit('/', maxsplit=1)[-1]
-
         if not ctx:
             raise RequiredArgument('get_filenames_and_oids', 'ctx')
+        if not pattern:
+            raise RequiredArgument('get_filenames_and_oids', 'pattern')
+        if not parser:
+            raise RequiredArgument('get_filenames_and_oids', 'parser')
 
         items = cls.get_keys_by_pattern(ctx, pattern)
 
-        return (
-            (ctx.lindex(item, 0), parse_oid(item, pattern)) for item in items
-        )
+        return ((ctx.lindex(item, 0), parser(item)) for item in items)
 
     @staticmethod
     def exists(ctx: RedisCtx, key: str) -> bool:

--- a/ospd_openvas/dryrun.py
+++ b/ospd_openvas/dryrun.py
@@ -73,7 +73,7 @@ class DryRun:
         vts = list(self._daemon.scan_collection.get_vts(scan_id))
         if "vt_groups" in vts:
             vts.remove("vt_groups")
-        vthelper = VtHelper(nvti)
+        vthelper = VtHelper(nvti, None)
 
         # Run the scan.
         # Scan simulation for each single host.

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -295,11 +295,6 @@ class NVTICache(BaseDB):
     def get_nvt_count(self) -> int:
         return OpenvasDB.get_key_count(self.ctx, "nvt:*")
 
-    def force_reload(self):
-        if self.notus:
-            self.notus.reload_cache()
-        self._main_db.release_database(self)
-
     def add_vt_to_cache(self, vt_id: str, vt: List[str]):
         if not vt_id:
             raise RequiredArgument('add_vt_to_cache', 'vt_id')

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -92,13 +92,15 @@ class NVTICache(BaseDB):
         Returns:
             An iterable of tuples of file name and oid.
         """
-        if self.notus:
-            for f, oid in self.notus.get_filenames_and_oids():
-                yield (f, oid)
+
+        def parse_oid(item):
+            return item[4:]
+
         if self.ctx:
-            for f, oid in OpenvasDB.get_filenames_and_oids(self.ctx):
-                if not self.notus or not self.notus.exists(oid):
-                    yield (f, oid)
+            for f, oid in OpenvasDB.get_filenames_and_oids(
+                self.ctx, 'nvt:*', parse_oid
+            ):
+                yield (f, oid)
 
     def get_nvt_params(self, oid: str) -> Optional[Dict[str, str]]:
         """Get NVT's preferences.

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -28,7 +28,6 @@ from time import time
 from ospd.errors import RequiredArgument
 from ospd_openvas.errors import OspdOpenvasError
 from ospd_openvas.db import NVT_META_FIELDS, OpenvasDB, MainDB, BaseDB, RedisCtx
-from ospd_openvas.notus import Notus
 
 NVTI_CACHE_NAME = "nvticache"
 
@@ -59,12 +58,11 @@ class NVTICache(BaseDB):
     }
 
     def __init__(  # pylint: disable=super-init-not-called
-        self, main_db: MainDB, notus: Optional[Notus] = None
+        self, main_db: MainDB
     ):
         self._ctx = None
         self.index = None
         self._main_db = main_db
-        self.notus = notus
 
     @property
     def ctx(self) -> Optional[RedisCtx]:

--- a/ospd_openvas/nvticache.py
+++ b/ospd_openvas/nvticache.py
@@ -246,10 +246,6 @@ class NVTICache(BaseDB):
         Returns:
             A str with the VT family.
         """
-        notus_entry = self.notus.get_nvt_metadata(oid) if self.notus else None
-        if notus_entry:
-            return notus_entry.get("family")
-
         return OpenvasDB.get_single_item(
             self.ctx,
             f"nvt:{oid}",

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -97,8 +97,7 @@ class PreferenceHandler:
         kbdb: KbDB,
         scan_collection: ScanCollection,
         nvticache: NVTICache,
-        notus: Notus = None,
-        is_handled_by_notus: Optional[Callable[[str], bool]] = None,
+        is_handled_by_notus: Callable[[str], bool],
     ):
         self.scan_id = scan_id
         self.kbdb = kbdb
@@ -108,11 +107,8 @@ class PreferenceHandler:
         self._nvts_params = None
 
         self.nvti = nvticache
-        self.notus = notus
         if is_handled_by_notus:
             self.is_handled_by_notus = is_handled_by_notus
-        elif not is_handled_by_notus and self.notus:
-            self.is_handled_by_notus = self.notus.exists
         else:
             self.is_handled_by_notus = lambda _: False
         self.errors = []
@@ -233,7 +229,7 @@ class PreferenceHandler:
         vts_params = {}
         vtgroups = vts.pop('vt_groups')
 
-        vthelper = VtHelper(self.nvti)
+        vthelper = VtHelper(self.nvti, None)
 
         # This get vt groups which are not Notus Family.
         # Since Notus advisories are handled by notus, they

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -97,6 +97,7 @@ class PreferenceHandler:
         kbdb: KbDB,
         scan_collection: ScanCollection,
         nvticache: NVTICache,
+        notus: Notus = None,
         is_handled_by_notus: Optional[Callable[[str], bool]] = None,
     ):
         self.scan_id = scan_id
@@ -107,10 +108,11 @@ class PreferenceHandler:
         self._nvts_params = None
 
         self.nvti = nvticache
+        self.notus = notus
         if is_handled_by_notus:
             self.is_handled_by_notus = is_handled_by_notus
-        elif not is_handled_by_notus and nvticache and nvticache.notus:
-            self.is_handled_by_notus = nvticache.notus.exists
+        elif not is_handled_by_notus and self.notus:
+            self.is_handled_by_notus = self.notus.exists
         else:
             self.is_handled_by_notus = lambda _: False
         self.errors = []

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -154,6 +154,8 @@ class PreferenceHandler:
         vts_list = list()
         families = dict()
 
+        # Only get vts from NVTICache. Does not include Notus advisories,
+        # since they are handled by Notus.
         oids = self.nvti.get_oids()
 
         for _, oid in oids:
@@ -228,6 +230,9 @@ class PreferenceHandler:
 
         vthelper = VtHelper(self.nvti)
 
+        # This get vt groups which are not Notus Family.
+        # Since Notus advisories are handled by notus, they
+        # are not sent to Openvas-scanner
         if vtgroups:
             vts_list = self._get_vts_in_groups(vtgroups)
 
@@ -241,7 +246,7 @@ class PreferenceHandler:
                 ):
                     break
 
-            # remove oids handled by notus
+            # Remove oids handled by notus
             if self.is_handled_by_notus(vtid):
                 logger.debug('The VT %s is handled by notus. Ignoring.', vtid)
                 continue

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -158,6 +158,9 @@ class PreferenceHandler:
         # since they are handled by Notus.
         oids = self.nvti.get_oids()
 
+        # Same here. Only check for families in NVT Cache.
+        # If necessary, consider to call get_advisory_famaly from
+        # Notus class
         for _, oid in oids:
             family = self.nvti.get_nvt_family(oid)
             if family not in families:

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -26,19 +26,20 @@ from itertools import chain
 
 from ospd.cvss import CVSS
 from ospd_openvas.nvticache import NVTICache
+from ospd_openvas.notus import Notus
 
 logger = logging.getLogger(__name__)
 
 
 class VtHelper:
-    def __init__(self, nvticache: NVTICache):
+    def __init__(self, nvticache: NVTICache, notus: Notus):
         self.nvti = nvticache
-        self.notus = self.nvti.notus
+        self.notus = notus
 
     def get_single_vt(self, vt_id: str, oids=None) -> Optional[Dict[str, Any]]:
         nr = None
-        if self.nvti.notus:
-            nr = self.nvti.notus.get_nvt_metadata(vt_id)
+        if self.notus:
+            nr = self.notus.get_nvt_metadata(vt_id)
 
         if nr:
             custom = nr

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class VtHelper:
-    def __init__(self, nvticache: NVTICache, notus: Notus):
+    def __init__(self, nvticache: NVTICache, notus: Optional[Notus] = None):
         self.nvti = nvticache
         self.notus = notus
 
@@ -188,7 +188,12 @@ class VtHelper:
             # notus contains multiple oids per advisory therefore unlike
             # nasl they share the filename
             # The vt collection is taken from both Caches
-            vt_collection = chain(self.notus.get_oids(), self.nvti.get_oids())
+            if self.notus:
+                vt_collection = chain(
+                    self.notus.get_oids(), self.nvti.get_oids()
+                )
+            else:
+                vt_collection = self.nvti.get_oids()
 
             if not vt_selection:
                 vt_selection = [v for _, v in vt_collection]

--- a/ospd_openvas/vthelper.py
+++ b/ospd_openvas/vthelper.py
@@ -22,6 +22,7 @@
 from hashlib import sha256
 import logging
 from typing import Any, Optional, Dict, List, Tuple, Iterator
+from itertools import chain
 
 from ospd.cvss import CVSS
 from ospd_openvas.nvticache import NVTICache
@@ -32,6 +33,7 @@ logger = logging.getLogger(__name__)
 class VtHelper:
     def __init__(self, nvticache: NVTICache):
         self.nvti = nvticache
+        self.notus = self.nvti.notus
 
     def get_single_vt(self, vt_id: str, oids=None) -> Optional[Dict[str, Any]]:
         nr = None
@@ -184,7 +186,8 @@ class VtHelper:
         if not vt_selection or details:
             # notus contains multiple oids per advisory therefore unlike
             # nasl they share the filename
-            vt_collection = self.nvti.get_oids()
+            # The vt collection is taken from both Caches
+            vt_collection = chain(self.notus.get_oids(), self.nvti.get_oids())
 
             if not vt_selection:
                 vt_selection = [v for _, v in vt_collection]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -355,9 +355,9 @@ class TestOspdOpenvas(TestCase):
 
     def test_update_vts(self):
         daemon = DummyDaemon()
-        daemon.nvti.notus = MagicMock(spec=Notus)
+        daemon.notus = MagicMock(spec=Notus)
         daemon.update_vts()
-        self.assertEqual(daemon.nvti.notus.reload_cache.call_count, 1)
+        self.assertEqual(daemon.notus.reload_cache.call_count, 1)
 
     @patch('ospd_openvas.daemon.Path.exists')
     @patch('ospd_openvas.daemon.Path.open')
@@ -652,7 +652,7 @@ class TestOspdOpenvas(TestCase):
 
 class TestFilters(TestCase):
     def test_format_vt_modification_time(self):
-        ovformat = OpenVasVtsFilter(None)
+        ovformat = OpenVasVtsFilter(None, None)
         td = '1517443741'
         formatted = ovformat.format_vt_modification_time(td)
         self.assertEqual(formatted, "20180201000901")
@@ -661,7 +661,7 @@ class TestFilters(TestCase):
         w = DummyDaemon()
         vts_collection = ['1234', '1.3.6.1.4.1.25623.1.0.100061']
 
-        ovfilter = OpenVasVtsFilter(w.nvti)
+        ovfilter = OpenVasVtsFilter(w.nvti, None)
         res = ovfilter.get_filtered_vts_list(
             vts_collection, "modification_time<10"
         )
@@ -671,7 +671,7 @@ class TestFilters(TestCase):
         w = DummyDaemon()
         vts_collection = ['1234', '1.3.6.1.4.1.25623.1.0.100061']
 
-        ovfilter = OpenVasVtsFilter(w.nvti)
+        ovfilter = OpenVasVtsFilter(w.nvti, None)
         res = ovfilter.get_filtered_vts_list(
             vts_collection, "modification_time>10"
         )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -272,14 +272,17 @@ class TestOpenvasDB(TestCase):
 
     def test_get_filenames_and_oids_error(self, mock_redis):
         with self.assertRaises(RequiredArgument):
-            OpenvasDB.get_filenames_and_oids(None)
+            OpenvasDB.get_filenames_and_oids(None, None, None)
 
     def test_get_filenames_and_oids(self, mock_redis):
+        def _pars(item):
+            return item[4:]
+
         ctx = mock_redis.from_url.return_value
         ctx.keys.return_value = ['nvt:1', 'nvt:2']
         ctx.lindex.side_effect = ['aa', 'ab']
 
-        ret = OpenvasDB.get_filenames_and_oids(ctx)
+        ret = OpenvasDB.get_filenames_and_oids(ctx, "nvt:*", _pars)
 
         self.assertEqual(list(ret), [('aa', '1'), ('ab', '2')])
 

--- a/tests/test_notus.py
+++ b/tests/test_notus.py
@@ -56,7 +56,7 @@ class NotusTestCase(TestCase):
         ]
         notus = Notus(path_mock, Cache(redis_mock))
         notus._verifier = lambda _: True  # pylint: disable=protected-access
-        oids = [x for x in notus.get_filenames_and_oids()]
+        oids = [x for x in notus.get_oids()]
         self.assertEqual(len(oids), 1)
 
     @mock.patch('ospd_openvas.notus.OpenvasDB')

--- a/tests/test_nvti_cache.py
+++ b/tests/test_nvti_cache.py
@@ -37,7 +37,7 @@ class TestNVTICache(TestCase):
     @patch('ospd_openvas.db.MainDB')
     def setUp(self, MockMainDB):  # pylint: disable=arguments-differ
         self.db = MockMainDB()
-        self.nvti = NVTICache(self.db, None)
+        self.nvti = NVTICache(self.db)
         self.nvti._ctx = 'foo'
 
     def test_set_index(self, MockOpenvasDB):

--- a/tests/test_nvti_cache.py
+++ b/tests/test_nvti_cache.py
@@ -302,11 +302,6 @@ class TestNVTICache(TestCase):
         self.assertEqual(self.nvti.get_nvt_count(), 20)
         MockOpenvasDB.get_key_count.assert_called_with('foo', 'nvt:*')
 
-    def test_force_reload(self, _MockOpenvasDB):
-        self.nvti.force_reload()
-
-        self.db.release_database.assert_called_with(self.nvti)
-
     def test_flush(self, _MockOpenvasDB):
         self.nvti._ctx = Mock()
 

--- a/tests/test_preferencehandler.py
+++ b/tests/test_preferencehandler.py
@@ -49,7 +49,7 @@ class PreferenceHandlerTestCase(TestCase):
         }
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, dummy.nvti
+            '1234-1234', mock_kb, dummy.scan_collection, dummy.nvti, None
         )
         dummy.nvti.get_nvt_metadata.return_value = None
         p_handler._process_vts(vts)  # pylint: disable = protected-access
@@ -65,7 +65,7 @@ class PreferenceHandlerTestCase(TestCase):
         }
 
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, dummy.nvti
+            '1234-1234', None, dummy.scan_collection, dummy.nvti, None
         )
 
         ret = p_handler._process_vts(vts)  # pylint: disable = protected-access
@@ -101,7 +101,7 @@ class PreferenceHandlerTestCase(TestCase):
         )
 
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, dummy.nvti
+            '1234-1234', None, dummy.scan_collection, dummy.nvti, None
         )
         ret = p_handler._process_vts(vts)  # pylint: disable = protected-access
 
@@ -115,7 +115,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_vts.return_value = {}
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, dummy.nvti
+            '1234-1234', mock_kb, dummy.scan_collection, dummy.nvti, None
         )
         p_handler.kbdb.add_scan_preferences = Mock()
         ret = p_handler.prepare_plugins_for_openvas()
@@ -135,7 +135,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_vts.return_value = vts
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, dummy.nvti
+            '1234-1234', mock_kb, dummy.scan_collection, dummy.nvti, None
         )
         p_handler.kbdb.add_scan_preferences = Mock()
         ret = p_handler.prepare_plugins_for_openvas()
@@ -163,7 +163,7 @@ class PreferenceHandlerTestCase(TestCase):
             }
         }
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, None
+            '1234-1234', None, dummy.scan_collection, None, None
         )
 
         ret = p_handler.build_credentials_as_prefs(cred_dict)
@@ -227,7 +227,7 @@ class PreferenceHandlerTestCase(TestCase):
         }
 
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, None
+            '1234-1234', None, dummy.scan_collection, None, None
         )
         ret = p_handler.build_credentials_as_prefs(cred_dict)
 
@@ -249,7 +249,7 @@ class PreferenceHandlerTestCase(TestCase):
         target_options_dict = {'alive_test': '0'}
 
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, None
+            '1234-1234', None, dummy.scan_collection, None, None
         )
         ret = p_handler.build_alive_test_opt_as_prefs(target_options_dict)
 
@@ -259,7 +259,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy = DummyDaemon()
         target_options_dict = {'alive_test_methods': '1', 'icmp': '0'}
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, None
+            '1234-1234', None, dummy.scan_collection, None, None
         )
         ret = p_handler.build_alive_test_opt_as_prefs(target_options_dict)
         self.assertEqual(ret, {})
@@ -283,7 +283,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         target_options_dict = {'alive_test': '2'}
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, None
+            '1234-1234', None, dummy.scan_collection, None, None
         )
         ret = p_handler.build_alive_test_opt_as_prefs(target_options_dict)
 
@@ -293,7 +293,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy = DummyDaemon()
         target_options_dict = {'alive_test_methods': '1', 'icmp': '1'}
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, None
+            '1234-1234', None, dummy.scan_collection, None, None
         )
         ret = p_handler.build_alive_test_opt_as_prefs(target_options_dict)
         self.assertEqual(ret, alive_test_out)
@@ -304,7 +304,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         target_options_dict = {'alive_test': 'a'}
         p_handler = PreferenceHandler(
-            '1234-1234', None, dummy.scan_collection, None
+            '1234-1234', None, dummy.scan_collection, None, None
         )
         target_options = p_handler.build_alive_test_opt_as_prefs(
             target_options_dict
@@ -322,7 +322,7 @@ class PreferenceHandlerTestCase(TestCase):
         )
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -340,7 +340,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_ports = MagicMock(return_value='80,443')
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -358,7 +358,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_ports = MagicMock(return_value='2,-9,4')
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -369,7 +369,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy = DummyDaemon()
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.kbdb.add_scan_preferences = Mock()
         p_handler.kbdb.index = 2
@@ -413,7 +413,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_credentials_to_scan_preferences = MagicMock()
@@ -439,7 +439,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -465,7 +465,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -490,7 +490,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -514,7 +514,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -540,7 +540,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -571,7 +571,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -604,7 +604,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -637,7 +637,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -668,7 +668,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -699,7 +699,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -723,7 +723,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_credentials = MagicMock(return_value=creds)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -740,7 +740,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_exclude_hosts = MagicMock(return_value=exc)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -760,7 +760,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_exclude_hosts = MagicMock(return_value=exc)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -787,7 +787,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_options = MagicMock(return_value=opt)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -805,7 +805,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_target_options = MagicMock(return_value=t_opt)
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler.scan_id = '456-789'
         p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -828,7 +828,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_target_options = MagicMock(return_value=t_opt)
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -843,7 +843,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -859,7 +859,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -875,7 +875,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -891,7 +891,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -910,7 +910,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -933,7 +933,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy.scan_collection.get_target_options = MagicMock(return_value=t_opt)
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -948,7 +948,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -964,7 +964,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -980,7 +980,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -996,7 +996,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -1012,7 +1012,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -1028,7 +1028,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -1051,7 +1051,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -1071,7 +1071,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -1097,7 +1097,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {BOREAS_SETTING_NAME: 1}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -1115,7 +1115,7 @@ class PreferenceHandlerTestCase(TestCase):
         ov_setting = {}
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -1134,7 +1134,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler.scan_id = '456-789'
             p_handler.kbdb.add_scan_preferences = MagicMock()
@@ -1153,7 +1153,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler._nvts_params = {}  # pylint: disable = protected-access
             p_handler.scan_id = '456-789'
@@ -1173,7 +1173,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler._nvts_params = {}  # pylint: disable = protected-access
             p_handler.scan_id = '456-789'
@@ -1205,7 +1205,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler._nvts_params = {}  # pylint: disable = protected-access
             p_handler.scan_id = '456-789'
@@ -1243,7 +1243,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler._nvts_params = {}  # pylint: disable = protected-access
             p_handler.scan_id = '456-789'
@@ -1266,7 +1266,7 @@ class PreferenceHandlerTestCase(TestCase):
 
         with patch.object(Openvas, 'get_settings', return_value=ov_setting):
             p_handler = PreferenceHandler(
-                '1234-1234', mock_kb, dummy.scan_collection, None
+                '1234-1234', mock_kb, dummy.scan_collection, None, None
             )
             p_handler._nvts_params = {}  # pylint: disable = protected-access
             p_handler.scan_id = '456-789'
@@ -1360,7 +1360,7 @@ class PreferenceHandlerTestCase(TestCase):
         ]
 
         p_handler = PreferenceHandler(
-            '1234-1234', mock_kb, dummy.scan_collection, None
+            '1234-1234', mock_kb, dummy.scan_collection, None, None
         )
         p_handler._nvts_params = {  # pylint: disable = protected-access
             "1.3.6.1.4.1.25623.1.0.100315:1:checkbox:Do a TCP ping": "no"
@@ -1378,7 +1378,7 @@ class PreferenceHandlerTestCase(TestCase):
         dummy = DummyDaemon()
 
         p_handler = PreferenceHandler(
-            '456-789', mock_kb, dummy.scan_collection, None
+            '456-789', mock_kb, dummy.scan_collection, None, None
         )
         p_handler._nvts_params = {}  # pylint: disable = protected-access
         p_handler.kbdb.add_scan_preferences = MagicMock()


### PR DESCRIPTION
**What**:
Separate notus redis cache from openvas cache.
Depends on PR #772 
Jira: SC-692
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It makes caches independent of each other. Now each cache has it owns methods to handle the oids. Before, the nvticache was initialized with the notus cache. There was only one get_oids methods in the nvticache, which returned the notus advisories as well.
VtHelper is now initialized with both cache (Notus is still optional), and the oids can be get separately from one or another cache.
<!-- Why are these changes necessary? -->

**How**:
Run the get_vts command. You should get the same amount of vts, in the same time

`time gvm-cli --protocol OSP --timeout 320  socket --sockpath /home/jnicola/install/var/run/ospd/openvas.sock --xml "<get_vts/>" |xmlstarlet fo |grep "<vt id" | wc -l` 

Also, the sha256:hash must the same for the same feed

`time gvm-cli --protocol OSP --timeout 320  socket --sockpath /home/jnicola/install/var/run/ospd/openvas.sock --xml "<get_vts version_only='1'/>" |xmlstarlet fo`

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
