### PR TITLE
Reset the advisory key instead of adding a new item 

### DIFF
--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -83,8 +83,8 @@ class Cache:
         self.__prefix = prefix
 
     def store_advisory(self, oid: str, value: Dict[str, str]):
-        return OpenvasDB.add_single_item(
-            self.ctx, f"{self.__prefix}/{oid}", [json.dumps(value)], lpush=True
+        return OpenvasDB.set_single_item(
+            self.ctx, f"{self.__prefix}/{oid}", [json.dumps(value)]
         )
 
     def exists(self, oid: str) -> bool:

--- a/tests/test_notus.py
+++ b/tests/test_notus.py
@@ -90,13 +90,13 @@ class NotusTestCase(TestCase):
         # pylint: disable=protected-access
         load_into_redis._verifier = lambda _: True
         load_into_redis.reload_cache()
-        self.assertEqual(mock_openvasdb.add_single_item.call_count, 1)
+        self.assertEqual(mock_openvasdb.set_single_item.call_count, 1)
         mock_openvasdb.reset_mock()
         do_not_load_into_redis = Notus(path_mock, Cache(redis_mock))
         # pylint: disable=protected-access
         do_not_load_into_redis._verifier = lambda _: False
         do_not_load_into_redis.reload_cache()
-        self.assertEqual(mock_openvasdb.add_single_item.call_count, 0)
+        self.assertEqual(mock_openvasdb.set_single_item.call_count, 0)
 
     def test_notus_cvss_v2_v3_none(self):
         path_mock = mock.MagicMock()


### PR DESCRIPTION
**What**:
Reset the advisory key instead of adding a new item 
Jira: SC-675

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
this avoid duplicated items under the advisory key, added on each reload (feed update or ospd-openvas restart)

<!-- Why are these changes necessary? -->

**How**:

Check that in redis, the advisory is stored just once under the key.

```
redis-cli -s /run/redis-openvas/redis.sock 

redis /run/redis-openvas/redis.sock[1]> info keyspace
# Keyspace
db0:keys=1,expires=0,avg_ttl=0
db1:keys=37778,expires=0,avg_ttl=0
db2:keys=197426,expires=0,avg_ttl=0
```
Select the namespace which stores the redis cache (about 37000 advisories)
```
redis /run/redis-openvas/redis.sock> SELECT 1
OK
redis /run/redis-openvas/redis.sock[1]> lrange internal/notus/advisories/1.3.6.1.4.1.25623.1.1.4.2022.1764.1 0 -1

1) "{\"vt_params\": [], \"creation_date\": \"1653280075\", \"last_modification\": \"1653280075\", \"modification_time\": \"1653280075\", \"summary\": \"The remote host is missing an update for the 'php7' package(s) announced via the SUSE-SU-2022:1764-1 advisory.\", \"impact\": null, \"affected\": \"'php7' package(s) on SUSE Linux Enterprise Module for Web Scripting 12, SUSE Linux Enterprise Software Development Kit 12-SP5.\", \"insight\": \"This update for php7 fixes the following issues:\\n\\nFixed filter_var bypass vulnerability (bsc#1197644).\", \"solution\": \"Please install the updated package(s).\", \"solution_type\": \"VendorFix\", \"vuldetect\": \"Checks if a vulnerable package version is present on the target host.\", \"qod_type\": \"package\", \"severity_vector\": \"AV:N/AC:L/Au:N/C:P/I:N/A:N\", \"filename\": \"suse.notus\", \"refs\": {\"url\": [\"https://www.suse.com/support/update/announcement/2022/suse-su-20221764-1/\"], \"advisory_id\": [\"SUSE-SU-2022:1764-1\"]}, \"family\": \"SuSE Local Security Checks\", \"name\": \"SUSE: Security Advisory (SUSE-SU-2022:1764-1)\", \"category\": \"3\"}"

```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
