### PR TITLE
Fix: mqtt test

### DIFF
--- a/smoketest/Dockerfile
+++ b/smoketest/Dockerfile
@@ -1,4 +1,4 @@
-FROM greenbone/vulnerability-tests AS nasl
+FROM registry.community.greenbone.net/community/vulnerability-tests AS nasl
 # use latest version
 RUN mv `ls -d /var/lib/openvas/* | sort -r | head -n 1`/vt-data/nasl /nasl
 
@@ -7,7 +7,7 @@ COPY --chmod=7777 smoketest /usr/local/src
 WORKDIR /usr/local/src
 RUN make build-cmds
 
-FROM greenbone/openvas-scanner:unstable
+FROM registry.community.greenbone.net/community/openvas-scanner:edge
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     mosquitto \

--- a/tests/messaging/test_mqtt.py
+++ b/tests/messaging/test_mqtt.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import time
 from datetime import datetime
 from uuid import UUID
 
@@ -87,12 +88,15 @@ class MQTTDaemonTestCase(TestCase):
         daemon = MQTTDaemon(client)
 
     def test_run(self):
-        client = mock.MagicMock()
-
+        client = mock.MagicMock(side_effect=1)
         daemon = MQTTDaemon(client)
+        t_ini = time.time()
 
         daemon.run()
+        # In some systems the spawn of the thread can take longer than expected.
+        # Therefore, we wait until the thread is spawned or times out.
+        while len(client.mock_calls) == 0 and time.time() - t_ini < 10:
+            time.sleep(1)
 
         client.connect.assert_called_with()
-
         client.loop_start.assert_called_with()


### PR DESCRIPTION
## What
SC-1239
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
In some systems the spawn of the thread can take longer than expected. Therefore, we wait until the thread is spawned or times out
<!-- Describe why are these changes necessary? -->

## References
greenbone/ospd-openvas#1026
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


