### PR TITLE
Fix: improve handling of malformed severity vectors. 

### DIFF
--- a/ospd/cvss.py
+++ b/ospd/cvss.py
@@ -17,8 +17,13 @@
 
 """ Common Vulnerability Scoring System handling class. """
 
+import logging
+
 import math
 from typing import List, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
 
 CVSS_V2_METRICS = {
     'AV': {'L': 0.395, 'A': 0.646, 'N': 1.0},
@@ -74,9 +79,13 @@ class CVSS(object):
         if not cvss_base_vector:
             return None
 
-        _av, _ac, _au, _c, _i, _a = cls._parse_cvss_base_vector(
-            cvss_base_vector
-        )
+        try:
+            _av, _ac, _au, _c, _i, _a = cls._parse_cvss_base_vector(
+                cvss_base_vector
+            )
+        except ValueError:
+            logger.warning('Invalid severity vector %s', cvss_base_vector)
+            return None
 
         _impact = 10.41 * (
             1
@@ -109,9 +118,21 @@ class CVSS(object):
         """
         if not cvss_base_vector:
             return None
-        _ver, _av, _ac, _pr, _ui, _s, _c, _i, _a = cls._parse_cvss_base_vector(
-            cvss_base_vector
-        )
+        try:
+            (
+                _ver,
+                _av,
+                _ac,
+                _pr,
+                _ui,
+                _s,
+                _c,
+                _i,
+                _a,
+            ) = cls._parse_cvss_base_vector(cvss_base_vector)
+        except ValueError:
+            logger.warning('Invalid severity vector %s', cvss_base_vector)
+            return None
 
         scope_changed = CVSS_V3_METRICS['S'].get(_s)
 

--- a/tests/test_cvss.py
+++ b/tests/test_cvss.py
@@ -35,3 +35,15 @@ class CvssTestCase(unittest.TestCase):
         cvss_base = CVSS.cvss_base_v3_value(vector)
 
         self.assertEqual(cvss_base, 3.8)
+
+    def test_cvssv2_optional_metrics(self):
+        vector = 'AV:A/AC:L/Au:S/C:P/I:P/A:P/E:F'
+        cvss_base = CVSS.cvss_base_v2_value(vector)
+
+        self.assertEqual(cvss_base, None)
+
+    def test_cvssv3_optional_metrics(self):
+        vector = 'CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N/E:X'
+        cvss_base = CVSS.cvss_base_v3_value(vector)
+
+        self.assertEqual(cvss_base, None)


### PR DESCRIPTION
**What**:
Fix: improve handling of malformed severity vectors.
Jira: SC-706
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Ospd-openvas handles base metrics only. If there are any optional metric the task fails.
With this patch, the error is handled in a way that task can continue.
<!-- Why are these changes necessary? -->

**How**:
Modify the severity vector  of an existing VT including optional metrics. Update the feed and run a scan. Be sure that you include the modify VT in the plugin list and that it generates an alarm/result.
Without the patch the task crashes. With the patch the task finished as expected.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] PR merge commit message adjusted
