### PR TITLE
Fix: Change lock file location in default config file

### DIFF
--- a/config/ospd-openvas.conf
+++ b/config/ospd-openvas.conf
@@ -4,4 +4,3 @@ socket_mode = 0o770
 unix_socket = /run/ospd/ospd-openvas.sock
 pid_file = /run/ospd/ospd-openvas.pid
 log_file = /var/log/gvm/ospd-openvas.log
-lock_file_dir = /run/ospd


### PR DESCRIPTION
**What**:

Change lock file location in default config file

Actually revert 0bd5ffff22f4254a51d2d4bc43818c664c34ae15 to use the default lock file location (`/var/lib/openvas/feed-update.lock`) again.

**Why**:

Using a different lock file location would also require to build openvas-scanner with the `-DOPENVAS_FEED_LOCK_PATH` pointing to the same path.

Reverting this change avoids that distributions are using the config file with diverging lock files and therefore breaking the feed synchronization.