### PR TITLE
Add: Configuration to Limit KB usage per script

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -352,6 +352,24 @@ OSPD_PARAMS = {
             + 'scan package results.'
         ),
     },
+    'max_mem_kb': {
+        'type': 'integer',
+        'name': 'max_mem_kb',
+        'default': 0,
+        'mandatory': 0,
+        'visible_for_client': True,
+        'description': (
+            'Maximum amount of memory (in MB) allowed to use for a single '
+            + 'script. If this value is set, the amount of memory put into '
+            + 'redis is tracked for every Script. If the amount of memory '
+            + 'exceeds this limit, the script is not able to set more kb '
+            + 'items. The tracked the value written into redis is only '
+            + 'estimated, as it does not check, if a value was replaced or '
+            + 'appended. The size of the key is also not tracked. If this '
+            + 'value is not set or <= 0, the maximum amount is unlimited '
+            + '(Default).'
+        ),
+    },
 }
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -320,6 +320,24 @@ OSPD_PARAMS_OUT = {
             + 'scan package results.'
         ),
     },
+    'max_mem_kb': {
+        'type': 'integer',
+        'name': 'max_mem_kb',
+        'default': 0,
+        'mandatory': 0,
+        'visible_for_client': True,
+        'description': (
+            'Maximum amount of memory (in MB) allowed to use for a single '
+            + 'script. If this value is set, the amount of memory put into '
+            + 'redis is tracked for every Script. If the amount of memory '
+            + 'exceeds this limit, the script is not able to set more kb '
+            + 'items. The tracked the value written into redis is only '
+            + 'estimated, as it does not check, if a value was replaced or '
+            + 'appended. The size of the key is also not tracked. If this '
+            + 'value is not set or <= 0, the maximum amount is unlimited '
+            + '(Default).'
+        ),
+    },
 }
 
 


### PR DESCRIPTION
Currently it can happen, that script try to allocate huge amount of memory in the KB, which leads to flooding the RAM and crashing redis and openvas. The introduced config `max_mem_kb` limits the maximum KB traffic (in MB) to the specified value for a single script. Only written strings are tracked and only an estimation, as we do not know, if an item is replaced or appended. Also the key size is not counted as well. If the value is not set or <= 0, the maximum amount is unlimited (Default).

Related to: https://github.com/greenbone/openvas-scanner/pull/1904
Jira: SC-919