### PR TITLE
Add: procps into docker image for debug purposes

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && \
     # gcc and python3-dev are required for psutil on arm
     gcc \
     gosu \
+    procps \
     python3 \
     python3-pip \
     python3-dev && \


### PR DESCRIPTION
To have the possibility which processes are running to may identify
openvas issues procps can be very handy in those situations.
