### PR TITLE
Add a delay after daemon.run() to avoid test failure

### DIFF
--- a/tests/messaging/test_mqtt.py
+++ b/tests/messaging/test_mqtt.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import time
 from datetime import datetime
 from uuid import UUID
 
@@ -92,6 +93,8 @@ class MQTTDaemonTestCase(TestCase):
         daemon = MQTTDaemon(client)
 
         daemon.run()
+
+        time.sleep(3)
 
         client.connect.assert_called_with()
 


### PR DESCRIPTION
## What
Running tests sometimes the test tests.messaging.test_mqtt.MQTTDaemonTestCase fails.
You can see the report here: https://bugs.gentoo.org/934153

## Why
Adding a small delay, seems to avoid the failure so that client.connect.assert_called_with() and client.loop_start.assert_called_with() run after daemon is setup.

The 3 arg on sleep() is arbitrary but in my test it is enough; a loop check to wait until daemon is started would be a better solution.



