### PR TITLE
Change: Support paho-mqtt version 1 and 2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1003,4 +1003,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "edaa085ec93bb8e1864dba7a256f77a39b122bc24d98f62e4189c19dad0b4158"
+content-hash = "277f771b3e353414c8a816d6a1768757a7818a3aacfdd197eaa0edeb283d10ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,7 @@ packaging = ">=20.4,<25.0"
 lxml = ">=4.5.2,<6.0.0"
 defusedxml = ">=0.6,<0.8"
 deprecated = "^1.2.10"
-# use v1.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
-paho-mqtt = "^1.6"
+paho-mqtt = ">=1.6,<3"
 python-gnupg = ">=0.4.8,<0.6.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION

## What

Support paho-mqtt version 1 and 2

## Why

For GOS we want to keep compatibility to paho-mqtt 1 but Kali for example already has switched to version 2. Therefore support both versions.

