### PR TITLE
Fix: missing dependencies for impacket

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update && \
 
 # produces the bug ` ‘/usr/share/doc/python3-impacket/examples/wmiexec.py’: [Errno 2] No such file or directory`
 RUN apt-get remove -y python3-impacket || true
+RUN apt-get autoremove -y
 
 RUN addgroup --gid 1001 --system ospd-openvas && \
     adduser --no-create-home --shell /bin/false --disabled-password \


### PR DESCRIPTION
On apt-get remove python3-impacket the dependencies will not be removed
and picked up on pip install while being removed on the auto remove
later on.

To fix it the auto remove is executed after removing python3-impacket
and before installing pip install.
