### PR TITLE
Add: option to use nasl-cli instead of openvas for feed update

### DIFF
--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -219,6 +219,16 @@ class CliParser:
                 'Default %(default)s'
             ),
         )
+        parser.add_argument(
+            '--feed-updater',
+            default="openvas",
+            choices=['openvas', 'nasl-cli'],
+            help=(
+                'Sets the method of updating the feed.'
+                ' Can either be openvas or nasl-cli.'
+                ' Default: %(default)s.'
+            ),
+        )
 
         self.parser = parser
 

--- a/ospd_openvas/openvas.py
+++ b/ospd_openvas/openvas.py
@@ -28,6 +28,22 @@ logger = logging.getLogger(__name__)
 _BOOL_DICT = {'no': 0, 'yes': 1}
 
 
+class NASLCli:
+    """Class for calling nasl-cli executable"""
+
+    @staticmethod
+    def load_vts_into_redis() -> bool:
+        """Loads all VTs into the redis database"""
+        try:
+            subprocess.check_call(
+                ['nasl-cli', 'feed', 'update'], stdout=subprocess.DEVNULL
+            )
+            return True
+        except (subprocess.SubprocessError, OSError) as err:
+            logger.error('nasl-cli failed to load VTs. %s', err)
+            return False
+
+
 class Openvas:
     """Class for calling the openvas executable"""
 


### PR DESCRIPTION
Adds a new option `--feed-updater` to switch between `openvas -u` and
`nasl-cli feed update`.

With this ospd-openvas can use the newly created `nasl-cli` to improve
the speed of importing nasl feed.
