### PR TITLE
Change: speed up smoketest by just usign gatherpackagelist policy

### DIFF
--- a/smoketest/Dockerfile
+++ b/smoketest/Dockerfile
@@ -1,7 +1,4 @@
-FROM ghcr.io/greenbone/data-objects:community-staging AS data_objects
-RUN mv `ls -d /var/lib/gvm/data-objects/gvmd/*/*configs | sort -r | head -n 1` /policies
-
-FROM ghcr.io/greenbone/vulnerability-tests:community-staging AS nasl
+FROM greenbone/vulnerability-tests AS nasl
 # use latest version
 RUN mv `ls -d /var/lib/openvas/* | sort -r | head -n 1`/vt-data/nasl /nasl
 
@@ -60,8 +57,14 @@ RUN chmod 774 /var/log/mosquitto
 COPY --from=binaries /usr/local/src/bin/* /usr/local/bin/
 RUN mv /usr/local/src/ospd-openvas/smoketest/run-tests.sh /usr/local/bin/run
 COPY --from=nasl --chmod=7777 /nasl /var/lib/openvas/plugins
+
+RUN mkdir -p /usr/local/src/policies 
+COPY smoketest/gatherpackagelist-c18bb781-3740-44c2-aa01-1b73a00066e8.xml /usr/local/src/policies
+RUN ospd-policy-feed -p /usr/local/src/policies -t /usr/local/src/plugins
+RUN rm -rf /var/lib/openvas/plugins
+RUN mv /usr/local/src/plugins /var/lib/openvas/plugins
 RUN cp -r /usr/local/src/ospd-openvas/smoketest/data/plugins/* /var/lib/openvas/plugins
-COPY --from=data_objects --chmod=7777 /policies /usr/local/src/policies
+
 RUN rm -rf /usr/local/src/ospd-openvas
 RUN apt-get remove --purge --auto-remove -y python3-pip python3-packaging
 RUN chown -R gvm:redis /var/lib/openvas/plugins/

--- a/smoketest/gatherpackagelist-c18bb781-3740-44c2-aa01-1b73a00066e8.xml
+++ b/smoketest/gatherpackagelist-c18bb781-3740-44c2-aa01-1b73a00066e8.xml
@@ -1,0 +1,13 @@
+<config id="c18bb781-3740-44c2-aa01-1b73a00066e8">
+  <name>GatherPackageList</name>
+  <comment>A simple policy containing only gather package list.</comment>
+  <type>0</type>
+  <usage_type>scan</usage_type>
+  <nvt_selectors>
+    <nvt_selector>
+      <include>1</include>
+      <type>2</type>
+      <family_or_nvt>1.3.6.1.4.1.25623.1.0.50282</family_or_nvt>
+    </nvt_selector>
+  </nvt_selectors>
+</config>

--- a/smoketest/usecases/policy/init.go
+++ b/smoketest/usecases/policy/init.go
@@ -11,9 +11,9 @@ import (
 
 func discoveryAuthenticated(cache *policies.Cache, username, password string) uc.Test {
 	return uc.Test{
-		Title: "Discovery - enable authenticated checks",
+		Title: "GatherPackageList - enable authenticated checks",
 		Run: func(co connection.OSPDSender) uc.Response {
-			pol := "Discovery"
+			pol := "GatherPackageList"
 			sc := cache.ByName(pol)
 			selection := sc.AsVTSelection(nil)
 			if len(selection.Single) == 0 && len(selection.Group) == 0 {


### PR DESCRIPTION
Instead of testing against a complete discovery policy use a specialized
test policy just containing gatherpackagelist to reduce the amount of
needed nasl plugins and speed up the smoketests.
