### PR TITLE
Add: Tini init manager to docker container

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && \
     procps \
     python3 \
     python3-pip \
+    tini \
     python3-dev && \
     apt-get remove --purge --auto-remove -y && \
     rm -rf /var/lib/apt/lists/*
@@ -67,6 +68,6 @@ RUN python3 -m pip install /ospd-openvas/*
 
 RUN apt-get purge -y gcc python3-dev && apt-get autoremove -y
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint"]
 
 CMD ["ospd-openvas", "--config", "/etc/gvm/ospd-openvas.conf", "-f", "-m", "666"]


### PR DESCRIPTION
## What
Add: Tini init manager to docker container
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
To run the ospd-openvas container in kubernetes we need a signal handler to avoid zombie processes. In docker this could be achieved with init: true option but this is not possible in many kubernetes setups.

<!-- Describe why are these changes necessary? -->

## References
DEVOPS-587
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested local.


