### PR TITLE
Docs: update documentation regarding targets

### DIFF
--- a/docs/OSP.xml
+++ b/docs/OSP.xml
@@ -231,7 +231,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
   <element>
     <name>targets</name>
-    <summary>List of targets</summary>
+    <summary>Includes one target element (deprecated)</summary>
     <pattern>
       <e>target</e>
     </pattern>
@@ -239,7 +239,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <summary>Two targets</summary>
       <e>
         <targets>
-          <target>...</target>
           <target>...</target>
         </targets>
       </e>
@@ -1531,7 +1530,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     </ele>
     <ele>
       <name>targets</name>
-      <summary>Contains elements that represent a target to execute a scan against. If target and port attributes are present this element is not take into account</summary>
+      <summary>Contains a single element that represent a target to execute a scan against. If target and port attributes are present this element is not take into account</summary>
     </ele>
     <response>
       <pattern>
@@ -1570,7 +1569,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
       </response>
     </example>
     <example>
-      <summary>Start a new scan with multi-targets running simultaneously. Each one has a different port list and one of them has credentials for authenticated scans.</summary>
+      <summary>Start a new scan with. Target element has port list and credentials for authenticated scans.</summary>
       <request>
         <start_scan parallel='10'>
           <scanner_params>
@@ -1580,9 +1579,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
             ....
           </vt_selection>
           <targets>
-            <target>
-              ...
-            </target>
             <target>
               <hosts>192.168.1.0/24</hosts>
               <ports>1,2,3,80,443</ports>
@@ -1932,14 +1928,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <version>1.1</version>
   </change>
   <change>
-    <command>Scanner Parameters Types</command>
-    <summary>Type credential_up added</summary>
-    <description>
-      Introduce an aggregated type to express a username:password tuple.
-    </description>
-    <version>1.1</version>
-  </change>
-  <change>
     <command>GET_PERFORMANCE</command>
     <summary>Command added</summary>
     <description>
@@ -1947,5 +1935,12 @@ SPDX-License-Identifier: GPL-2.0-or-later
     </description>
     <version>1.2</version>
   </change>
-
+  <change>
+    <command>START_SCAN</command>
+    <summary>Deprecation of targets and parallel</summary>
+    <description>
+      Possibility of running multi-targets was not implemented. Currently, only the first target element is used and the following are ignored as well as parallel attribute.
+    </description>
+    <version>1.3</version>
+  </change>
 </protocol>

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -585,7 +585,7 @@ class StartScan(BaseCommand):
 
             if xml.get('parallel'):
                 logger.warning(
-                    "parallel attribute of start_scan will be ignored, sice "
+                    "parallel attribute of start_scan will be ignored, since "
                     "parallel scan is not supported by OSPd."
                 )
 


### PR DESCRIPTION
## What
Update OSP documentation. <targets> element and parallel attribute are deprecated
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Multi target is not supported and was never implemented. Parallel attribute is ignored and only the first target inside the targets element is used, other ones are ignored.
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


