### PR TITLE
Add: krb5 credential

### DIFF
--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -577,6 +577,11 @@ class PreferenceHandler:
         if prefs_val:
             self.kbdb.add_scan_preferences(self.scan_id, prefs_val)
 
+    def disable_message(self, disabled: str) -> str:
+        """Return a string with the message for exclusive services."""
+        disabled = f"Disabled {disabled}"
+        return disabled + ": KRB5 and SMB credentials are mutually exclusive."
+
     def build_credentials_as_prefs(self, credentials: Dict) -> List[str]:
         """Parse the credential dictionary.
         Arguments:
@@ -586,6 +591,7 @@ class PreferenceHandler:
             A list with the credentials in string format to be
             added to the redis KB.
         """
+
         cred_prefs_list = []
         krb5_set = False
         smb_set = False
@@ -668,9 +674,7 @@ class PreferenceHandler:
             # Check servic smb
             elif service == 'smb':
                 if krb5_set:
-                    self.errors.append(
-                        "Disabled SMB: Kerberos and SMB credentials are mutually exclusive."
-                    )
+                    self.errors.append(self.disable_message("SMB"))
                     continue
                 smb_set = True
                 cred_prefs_list.append(
@@ -681,9 +685,7 @@ class PreferenceHandler:
                 )
             elif service == 'krb5':
                 if smb_set:
-                    self.errors.append(
-                        "Disabled KRB5: Kerberos and SMB credentials are mutually exclusive."
-                    )
+                    self.errors.append(self.disable_message("KRB5"))
                     continue
                 krb5_set = True
                 realm = cred_params.get('realm', '')

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -669,7 +669,7 @@ class PreferenceHandler:
             elif service == 'smb':
                 if krb5_set:
                     self.errors.append(
-                        "Kerberos and SMB credentials are mutually exclusive."
+                        "Disabled SMB: Kerberos and SMB credentials are mutually exclusive."
                     )
                     continue
                 smb_set = True
@@ -682,7 +682,7 @@ class PreferenceHandler:
             elif service == 'krb5':
                 if smb_set:
                     self.errors.append(
-                        "Kerberos and SMB credentials are mutually exclusive."
+                        "Disabled KRB5: Kerberos and SMB credentials are mutually exclusive."
                     )
                     continue
                 krb5_set = True

--- a/ospd_openvas/preferencehandler.py
+++ b/ospd_openvas/preferencehandler.py
@@ -32,6 +32,8 @@ OID_SMB_AUTH = "1.3.6.1.4.1.25623.1.0.90023"
 OID_ESXI_AUTH = "1.3.6.1.4.1.25623.1.0.105058"
 OID_SNMP_AUTH = "1.3.6.1.4.1.25623.1.0.105076"
 OID_PING_HOST = "1.3.6.1.4.1.25623.1.0.100315"
+# TODO: check me, check me, check me 
+OID_KRB5_AUTH = "1.3.6.1.4.1.25623.1.81.0"
 
 BOREAS_ALIVE_TEST = "ALIVE_TEST"
 BOREAS_ALIVE_TEST_PORTS = "ALIVE_TEST_PORTS"
@@ -589,6 +591,9 @@ class PreferenceHandler:
         for credential in credentials.items():
             service = credential[0]
             cred_params = credentials.get(service)
+            if not cred_params:
+                logger.warning("No credentials parameter found for service %s", service)
+                continue
             cred_type = cred_params.get('type', '')
             username = cred_params.get('username', '')
             password = cred_params.get('password', '')
