### PR TITLE
Fix: qod-type is in advisory not meta-data

### DIFF
--- a/ospd_openvas/notus.py
+++ b/ospd_openvas/notus.py
@@ -169,7 +169,7 @@ class Notus:
             'Checks if a vulnerable package version is present on the target'
             ' host.'
         )
-        result['qod_type'] = meta_data.get('qod_type', 'package')
+        result['qod_type'] = advisory.get('qod_type', 'package')
         severity = advisory.get('severity', {})
         cvss = severity.get("cvss_v3", None)
         if not cvss:


### PR DESCRIPTION
Instead of asking meta-data and always fallback to package use the
defined value within advisory.

Will fix: SC-683