### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Python 3.7 and later is supported.
 `ospd-openvas` has dependencies on the following Python packages:
 
 - `defusedxml`
-- `depreacted`
+- `deprecated`
 - `lxml`
 - `packaging`
 - `paho-mqtt`


### PR DESCRIPTION
depreacted -> deprecated

## What

Fix typos in README.md, depreacted to deprecated.

## Why

It's confuse.

## References
https://pypi.org/project/Deprecated/