@@ -664,6 +669,28 @@ class PreferenceHandler:
                 )
                 cred_prefs_list.append(
                     f'{OID_SMB_AUTH}:2:password:SMB password:|||{password}'
+                )
+            elif service == 'krb5':
+                realm = cred_params.get('realm', '')
+                if not realm:
+                    self.errors.append("Missing realm for Kerberos authentication.")
+                    continue
+                kdc = cred_params.get('kdc', '')
+                if not kdc:
+                    self.errors.append("Missing KDC for Kerberos authentication.")
+                    continue
+                cred_prefs_list.append(
+                    f'{OID_KRB5_AUTH}:1:entry:KRB5 login:|||{username}'
+                )
+                cred_prefs_list.append(
+                    f'{OID_KRB5_AUTH}:2:password:KRB5 password:|||{password}'
+                )
+                cred_prefs_list.append(
+                    f'{OID_KRB5_AUTH}:3:entry:KRB5 realm:|||{realm}'
+                )
+                #TODO: add multiple kdcs
+                cred_prefs_list.append(
+                    f'{OID_KRB5_AUTH}:4:entry:KRB5 kdc:|||{kdc}'
                 )
             # Check service esxi
             elif service == 'esxi':


### PR DESCRIPTION
To support krb5 a new credential service is required to get the `realm`, as well as `kdc` in addition to `username` and `password`.

This adds:
```
<credentials>
 <credential type="up" service="krb5">
   <username>scanuser</username>
   <password>mypass</password>
   <realm>myrealm</realm>
   <kdc>mykdc</kdc>
 </credential>
</credentials>
```
#  Testing
To test create a test feed with the described nasl scripts. When you created the scripts run 

```
sha256sum * > sha256sums
```

within the feed dir. Afterwards change the `openvas.conf` to the feed dir and disable the signature check.

For reference this is the openvas.conf that I used:

```
> openvas -s
timeout_retry = 3
max_checks = 10
optimize_test = yes
auto_enable_dependencies = yes
checks_read_timeout = 5
time_between_request = 0
allow_simultaneous_ips = yes
non_simult_ports = 139, 445, 3389, Services/irc
drop_privileges = no
log_whole_attack = no
nasl_no_signature_check = yes
cgi_path = /cgi-bin:/scripts
max_hosts = 30
debug_tls = 0
open_sock_max_attempts = 5
config_file = /etc/openvas/openvas.conf
test_alive_wait_timeout = 3
vendor_version =
safe_checks = yes
scanner_plugins_timeout = 36000
include_folders = /workspaces/greenbone/ospd-krb5-feed
plugins_timeout = 320
log_plugins_name_at_load = no
plugins_folder = /workspaces/greenbone/ospd-krb5-feed
unscanned_closed = yes
test_empty_vhost = no
report_host_details = yes
expand_vhosts = yes
test_alive_hosts_only = yes
db_address = /run/redis/redis.sock
openvasd_server = http://localhost:6969
unscanned_closed_udp = yes
```

