### PR TITLE
Migrate to modern datetime interface

### DIFF
--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -12,7 +12,7 @@ import time
 import copy
 
 from typing import Optional, Dict, List, Tuple, Iterator, Any
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pathlib import Path
 from os import geteuid
@@ -398,7 +398,7 @@ class OpenVasVtsFilter(VtsFilter):
         e.g. 20190319122532. This always refers to UTC.
         """
 
-        return datetime.utcfromtimestamp(int(value)).strftime("%Y%m%d%H%M%S")
+        return datetime.fromtimestamp(int(value), timezone.utc).strftime("%Y%m%d%H%M%S")
 
     def get_filtered_vts_list(self, vts, vt_filter: str) -> Optional[List[str]]:
         """Gets a collection of vulnerability test from the redis cache,

--- a/ospd_openvas/daemon.py
+++ b/ospd_openvas/daemon.py
@@ -398,7 +398,9 @@ class OpenVasVtsFilter(VtsFilter):
         e.g. 20190319122532. This always refers to UTC.
         """
 
-        return datetime.fromtimestamp(int(value), timezone.utc).strftime("%Y%m%d%H%M%S")
+        return datetime.fromtimestamp(int(value), timezone.utc).strftime(
+            "%Y%m%d%H%M%S"
+        )
 
     def get_filtered_vts_list(self, vts, vt_filter: str) -> Optional[List[str]]:
         """Gets a collection of vulnerability test from the redis cache,


### PR DESCRIPTION
## What
Migrate to modern datetime interface
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
``` python
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```
<!-- Describe why are these changes necessary? -->

## References

Reference: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


