### PR TITLE
Add: Make openvas-scanner option visible for the client

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -318,6 +318,17 @@ OSPD_PARAMS = {
             + 'significantly.'
         ),
     },
+    'test_alive_wait_timeout': {
+        'type': 'integer',
+        'name': 'test_alive_wait_timeout',
+        'default': 1,
+        'mandatory': 0,
+        'visible_for_client': True,
+        'description': (
+            'This is the default timeout to wait for replies after last '
+            + 'packet was sent.'
+        ),
+    },
     'hosts_allow': {
         'type': 'string',
         'name': 'hosts_allow',

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -272,6 +272,17 @@ OSPD_PARAMS_OUT = {
             + 'significantly.'
         ),
     },
+    'test_alive_wait_timeout': {
+        'type': 'integer',
+        'name': 'test_alive_wait_timeout',
+        'default': 1,
+        'mandatory': 0,
+        'visible_for_client': True,
+        'description': (
+            'This is the default timeout to wait for replies after last '
+            + 'packet was sent.'
+        ),
+    },
     'hosts_allow': {
         'type': 'string',
         'name': 'hosts_allow',


### PR DESCRIPTION
**What**:
Make openvas-scanner option visible for the client
Now, the client can see the option "test_alive_wait_timeout"

Jira: SC-680

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Openvas has this option available, and it is desirable to set it from the client side.
<!-- Why are these changes necessary? -->

**How**:
Send the
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