When all this is done send the xmls:
```
#/bin/sh
OSPD_SOCKET="/run/ospd/ospd-openvas.sock"
KRB5_ID="97079ee9-8917-49da-aa4f-4ef95f757ac1"
KRB5_TEST="<start_scan scan_id='$KRB5_ID'>
    <vt_selection>
        <vt_single id='1.3.6.1.4.1.25623.1.81.0'/>
        <vt_single id='0.0.0.0.0.0.0.0.0.42'/>
    </vt_selection>
    <targets>
        <target>
            <hosts>localhost</hosts>
            <ports>22,80,8080,443</ports>
            <alive_test_methods>
                <consider_alive>1</consider_alive>
            </alive_test_methods>
            <credentials>
                <credential type=\"up\" service=\"krb5\">
                   <username>scanuser</username>
                   <password>mypass</password>
                   <realm>myrealm</realm>
                   <kdc>mykdc</kdc>
                 </credential>
             </credentials>
        </target>
    </targets>
</start_scan>"

SMB_ID="97079ee9-8917-49da-aa4f-4ef95f757ac2"
SMB_TEST="<start_scan scan_id='$SMB_ID'>
    <vt_selection>
        <vt_single id='1.3.6.1.4.1.25623.1.0.90023'/>
        <vt_single id='0.0.0.0.0.0.0.0.0.42'/>
    </vt_selection>
    <targets>
        <target>
            <hosts>localhost</hosts>
            <ports>22,80,8080,443</ports>
            <alive_test_methods>
                <consider_alive>1</consider_alive>
            </alive_test_methods>
            <credentials>
                <credential type=\"up\" service=\"smb\">
                   <username>scanuser</username>
                   <password>mypass</password>
                 </credential>
             </credentials>
        </target>
    </targets>
</start_scan>"

ILLEGAL_ID="97079ee9-8917-49da-aa4f-4ef95f757ac3"
ILLEGAL_TEST="<start_scan scan_id='$ILLEGAL_ID'>
    <vt_selection>
        <vt_single id='1.3.6.1.4.1.25623.1.81.0'/>
        <vt_single id='1.3.6.1.4.1.25623.1.0.90023'/>
        <vt_single id='0.0.0.0.0.0.0.0.0.42'/>
    </vt_selection>
    <targets>
        <target>
            <hosts>localhost</hosts>
            <ports>22,80,8080,443</ports>
            <alive_test_methods>
                <consider_alive>1</consider_alive>
            </alive_test_methods>
            <credentials>
                <credential type=\"up\" service=\"smb\">
                   <username>scanuser</username>
                   <password>mypass</password>
                 </credential>
                <credential type=\"up\" service=\"krb5\">
                   <username>scanuser</username>
                   <password>mypass</password>
                   <realm>myrealm</realm>
                   <kdc>mykdc</kdc>
                 </credential>
             </credentials>
        </target>
    </targets>
</start_scan>"

echo "$KRB5_TEST" | nc -U $OSPD_SOCKET
echo "$SMB_TEST" | nc -U $OSPD_SOCKET
echo "$ILLEGAL_TEST" | nc -U $OSPD_SOCKET

sleep 20

printf "KRB5 Test\n\n"
printf "\n\n"
echo 'check that krb5 log message contains credentials, while smb should not'
printf "\n\n"
echo "<get_scans scan_id='$KRB5_ID' details='1'/>" | nc -U $OSPD_SOCKET

printf "\n\n"
echo "SMB Test"
printf "\n\n"
printf "\n\n"
echo 'check that smb log message contains credentials, while krb5 should not'
echo "<get_scans scan_id='$SMB_ID' details='1'/>" | nc -U $OSPD_SOCKET

printf "\n\n"
echo "Illegal Test"
printf "\n\n"
echo 'check that log contains either smb or krb5 credentials, but not both'
echo "<get_scans scan_id='$ILLEGAL_ID' details='1'/>" | nc -U $OSPD_SOCKET
```


## plugin_feed.inc 

```nasl
PLUGIN_SET = "197001010000";
PLUGIN_FEED = "Greenbone SCM Feed";
FEED_VENDOR = "Greenbone AG";
FEED_HOME = "https://github.com/greenbone/vulnerability-tests";
FEED_NAME = "SCM";
FEED_COMMIT = "N/A";
```

## krb5_authorization.nasl

```nasl
if(description)
{
  script_oid("1.3.6.1.4.1.25623.1.81.0");
  script_version("2024-10-28T06:44:43+0000");
  script_tag(name:"last_modification", value:"2024-10-28 06:44:43 +0000 (Mon, 28 Oct 2024)");
  script_tag(name:"creation_date", value:"2024-10-28 06:44:43 +0000 (Mon, 28 Oct 2024)");
  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
  script_tag(name:"cvss_base", value:"0.0");
  script_name("KRB5 Authorization"); # nb: Don't change the script name, this name is hardcoded within some manager functions...
  script_category(ACT_SETTINGS);
  script_copyright("Copyright (C) 2024 Greenbone AG");
  script_family("Credentials");

  # nichtsfrei: The following preferences are used in OSPD-OpenVAS and the ids are hardcoded there.
  script_add_preference(name:"KRB5 login:", type:"entry", value:"", id:1);
  script_add_preference(name:"KRB5 password:", type:"password", value:"", id:2);
  script_add_preference(name:"KRB5 realm:", type:"entry", value:"", id:3);
  script_add_preference(name:"KRB5 kdc:", type:"entry", value:"", id:4);

  script_tag(name:"summary", value:"This script allows users to enter the information
  required to authorize and login via KRB5.

  These data are used by tests that require authentication.");

  script_tag(name:"qod_type", value:"registry");

  exit(0);
}

krb5_login    = script_get_preference( "KRB5 login:", id:1 );
krb5_password = script_get_preference( "KRB5 password:", id:2 );
krb5_realm    = script_get_preference( "KRB5 realm:", id:3 );
krb5_kdc      = script_get_preference( "KRB5 kdc:", id:4 );

if( krb5_login )    set_kb_item( name:"KRB5/login_filled/0", value:krb5_login );
if( krb5_password ) set_kb_item( name:"KRB5/password_filled/0", value:krb5_password );
if( krb5_realm )    set_kb_item( name:"KRB5/realm_filled/0", value:krb5_realm );
if( krb5_kdc )      set_kb_item( name:"KRB5/kdc_filled/0", value:krb5_kdc );

exit( 0 )
```

