### PR TITLE
Add: support authenticated connection to MQTT broker

### DIFF
--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -208,6 +208,25 @@ class CliParser:
             ),
         )
         parser.add_argument(
+            '--mqtt-broker-username',
+            default=None,
+            type=str,
+            help=(
+                'Username to connect to MQTT broker for MQTT communication.'
+                'Default %(default)s'
+            ),
+        )
+        parser.add_argument(
+            '--mqtt-broker-password',
+            default=None,
+            type=str,
+            help=(
+                'PASSWORD to connect to MQTT broker for MQTT communication.'
+                'Default %(default)s'
+            ),
+        )
+
+        parser.add_argument(
             '--feed-updater',
             default="openvas",
             choices=['openvas', 'nasl-cli'],

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -493,6 +493,8 @@ class OSPDopenvas(OSPDaemon):
 
         self._mqtt_broker_address = mqtt_broker_address
         self._mqtt_broker_port = mqtt_broker_port
+        self._mqtt_broker_username = kwargs.get('mqtt_broker_username')
+        self._mqtt_broker_password = kwargs.get('mqtt_broker_password')
 
     def init(self, server: BaseServer) -> None:
         notus_handler = NotusResultHandler(self.report_results)
@@ -501,6 +503,11 @@ class OSPDopenvas(OSPDaemon):
             client = MQTTClient(
                 self._mqtt_broker_address, self._mqtt_broker_port, "ospd"
             )
+            if self._mqtt_broker_username and self._mqtt_broker_password:
+                client.username_pw_set(
+                    self._mqtt_broker_username, self._mqtt_broker_password
+                )
+
             daemon = MQTTDaemon(client)
             subscriber = MQTTSubscriber(client)
 


### PR DESCRIPTION
## What
Support authenticated connection to MQTT broker
If ospd-openvas options `--mqtt-broker-user` and `--mqtt-broker-password are given (or configured in the ospd.conf configuration file), the connection will be authenticated.
For this to work, MQTT broker must be configured with valid user and pass. This is disable per default

SC-917

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Improvement
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


