### PR TITLE
Rename count_total_excluded -> count_excluded

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -817,7 +817,7 @@ class OSPDaemon:
         current_progress['count_dead'] = self.scan_collection.get_count_dead(
             scan_id
         )
-        current_progress['count_total_excluded'] = (
+        current_progress['count_excluded'] = (
             self.scan_collection.get_simplified_exclude_host_count(scan_id)
         )
 
@@ -1262,9 +1262,7 @@ class OSPDaemon:
     ) -> None:
         """Sets a scan's total excluded hosts. Allow the scanner to update
         the total excluded count of hosts from the host to be scanned."""
-        self.scan_collection.update_count_total_excluded(
-            scan_id, excluded_hosts
-        )
+        self.scan_collection.update_count_excluded(scan_id, excluded_hosts)
 
     def clean_forgotten_scans(self) -> None:
         """Check for old stopped or finished scans which have not been

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -279,7 +279,7 @@ class ScanCollection:
         scan_info['count_alive'] = 0
         scan_info['count_dead'] = 0
         scan_info['count_total'] = None
-        scan_info['count_total_excluded'] = 0
+        scan_info['count_excluded'] = 0
         scan_info['excluded_simplified'] = None
         scan_info['target'] = unpickled_scan_info.pop('target')
         scan_info['vts'] = unpickled_scan_info.pop('vts')
@@ -384,17 +384,15 @@ class ScanCollection:
 
         self.scans_table[scan_id]['count_total'] = count_total
 
-    def update_count_total_excluded(
-        self, scan_id: str, count_excluded: int
-    ) -> int:
+    def update_count_excluded(self, scan_id: str, count_excluded: int) -> int:
         """Sets a scan's total hosts."""
 
-        self.scans_table[scan_id]['count_total_excluded'] = count_excluded
+        self.scans_table[scan_id]['count_excluded'] = count_excluded
 
-    def get_count_total_excluded(self, scan_id: str) -> int:
+    def get_count_excluded(self, scan_id: str) -> int:
         """Get a scan's total host count."""
 
-        count_excluded = self.scans_table[scan_id]['count_total_excluded']
+        count_excluded = self.scans_table[scan_id]['count_excluded']
         return count_excluded
 
     def get_count_total(self, scan_id: str) -> int:

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1370,7 +1370,7 @@ class ScanTestCase(unittest.TestCase):
         current_hosts = progress.findall('host')
         self.assertEqual(len(current_hosts), 2)
 
-        count_excluded = progress.findtext('count_total_excluded')
+        count_excluded = progress.findtext('count_excluded')
         self.assertEqual(count_excluded, '0')
 
     def test_set_get_vts_version(self):


### PR DESCRIPTION
With a past PR the progress calculation was adjusted and introduced a new count_total_excluded, which replaced the count_excluded field. This caused issues parsing the XML. As the name count_total was completely replaced by count_total_excluded, renaming it fixed this issue.
