### PR TITLE
Add: option to enable feed signature check when using 'nasl-cli' as feed updater

### DIFF
--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -217,6 +217,13 @@ class CliParser:
                 ' Default: %(default)s.'
             ),
         )
+        parser.add_argument(
+            '-x',
+            '--signature-check',
+            default=False,
+            action='store_true',
+            help=('Enable feed signature check.' ' Default: %(default)s.'),
+        )
 
         self.parser = parser
 

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -463,6 +463,7 @@ class OSPDopenvas(OSPDaemon):
             )
 
         self.feed_updater = feed_updater
+        self.signature_check = kwargs.get('signature_check')
         self.nvti = NVTICache(self.main_db)
 
         super().__init__(
@@ -647,7 +648,7 @@ class OSPDopenvas(OSPDaemon):
             self.notus.reload_cache()
         loaded = False
         if self.feed_updater == "nasl-cli":
-            loaded = NASLCli.load_vts_into_redis()
+            loaded = NASLCli.load_vts_into_redis(self.signature_check)
         else:
             loaded = Openvas.load_vts_into_redis()
 

--- a/ospd_openvas/openvas.py
+++ b/ospd_openvas/openvas.py
@@ -19,12 +19,18 @@ class NASLCli:
     """Class for calling nasl-cli executable"""
 
     @staticmethod
-    def load_vts_into_redis() -> bool:
+    def load_vts_into_redis(signature_check: bool) -> bool:
         """Loads all VTs into the redis database"""
         try:
-            subprocess.check_call(
-                ['nasl-cli', 'feed', 'update'], stdout=subprocess.DEVNULL
-            )
+            if signature_check:
+                subprocess.check_call(
+                    ['nasl-cli', 'feed', 'update', '-x'],
+                    stdout=subprocess.DEVNULL,
+                )
+            else:
+                subprocess.check_call(
+                    ['nasl-cli', 'feed', 'update'], stdout=subprocess.DEVNULL
+                )
             return True
         except (subprocess.SubprocessError, OSError) as err:
             logger.error('nasl-cli failed to load VTs. %s', err)


### PR DESCRIPTION
## What
Add option to enable feed signature check when using 'nasl-cli' as feed updater
Depends on greenbone/openvas-scanner/pull/1505

Jira: SC-920

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
nasl-cli supports now signature check of the sha256sums file. 
<!-- Describe why are these changes necessary? -->

## How

Add the following settings to the ospd.conf configuration file:
```
# feed updater
feed_updater = nasl-cli
signature_check = True
```
or run ospd-openvas with:

`ospd-openvas --feed-updater nasl-cli -x`

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


