### PR TITLE
Make the alive_test_ports scanner preference visible for the clients.

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -295,6 +295,15 @@ OSPD_PARAMS = {
             + '"T:1-65535,U:1-1024".'
         ),
     },
+    'alive_test_ports': {
+        'type': 'string',
+        'name': 'alive_test_ports',
+        'default': '21-23,25,53,80,110-111,135,139,143,443,445,'
+        + '993,995,1723,3306,3389,5900,8080',
+        'mandatory': 0,
+        'visible_for_client': True,
+        'description': ('Port list used for host alive detection.'),
+    },
     'test_alive_hosts_only': {
         'type': 'boolean',
         'name': 'test_alive_hosts_only',

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -249,6 +249,15 @@ OSPD_PARAMS_OUT = {
             + '"T:1-65535,U:1-1024".'
         ),
     },
+    'alive_test_ports': {
+        'type': 'string',
+        'name': 'alive_test_ports',
+        'default': '21-23,25,53,80,110-111,135,139,143,443,445,'
+        + '993,995,1723,3306,3389,5900,8080',
+        'mandatory': 0,
+        'visible_for_client': True,
+        'description': ('Port list used for host alive detection.'),
+    },
     'test_alive_hosts_only': {
         'type': 'boolean',
         'name': 'test_alive_hosts_only',


### PR DESCRIPTION
**What**:
Make the alive_test_ports scanner preference visible for the clients.
The option can be sent to ospd-openvas as scanner preference now.

Jira: SC-689

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Improve the alive detection. Now the user are able to specify a port list for the TCP SYN and TCP ACK alive test methods.
This scanner preference was before scanner preference only and hide for the clients.
<!-- Why are these changes necessary? -->

**How**:
Configure a target for testing. E.g enter the target and set an iptable rule, so the port 35000 does not answer.
`sudo iptables -A INPUT -p tcp --dport 35000 -s 192.168.x.x -j DROP`
- Configure a target in GSA with the alive test method "TCP ACK" 

Run a scan and check that the host is found **_alive_** (maybe ssh port 22 is open)

- Create a new scan config and set the scanner preference "alive_test_ports = 35000"
- Run a scan against the target with the new scan config. The host should be find **_dead._**
 




<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
