### PR TITLE
Fix: ospd-openvas depends on mosquitto MQTT broker

### DIFF
--- a/config/ospd-openvas.service
+++ b/config/ospd-openvas.service
@@ -2,7 +2,7 @@
 Description=OSPd Wrapper for the OpenVAS Scanner (ospd-openvas)
 Documentation=man:ospd-openvas(8) man:openvas(8)
 After=network.target networking.service redis-server@openvas.service mosquitto.service
-Wants=redis-server@openvas.service mosquitto.service
+Wants=redis-server@openvas.service mosquitto.service notus-scanner.service
 ConditionKernelCommandLine=!recovery
 
 [Service]

--- a/config/ospd-openvas.service
+++ b/config/ospd-openvas.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=OSPd Wrapper for the OpenVAS Scanner (ospd-openvas)
 Documentation=man:ospd-openvas(8) man:openvas(8)
-After=network.target networking.service redis-server@openvas.service
-Wants=redis-server@openvas.service
+After=network.target networking.service redis-server@openvas.service mosquitto.service
+Wants=redis-server@openvas.service mosquitto.service
 ConditionKernelCommandLine=!recovery
 
 [Service]


### PR DESCRIPTION
**What**:

Update the ospd-openvas.service file to require a running mosquitto service.

**Why**:

Without mosquitto ospd-openvas will issue errors in the log