## smb_authorization.nasl

```nasl
if(description)
{
  script_oid("1.3.6.1.4.1.25623.1.0.90023");
  script_version("2023-07-28T06:44:43+0000");
  script_tag(name:"last_modification", value:"2023-07-28 06:44:43 +0000 (Fri, 28 Jul 2023)");
  script_tag(name:"creation_date", value:"2008-06-02 00:42:27 +0200 (Mon, 02 Jun 2008)");
  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
  script_tag(name:"cvss_base", value:"0.0");
  script_name("SMB Authorization"); # nb: Don't change the script name, this name is hardcoded within some manager functions...
  script_category(ACT_SETTINGS);
  script_copyright("Copyright (C) 2008 Greenbone AG");
  script_family("Credentials");

  script_add_preference(name:"SMB login:", type:"entry", value:"", id:1); # nb: Don't change this name and id, these are hardcoded / used in GVMd
  script_add_preference(name:"SMB password:", type:"password", value:"", id:2); # nb: Don't change this name and id, these are hardcoded / used in GVMd
  script_add_preference(name:"SMB domain (optional):", type:"entry", value:"", id:3);

  script_tag(name:"summary", value:"This script allows users to enter the information
  required to authorize and login via SMB.

  These data are used by tests that require authentication.");

  script_tag(name:"qod_type", value:"registry");

  exit(0);
}

smb_login    = script_get_preference( "SMB login:", id:1 );
smb_password = script_get_preference( "SMB password:", id:2 );
smb_domain   = script_get_preference( "SMB domain (optional):", id:3 );

if( smb_login )    set_kb_item( name:"SMB/login_filled/0", value:smb_login );
if( smb_password ) set_kb_item( name:"SMB/password_filled/0", value:smb_password );
if( smb_domain )   set_kb_item( name:"SMB/domain_filled/0", value:smb_domain );

exit( 0 );
```

## test.nasl

```nasl
if(description)
{
  script_oid("0.0.0.0.0.0.0.0.0.42");
  script_version("2023-07-28T06:44:43+0000");
  script_tag(name:"last_modification", value:"2023-07-28 06:44:43 +0000 (Fri, 28 Jul 2023)");
  script_tag(name:"creation_date", value:"2008-06-02 00:42:27 +0200 (Mon, 02 Jun 2008)");
  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
  script_tag(name:"cvss_base", value:"0.0");
  script_name("SMB Test");
  script_category(ACT_ATTACK);
  script_copyright("Copyright (C) 2008 Greenbone AG");
  script_family("Moep");
  script_tag(name:"qod_type", value:"registry");
  exit(0);
}

login       = string( get_kb_item( "KRB5/login_filled/0" ) );
password    = string( get_kb_item( "KRB5/password_filled/0" ) );
realm = string( get_kb_item( "KRB5/realm_filled/0" ) );
kdc         = string( get_kb_item( "KRB5/kdc_filled/0" ) );
log_message(data: "krb5 login: " + login + " password: " + password + " realm: " + realm + " kdc: " + kdc);
slogin       = string( get_kb_item( "SMB/login_filled/0" ) );
spassword    = string( get_kb_item( "SMB/password_filled/0" ) );
log_message(data: "smb login: " + slogin + " password: " + spassword);
exit( 0 );
```


SC-1132